### PR TITLE
test: declare adapter-specific expected failures

### DIFF
--- a/tests/e2e/baseline/agents.py
+++ b/tests/e2e/baseline/agents.py
@@ -50,6 +50,7 @@ __all__ = [
     "Adapter",
     "Lane",
     "ExcludedAdapter",
+    "ExpectedFailure",
     "WithAdapters",
     "PerAdapter",
     "adapter_params",
@@ -145,6 +146,20 @@ class ExcludedAdapter:
 
 
 @dataclass(frozen=True)
+class ExpectedFailure:
+    """An adapter expected to fail a matrix test, with a documented reason."""
+
+    adapter: Adapter
+    reason: str
+
+    def __post_init__(self) -> None:
+        if not self.reason.strip():
+            raise ValueError(
+                f"@per_adapter xfail of {self.adapter} needs a non-empty reason"
+            )
+
+
+@dataclass(frozen=True)
 class PerAdapter(MarkerPayload):
     """Per-cell construction steering for ``@per_adapter`` (carried on its marker).
 
@@ -161,6 +176,7 @@ class PerAdapter(MarkerPayload):
     tools: list[ToolSpec] | None
     peer: Adapter | None = None
     exclude: tuple[ExcludedAdapter, ...] = ()
+    xfail: tuple[ExpectedFailure, ...] = ()
 
 
 def with_adapters(
@@ -200,6 +216,7 @@ def adapter_params(
     runs_tool_loop: bool | None = None,
     lane: Lane | None = None,
     peer: Adapter | None = None,
+    xfail: dict[Adapter, str] | None = None,
 ) -> list[ParameterSet]:
     """One ``pytest.param`` per registered adapter (narrowed by the filters), each gated
     by its requirements.
@@ -215,10 +232,18 @@ def adapter_params(
     the parameter source ``@per_adapter`` feeds to the ``adapter_id`` fixture.
     """
     peer_deps = spec_for(peer).requires if peer is not None else ()
+    xfail = xfail or {}
     return [
         pytest.param(
             spec.id,
-            marks=requires(*dict.fromkeys((*spec.requires, *peer_deps))),
+            marks=(
+                requires(*dict.fromkeys((*spec.requires, *peer_deps))),
+                *(
+                    (pytest.mark.xfail(reason=xfail[spec.id], strict=True),)
+                    if spec.id in xfail
+                    else ()
+                ),
+            ),
             id=str(spec.id),
         )
         for spec in specs(
@@ -235,6 +260,7 @@ def adapter_params(
 def per_adapter(
     *adapters: Adapter,
     exclude: Collection[ExcludedAdapter] | None = None,
+    xfail: Collection[ExpectedFailure] | None = None,
     supports: Collection[Capability] | None = None,
     without: Collection[Capability] | None = None,
     runs_tool_loop: bool | None = None,
@@ -254,6 +280,7 @@ def per_adapter(
 
         @per_adapter()                                   # full matrix
         @per_adapter(exclude=[ExcludedAdapter(Adapter.CREWAI, "no per-turn usage")])
+        @per_adapter(xfail=[ExpectedFailure(Adapter.COPILOT_ACP, "no usage support")])
         @per_adapter(Adapter.ANTHROPIC, Adapter.AGNO)    # only these
         @per_adapter(supports={Capability.MEMORY})       # by capability
         @per_adapter(lane=Lane.CORE, peer=Adapter.LANGGRAPH)  # each cell + a foreign peer
@@ -266,13 +293,19 @@ def per_adapter(
     """
     include = frozenset(adapters) or None
     excluded = tuple(exclude or ())
+    expected_failures = tuple(xfail or ())
     exclude_ids = frozenset(e.adapter for e in excluded)
+    xfail_ids = frozenset(e.adapter for e in expected_failures)
     registered = {s.id for s in specs(include_pending=True)}
-    unknown = exclude_ids - registered
+    unknown = (exclude_ids | xfail_ids) - registered
     if unknown:
         # A typo'd or stale exclusion would otherwise silently no-op (nothing to drop).
         raise ValueError(
             f"@per_adapter(exclude=...) names unregistered adapters: {sorted(unknown)}"
+        )
+    if overlap := exclude_ids & xfail_ids:
+        raise ValueError(
+            f"@per_adapter cannot both exclude and xfail adapters: {sorted(overlap)}"
         )
     if peer is not None:
         if peer not in registered:
@@ -292,6 +325,7 @@ def per_adapter(
         runs_tool_loop=runs_tool_loop,
         lane=lane,
         peer=peer,
+        xfail={failure.adapter: failure.reason for failure in expected_failures},
     )
     # Fail loud rather than let an empty parametrize skip silently (a mis-specified
     # filter or registry drift). A bare @per_adapter() is never empty.
@@ -304,7 +338,12 @@ def per_adapter(
             "the filter or fix the registry drift"
         )
     build = PerAdapter(
-        prompt=prompt, features=features, tools=tools, peer=peer, exclude=excluded
+        prompt=prompt,
+        features=features,
+        tools=tools,
+        peer=peer,
+        exclude=excluded,
+        xfail=expected_failures,
     )
 
     def decorate(fn: Callable[..., object]) -> Callable[..., object]:

--- a/tests/e2e/baseline/smoke/inspection/test_usage.py
+++ b/tests/e2e/baseline/smoke/inspection/test_usage.py
@@ -38,7 +38,12 @@ from __future__ import annotations
 
 import pytest
 
-from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, per_adapter
+from tests.e2e.baseline.agents import (
+    Adapter,
+    ExcludedAdapter,
+    ExpectedFailure,
+    per_adapter,
+)
 from tests.e2e.baseline.smoke.samples.sample_agents import (
     COST_AGENT,
     COST_MULTI_TURN_AGENT,
@@ -58,6 +63,12 @@ from tests.e2e.baseline.toolkit.user_ops import UserOps
         ExcludedAdapter(
             Adapter.CREWAI, "deferred: cumulative-lifetime counter, not per-turn"
         ),
+    ],
+    xfail=[
+        ExpectedFailure(
+            Adapter.COPILOT_ACP,
+            "Copilot ACP does not expose per-turn usage through ACP",
+        )
     ],
     **COST_AGENT,
 )
@@ -145,6 +156,12 @@ async def test_usage_recorded_for_a_turn(
         ExcludedAdapter(
             Adapter.CREWAI, "deferred: cumulative-lifetime counter, not per-turn"
         ),
+    ],
+    xfail=[
+        ExpectedFailure(
+            Adapter.COPILOT_ACP,
+            "Copilot ACP does not expose per-turn usage through ACP",
+        )
     ],
     **COST_MULTI_TURN_AGENT,
 )

--- a/tests/framework_conformance/test_scorecard.py
+++ b/tests/framework_conformance/test_scorecard.py
@@ -25,6 +25,7 @@ from tests.e2e.baseline.agents import (
     PER_ADAPTER_MARKER,
     Adapter,
     ExcludedAdapter,
+    ExpectedFailure,
     PerAdapter,
     per_adapter,
 )
@@ -84,6 +85,28 @@ def test_per_adapter_rejects_unregistered_exclusion() -> None:
     # Adapter is a StrEnum, so a plain unregistered string is an unknown id.
     with pytest.raises(ValueError, match="unregistered adapters"):
         per_adapter(exclude=[ExcludedAdapter("no-such-adapter", "typo")])(lambda: None)  # type: ignore[arg-type]
+
+
+def test_per_adapter_marks_only_declared_adapter_as_xfail() -> None:
+    @per_adapter(
+        Adapter.ANTHROPIC,
+        Adapter.CREWAI,
+        xfail=[ExpectedFailure(Adapter.CREWAI, "known usage limitation")],
+    )
+    def fn() -> None: ...
+
+    params = next(mark.args[1] for mark in fn.pytestmark if mark.name == "parametrize")
+    marks_by_id = {param.id: {mark.name for mark in param.marks} for param in params}
+    assert "xfail" not in marks_by_id[str(Adapter.ANTHROPIC)]
+    assert "xfail" in marks_by_id[str(Adapter.CREWAI)]
+
+
+def test_per_adapter_rejects_overlapping_exclusion_and_xfail() -> None:
+    with pytest.raises(ValueError, match="both exclude and xfail"):
+        per_adapter(
+            exclude=[ExcludedAdapter(Adapter.CREWAI, "unsupported")],
+            xfail=[ExpectedFailure(Adapter.CREWAI, "unsupported")],
+        )
 
 
 # --- na_rows: marker exclusions become N/A rows -------------------------------------


### PR DESCRIPTION
## Summary
- add declarative per-adapter strict xfail support to the Baseline matrix
- mark Copilot ACP usage telemetry cells as expected failures
- add policy coverage for xfail matrix generation

## Validation
- `uv run pytest tests/framework_conformance/test_scorecard.py tests/converters/test_acp_client.py -q`
- `uv run ruff check tests/e2e/baseline/agents.py tests/e2e/baseline/smoke/inspection/test_usage.py tests/framework_conformance/test_scorecard.py`
- targeted Baseline collection for Copilot ACP usage cells