### PR TITLE
feat(delegation): typed msg.delegation, kept out of the model [INT-992]

### DIFF
--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -15,9 +15,16 @@ from phoenix_channels_python_client.client import (
 from phoenix_channels_python_client.client_types import ReconnectPolicy
 from phoenix_channels_python_client.exceptions import PHXConnectionError
 from phoenix_channels_python_client.phx_messages import PHXMessage
-from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from band.client.streaming.errors import classify_initial_upgrade_error
+from band.core.delegation import DelegationEnvelope, parse_delegation_value
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +86,17 @@ class MessageMetadata(BaseModel):
     # ``attempts`` list. This is the same signal the runtime uses to dedup
     # already-handled messages.
     delivery_status: dict[str, Any] | None = None
+    # Cross-owner identity envelope minted by the platform (INT-992). Typed so
+    # handler code gets a real model instead of a raw extra; validated
+    # tolerantly because the REST backlog path re-wraps platform dicts with
+    # ``MessageMetadata(**metadata)`` and a malformed envelope must never fail
+    # the whole metadata parse (it is logged and treated as absent).
+    delegation: DelegationEnvelope | None = None
+
+    @field_validator("delegation", mode="before")
+    @classmethod
+    def _tolerate_malformed_delegation(cls, value: Any) -> DelegationEnvelope | None:
+        return parse_delegation_value(value)
 
 
 class MessageCreatedPayload(BaseModel):

--- a/src/band/core/delegation.py
+++ b/src/band/core/delegation.py
@@ -1,0 +1,102 @@
+"""Typed view of the platform's cross-owner identity envelope (INT-992).
+
+The platform mints ``metadata["delegation"]`` server-side on cross-owner
+messages so handler and tool code can see *who is asking*. The LLM must never
+see it: ``band.runtime.formatters.format_message_for_llm`` strips exactly this
+key at the history seam, and both ``PlatformMessage.format_for_llm``
+implementations render ``[name]: content`` only.
+
+Import-light on purpose (pydantic + logging): consumed by the wire models in
+``band.client.streaming``, the preprocessor, and ``BandLink`` without dragging
+runtime modules into ``band.core``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+class Originator(BaseModel):
+    """Who minted the delegated request. Platform-authored; read-only."""
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    uuid: str | None = None
+    handle: str | None = None
+    display_name: str | None = None
+
+
+class DelegationEnvelope(BaseModel):
+    """The identity envelope the platform mints on ``metadata["delegation"]``.
+
+    Every field is optional on purpose: the SDK must keep parsing envelopes
+    from newer platforms (``extra="allow"`` absorbs added keys; ``version != 1``
+    still parses), and a partially formed envelope is more useful than a
+    dropped one. Frozen because this is a read-only view — handler/tool code
+    consumes it, nothing in the SDK writes through it.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    version: int | None = None
+    originator: Originator | None = None
+    message_id: str | None = None
+    minted_at: str | None = None
+    # Reserved by the platform for delegation chains (M2.5); ``None`` today.
+    hop: Any | None = None
+
+
+def parse_delegation_value(value: Any) -> DelegationEnvelope | None:
+    """Tolerantly coerce a raw ``delegation`` value into an envelope.
+
+    Accepts an already-parsed :class:`DelegationEnvelope`, a dict in the
+    platform's minted shape, or anything else (malformed → ``None``). Never
+    raises: a platform bug must not take down the agent loop.
+    """
+    if value is None:
+        return None
+    if isinstance(value, DelegationEnvelope):
+        return value
+    try:
+        return DelegationEnvelope.model_validate(value)
+    except Exception:
+        logger.debug("Ignoring malformed delegation envelope: %r", value)
+        return None
+
+
+def parse_delegation(metadata: Any) -> DelegationEnvelope | None:
+    """Extract and parse the identity envelope off message ``metadata``.
+
+    ``metadata`` may be a plain dict (REST / Fern models dump to dicts), a
+    pydantic model such as ``MessageMetadata`` (the WebSocket wire type), or
+    ``None`` — the same dict-or-model split that
+    ``ExecutionContext._metadata_to_dict`` normalizes. Returns ``None`` when
+    the envelope is absent or malformed; never raises.
+    """
+    if metadata is None:
+        return None
+    try:
+        if isinstance(metadata, dict):
+            raw = metadata.get("delegation")
+        else:
+            # Covers typed fields and pydantic extra="allow" attributes alike.
+            raw = getattr(metadata, "delegation", None)
+    except Exception:
+        # Defensive: exotic metadata objects (broken __getattr__) must not
+        # take down preprocessing.
+        logger.debug("Could not read delegation off metadata: %r", metadata)
+        return None
+    return parse_delegation_value(raw)
+
+
+__all__ = [
+    "DelegationEnvelope",
+    "Originator",
+    "parse_delegation",
+    "parse_delegation_value",
+]

--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 from band.client.rest import AsyncRestClient, DEFAULT_REQUEST_OPTIONS
 from band.client.streaming import WebSocketClient, WebSocketDisconnectReason
+from band.core.delegation import parse_delegation
 from band.runtime.types import PlatformMessage
 from band_rest.core.api_error import ApiError
 
@@ -675,6 +676,9 @@ class BandLink:
             message_type=item.message_type,
             metadata=item.metadata or {},
             created_at=item.inserted_at or datetime.now(timezone.utc),
+            # Typed view of the platform's identity envelope (INT-992);
+            # tolerant — a malformed envelope becomes None, never a raise.
+            delegation=parse_delegation(item.metadata),
         )
 
     async def get_stale_processing_messages(
@@ -721,6 +725,7 @@ class BandLink:
                             message_type=item.message_type,
                             metadata=item.metadata or {},
                             created_at=item.inserted_at or datetime.now(timezone.utc),
+                            delegation=parse_delegation(item.metadata),
                         )
                     )
 

--- a/src/band/preprocessing/default.py
+++ b/src/band/preprocessing/default.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime
 from typing import Any
 
+from band.core.delegation import parse_delegation
 from band.core.protocols import Preprocessor
 from band.core.types import AgentInput, HistoryProvider, PlatformMessage
 from band.platform.event import MessageEvent, PlatformEvent
@@ -60,6 +61,15 @@ class DefaultPreprocessor(Preprocessor):
         if msg_data.sender_type == "Agent" and msg_data.sender_id == agent_id:
             logger.debug("Room %s: Skipping own message %s", room_id, msg_data.id)
             return None
+
+        # Lift the platform-minted identity envelope (INT-992) once, at this
+        # single preprocessing seam: handler/tool code reads it off
+        # ctx.delegation; the LLM never sees it (format_message_for_llm strips
+        # the key from history, format_for_llm renders name + content only).
+        # Assigned unconditionally so an undelegated message clears any
+        # previous turn's envelope. parse_delegation never raises (a malformed
+        # envelope logs at DEBUG and lifts as None).
+        ctx.delegation = parse_delegation(msg_data.metadata)
 
         # Look up sender name from participants list
         sender_name = self._lookup_sender_name(ctx, msg_data.sender_id)

--- a/src/band/runtime/execution.py
+++ b/src/band/runtime/execution.py
@@ -54,6 +54,7 @@ from band.runtime.retry_tracker import MessageRetryTracker
 from band.runtime.working_state import WorkingStateReporter
 
 if TYPE_CHECKING:
+    from band.core.delegation import DelegationEnvelope
     from band.platform.link import BandLink
 
 logger = logging.getLogger(__name__)
@@ -279,6 +280,13 @@ class ExecutionContext:
 
         # LLM context tracking
         self._llm_initialized = False
+
+        # Cross-owner identity envelope for the message currently being
+        # processed (INT-992). DefaultPreprocessor.process assigns it on every
+        # message it lifts — the parsed envelope for a delegated message, None
+        # otherwise — so it can never carry over from a previous turn. Typed,
+        # read-only view for handler/tool code; never rendered for the LLM.
+        self.delegation: DelegationEnvelope | None = None
 
         # Message ownership ledger (in-flight claims, completed LRU, pending
         # acks) shared by /next and WebSocket processing. Runtime-provided so

--- a/src/band/runtime/formatters.py
+++ b/src/band/runtime/formatters.py
@@ -75,13 +75,25 @@ def format_message_for_llm(msg: dict, participants: list[dict] | None = None) ->
     if participants:
         content = replace_uuid_mentions(content, participants)
 
+    metadata = msg.get("metadata", {})
+    if isinstance(metadata, dict) and "delegation" in metadata:
+        # The platform's identity envelope (metadata["delegation"], INT-992)
+        # is for handler/tool code, never the model. This function is the
+        # single choke point every history path flows through (bootstrap
+        # hydration and oneshot alike), so the strip is enforced here and ONLY
+        # here. Strip ONLY this key: adapters keep reading their session keys
+        # (e.g. a2a_context_id) off history metadata — a deliberate contract
+        # pinned by test_preserves_metadata. Copy, don't mutate: the source
+        # dict belongs to the hydrated context cache.
+        metadata = {k: v for k, v in metadata.items() if k != "delegation"}
+
     return {
         "role": "assistant" if sender_type == "Agent" else "user",
         "content": content,
         "sender_name": sender_name,
         "sender_type": sender_type,
         "message_type": msg.get("message_type", "text"),
-        "metadata": msg.get("metadata", {}),
+        "metadata": metadata,
     }
 
 

--- a/src/band/runtime/types.py
+++ b/src/band/runtime/types.py
@@ -57,6 +57,7 @@ def normalize_handle(handle: str | None) -> str | None:
 
 
 if TYPE_CHECKING:
+    from band.core.delegation import DelegationEnvelope
     from band.platform.event import (
         ContactEvent,
         ParticipantAddedEvent,
@@ -177,6 +178,12 @@ class PlatformMessage:
     message_type: str
     metadata: dict[str, Any]
     created_at: datetime
+    # Typed view of the platform's cross-owner identity envelope
+    # (metadata["delegation"], INT-992). BandLink populates it when building
+    # messages off the REST backlog endpoints; None when the message is not
+    # delegated (or the envelope is malformed — parsing is tolerant). For
+    # handler/tool code only: format_for_llm never renders it.
+    delegation: "DelegationEnvelope | None" = None
 
     def format_for_llm(self) -> str:
         """

--- a/tests/core/test_delegation.py
+++ b/tests/core/test_delegation.py
@@ -1,0 +1,195 @@
+"""Tests for the platform identity-envelope parser (INT-992).
+
+The platform mints ``metadata["delegation"]`` server-side on cross-owner
+messages. The SDK must expose it to handler/tool code as a typed, read-only
+view and must never let a malformed envelope raise (a platform bug must not
+take down the agent loop).
+"""
+
+from __future__ import annotations
+
+import copy
+
+from band.client.streaming import MessageMetadata
+from band.core.delegation import (
+    DelegationEnvelope,
+    Originator,
+    parse_delegation,
+    parse_delegation_value,
+)
+
+# The platform's frozen minted shape (PLT-1075).
+ORIGINATOR_UUID = "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b"
+ENVELOPE_MESSAGE_ID = "7f3e9a1b-5c2d-4f6e-8a9b-1c3d5e7f9a2b"
+ENVELOPE = {
+    "version": 1,
+    "originator": {
+        "uuid": ORIGINATOR_UUID,
+        "handle": "alice.asker",
+        "display_name": "Alice Asker",
+    },
+    "message_id": ENVELOPE_MESSAGE_ID,
+    "minted_at": "2026-08-13T09:30:00Z",
+    "hop": None,
+}
+
+
+def make_envelope_dict() -> dict:
+    """A fresh copy of the frozen platform shape (tests may mutate it)."""
+    return copy.deepcopy(ENVELOPE)
+
+
+class TestParseDelegationHappyPath:
+    def test_parses_the_frozen_platform_shape_from_dict_metadata(self):
+        metadata = {
+            "mentions": [],
+            "status": "sent",
+            "delegation": make_envelope_dict(),
+        }
+
+        envelope = parse_delegation(metadata)
+
+        assert isinstance(envelope, DelegationEnvelope)
+        assert envelope.version == 1
+        assert isinstance(envelope.originator, Originator)
+        assert envelope.originator.uuid == ORIGINATOR_UUID
+        assert envelope.originator.handle == "alice.asker"
+        assert envelope.originator.display_name == "Alice Asker"
+        assert envelope.message_id == ENVELOPE_MESSAGE_ID
+        assert envelope.minted_at == "2026-08-13T09:30:00Z"
+        assert envelope.hop is None
+
+    def test_parses_from_message_metadata_model(self):
+        """The WS wire type (pydantic, extra="allow") is the other metadata
+        shape ``ExecutionContext._metadata_to_dict`` normalizes; the parser
+        accepts it directly."""
+        metadata = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": make_envelope_dict()}
+        )
+
+        envelope = parse_delegation(metadata)
+
+        assert isinstance(envelope, DelegationEnvelope)
+        assert envelope.originator is not None
+        assert envelope.originator.handle == "alice.asker"
+
+    def test_none_metadata_returns_none(self):
+        assert parse_delegation(None) is None
+
+    def test_dict_metadata_without_envelope_returns_none(self):
+        assert parse_delegation({"mentions": [], "status": "sent"}) is None
+
+    def test_model_metadata_without_envelope_returns_none(self):
+        assert parse_delegation(MessageMetadata(mentions=[], status="sent")) is None
+
+    def test_accepts_an_already_parsed_envelope(self):
+        envelope = DelegationEnvelope.model_validate(make_envelope_dict())
+        assert parse_delegation({"delegation": envelope}) is envelope
+
+
+class TestParseDelegationTolerance:
+    """I3: a malformed envelope never raises — log and treat as absent."""
+
+    def test_junk_string_envelope_returns_none(self):
+        assert parse_delegation({"delegation": "junk"}) is None
+
+    def test_junk_int_envelope_returns_none(self):
+        assert parse_delegation({"delegation": 42}) is None
+
+    def test_junk_list_envelope_returns_none(self):
+        assert parse_delegation({"delegation": ["not", "an", "envelope"]}) is None
+
+    def test_junk_version_returns_none(self):
+        envelope = make_envelope_dict()
+        envelope["version"] = "not-an-int"
+        assert parse_delegation({"delegation": envelope}) is None
+
+    def test_junk_originator_returns_none(self):
+        envelope = make_envelope_dict()
+        envelope["originator"] = "alice"
+        assert parse_delegation({"delegation": envelope}) is None
+
+    def test_junk_metadata_object_returns_none(self):
+        """Even a metadata object that is neither dict nor model is absorbed."""
+        assert parse_delegation(object()) is None
+        assert parse_delegation("metadata?") is None
+
+    def test_version_2_still_parses(self):
+        """Version-tolerant by design: a newer platform's envelope is parsed,
+        not dropped (M2.5 may bump the version)."""
+        envelope = make_envelope_dict()
+        envelope["version"] = 2
+
+        parsed = parse_delegation({"delegation": envelope})
+
+        assert parsed is not None
+        assert parsed.version == 2
+
+    def test_partial_envelope_parses(self):
+        """A partially formed envelope is better than a dropped one — every
+        field is optional."""
+        parsed = parse_delegation({"delegation": {"originator": {"handle": "a.b"}}})
+
+        assert parsed is not None
+        assert parsed.version is None
+        assert parsed.originator is not None
+        assert parsed.originator.handle == "a.b"
+
+    def test_unknown_keys_are_absorbed(self):
+        """extra="allow" absorbs platform additions (e.g. a future hop shape)."""
+        envelope = make_envelope_dict()
+        envelope["hop"] = {"via": "org/router"}
+        envelope["new_platform_key"] = "surprise"
+
+        parsed = parse_delegation({"delegation": envelope})
+
+        assert parsed is not None
+        assert parsed.hop == {"via": "org/router"}
+        assert parsed.model_extra is not None
+        assert parsed.model_extra["new_platform_key"] == "surprise"
+
+
+class TestParseDelegationValue:
+    """The value-level coercion used at the wire boundary (MessageMetadata)."""
+
+    def test_parses_a_dict_value(self):
+        parsed = parse_delegation_value(make_envelope_dict())
+        assert isinstance(parsed, DelegationEnvelope)
+        assert parsed.message_id == ENVELOPE_MESSAGE_ID
+
+    def test_passes_through_an_envelope_instance(self):
+        envelope = DelegationEnvelope.model_validate(make_envelope_dict())
+        assert parse_delegation_value(envelope) is envelope
+
+    def test_none_returns_none(self):
+        assert parse_delegation_value(None) is None
+
+    def test_junk_returns_none_without_raising(self):
+        assert parse_delegation_value("junk") is None
+        assert parse_delegation_value(3.14) is None
+
+
+class TestEnvelopeIsReadOnly:
+    """I2: handler code gets a read-only view — the envelope is platform-
+    authored and nothing in the SDK writes through it."""
+
+    def test_envelope_rejects_assignment(self):
+        envelope = DelegationEnvelope.model_validate(make_envelope_dict())
+        try:
+            envelope.message_id = "overwritten"
+        except Exception:
+            pass
+        else:
+            raise AssertionError("frozen envelope accepted attribute assignment")
+        assert envelope.message_id == ENVELOPE_MESSAGE_ID
+
+    def test_originator_rejects_assignment(self):
+        envelope = DelegationEnvelope.model_validate(make_envelope_dict())
+        assert envelope.originator is not None
+        try:
+            envelope.originator.handle = "mallory"
+        except Exception:
+            pass
+        else:
+            raise AssertionError("frozen originator accepted attribute assignment")
+        assert envelope.originator.handle == "alice.asker"

--- a/tests/core/test_delegation.py
+++ b/tests/core/test_delegation.py
@@ -221,6 +221,84 @@ class TestMessageMetadataWireBoundary:
         assert rewrapped.delegation.originator.uuid == ORIGINATOR_UUID
 
 
+class TestFormatForLlmNeverRendersTheEnvelope:
+    """I1 regression across BOTH PlatformMessage classes: the SDK has two
+    (band.core.types for adapters, band.runtime.types for MessageHandlers) and
+    neither may render envelope content for a delegated message — their
+    ``format_for_llm`` stays name + content only."""
+
+    def _assert_clean(self, rendered: str) -> None:
+        assert rendered == "[Bob Broker]: delegated ask"
+        for leaked in (
+            "delegation",
+            "alice.asker",
+            "Alice Asker",
+            ORIGINATOR_UUID,
+            ENVELOPE_MESSAGE_ID,
+        ):
+            assert leaked not in rendered
+
+    def test_core_platform_message_format_for_llm_is_clean(self):
+        from datetime import datetime, timezone
+
+        from band.core.types import PlatformMessage as CorePlatformMessage
+
+        msg = CorePlatformMessage(
+            id="msg-1",
+            room_id="room-1",
+            content="delegated ask",
+            sender_id="user-1",
+            sender_type="User",
+            sender_name="Bob Broker",
+            message_type="text",
+            metadata={"delegation": make_envelope_dict(), "status": "sent"},
+            created_at=datetime.now(timezone.utc),
+        )
+
+        self._assert_clean(msg.format_for_llm())
+
+    def test_runtime_platform_message_format_for_llm_is_clean(self):
+        from datetime import datetime, timezone
+
+        from band.runtime.types import PlatformMessage as RuntimePlatformMessage
+
+        msg = RuntimePlatformMessage(
+            id="msg-1",
+            room_id="room-1",
+            content="delegated ask",
+            sender_id="user-1",
+            sender_type="User",
+            sender_name="Bob Broker",
+            message_type="text",
+            metadata={"delegation": make_envelope_dict(), "status": "sent"},
+            created_at=datetime.now(timezone.utc),
+            delegation=DelegationEnvelope.model_validate(make_envelope_dict()),
+        )
+
+        self._assert_clean(msg.format_for_llm())
+
+    def test_runtime_platform_message_defaults_delegation_to_none(self):
+        """Existing construction sites (and the Slack adapter's synthesized
+        messages) build the runtime PlatformMessage without the field."""
+        from datetime import datetime, timezone
+
+        from band.runtime.types import PlatformMessage as RuntimePlatformMessage
+
+        msg = RuntimePlatformMessage(
+            id="msg-1",
+            room_id="room-1",
+            content="plain",
+            sender_id="user-1",
+            sender_type="User",
+            sender_name=None,
+            message_type="text",
+            metadata={},
+            created_at=datetime.now(timezone.utc),
+        )
+
+        assert msg.delegation is None
+
+
 class TestEnvelopeIsReadOnly:
     """I2: handler code gets a read-only view — the envelope is platform-
     authored and nothing in the SDK writes through it."""

--- a/tests/core/test_delegation.py
+++ b/tests/core/test_delegation.py
@@ -169,6 +169,58 @@ class TestParseDelegationValue:
         assert parse_delegation_value(3.14) is None
 
 
+class TestMessageMetadataWireBoundary:
+    """The WS wire type carries the envelope as a typed field, and the typed
+    field must stay tolerant: the REST backlog path re-wraps raw dicts with
+    ``MessageMetadata(**metadata)`` (execution.py), so a malformed envelope
+    must not fail the whole metadata parse (I3)."""
+
+    def test_wire_metadata_types_the_envelope(self):
+        metadata = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": make_envelope_dict()}
+        )
+
+        assert isinstance(metadata.delegation, DelegationEnvelope)
+        assert metadata.delegation.originator is not None
+        assert metadata.delegation.originator.handle == "alice.asker"
+
+    def test_absent_envelope_defaults_to_none(self):
+        assert MessageMetadata(mentions=[], status="sent").delegation is None
+
+    def test_rewrap_kwargs_path_tolerates_a_malformed_envelope(self):
+        """Mirrors ExecutionContext._process_claimed_backlog_message, which
+        constructs ``MessageMetadata(**metadata)`` from platform dicts."""
+        metadata = MessageMetadata(
+            **{"mentions": [], "status": "sent", "delegation": "junk"}
+        )
+
+        assert metadata.delegation is None
+
+    def test_rewrap_kwargs_path_tolerates_junk_version(self):
+        envelope = make_envelope_dict()
+        envelope["version"] = "not-an-int"
+
+        metadata = MessageMetadata(
+            **{"mentions": [], "status": "sent", "delegation": envelope}
+        )
+
+        assert metadata.delegation is None
+
+    def test_model_dump_then_rewrap_keeps_the_envelope(self):
+        """The backlog cycle dumps the WS model to a dict and re-wraps it;
+        the envelope must survive that round trip."""
+        original = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": make_envelope_dict()}
+        )
+
+        rewrapped = MessageMetadata(**original.model_dump())
+
+        assert rewrapped.delegation is not None
+        assert rewrapped.delegation.message_id == ENVELOPE_MESSAGE_ID
+        assert rewrapped.delegation.originator is not None
+        assert rewrapped.delegation.originator.uuid == ORIGINATOR_UUID
+
+
 class TestEnvelopeIsReadOnly:
     """I2: handler code gets a read-only view — the envelope is platform-
     authored and nothing in the SDK writes through it."""

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -816,6 +816,111 @@ class TestGetStaleProcessingMessages:
         link.rest.agent_api_messages.list_agent_messages.assert_awaited_once()
 
 
+class TestRestMessagesCarryTheDelegationEnvelope:
+    """INT-992: the REST backlog wrappers build the runtime PlatformMessage,
+    the message handler-facing type — its ``delegation`` field is the typed
+    view of ``metadata["delegation"]``. Parsing is tolerant: a malformed
+    envelope yields ``None``, never an exception (the recovery sweep must not
+    die on a platform bug)."""
+
+    ENVELOPE = {
+        "version": 1,
+        "originator": {
+            "uuid": "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b",
+            "handle": "alice.asker",
+            "display_name": "Alice Asker",
+        },
+        "message_id": "7f3e9a1b-5c2d-4f6e-8a9b-1c3d5e7f9a2b",
+        "minted_at": "2026-08-13T09:30:00Z",
+        "hop": None,
+    }
+
+    @staticmethod
+    def _rest_item(metadata):
+        item = MagicMock()
+        item.id = "msg-1"
+        item.chat_room_id = "room-1"
+        item.content = "delegated ask"
+        item.sender_id = "user-1"
+        item.sender_type = "User"
+        item.sender_name = "Bob Broker"
+        item.message_type = "text"
+        item.metadata = metadata
+        item.inserted_at = None
+        return item
+
+    @pytest.mark.asyncio
+    async def test_get_next_message_parses_the_envelope(self):
+        from band.core.delegation import DelegationEnvelope
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        response = MagicMock()
+        response.data = self._rest_item({"delegation": dict(self.ENVELOPE)})
+        link.rest.agent_api_messages.get_agent_next_message = AsyncMock(
+            return_value=response
+        )
+
+        msg = await link.get_next_message("room-1")
+
+        assert msg is not None
+        assert isinstance(msg.delegation, DelegationEnvelope)
+        assert msg.delegation.originator is not None
+        assert msg.delegation.originator.handle == "alice.asker"
+        # The raw metadata still carries the envelope for the backlog re-wrap;
+        # only LLM-facing formatting strips it.
+        assert msg.metadata["delegation"] == self.ENVELOPE
+
+    @pytest.mark.asyncio
+    async def test_get_next_message_without_envelope_yields_none(self):
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        response = MagicMock()
+        response.data = self._rest_item({})
+        link.rest.agent_api_messages.get_agent_next_message = AsyncMock(
+            return_value=response
+        )
+
+        msg = await link.get_next_message("room-1")
+
+        assert msg is not None
+        assert msg.delegation is None
+
+    @pytest.mark.asyncio
+    async def test_get_next_message_tolerates_a_malformed_envelope(self):
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        response = MagicMock()
+        response.data = self._rest_item({"delegation": "junk-not-an-envelope"})
+        link.rest.agent_api_messages.get_agent_next_message = AsyncMock(
+            return_value=response
+        )
+
+        msg = await link.get_next_message("room-1")
+
+        assert msg is not None
+        assert msg.delegation is None
+
+    @pytest.mark.asyncio
+    async def test_stale_processing_messages_parse_the_envelope(self):
+        from band.core.delegation import DelegationEnvelope
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        response = MagicMock()
+        response.data = [self._rest_item({"delegation": dict(self.ENVELOPE)})]
+        response.metadata = MagicMock(total_pages=1)
+        link.rest.agent_api_messages.list_agent_messages = AsyncMock(
+            return_value=response
+        )
+
+        messages = await link.get_stale_processing_messages("room-1")
+
+        assert len(messages) == 1
+        assert isinstance(messages[0].delegation, DelegationEnvelope)
+        assert messages[0].delegation.message_id == self.ENVELOPE["message_id"]
+
+
 class TestReportActivity:
     """Tests for BandLink.report_activity (boolean working-state reporting)."""
 

--- a/tests/preprocessing/test_default.py
+++ b/tests/preprocessing/test_default.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 
 from band.client.streaming import MessageCreatedPayload, MessageMetadata
+from band.core.delegation import DelegationEnvelope
 from band.core.protocols import Preprocessor
 from band.core.types import AgentInput, HistoryProvider
 from band.platform.event import (
@@ -15,6 +16,9 @@ from band.preprocessing.default import DefaultPreprocessor
 from band.runtime.types import SessionConfig
 
 
+_DEFAULT_METADATA = object()  # sentinel: "caller didn't pass metadata"
+
+
 def make_message_payload(
     *,
     id: str = "msg-1",
@@ -23,13 +27,16 @@ def make_message_payload(
     sender_type: str = "User",
     room_id: str = "room-1",
     message_type: str = "text",
+    metadata: MessageMetadata | None | object = _DEFAULT_METADATA,
 ) -> MessageCreatedPayload:
     """Create test MessageCreatedPayload."""
+    if metadata is _DEFAULT_METADATA:
+        metadata = MessageMetadata(mentions=[], status="sent")
     return MessageCreatedPayload(
         id=id,
         content=content,
         message_type=message_type,
-        metadata=MessageMetadata(mentions=[], status="sent"),
+        metadata=metadata,  # type: ignore[arg-type]
         sender_id=sender_id,
         sender_type=sender_type,
         chat_room_id=room_id,
@@ -45,6 +52,7 @@ def make_message_event(
     content: str = "Hello",
     sender_id: str = "user-1",
     sender_type: str = "User",
+    metadata: MessageMetadata | None | object = _DEFAULT_METADATA,
 ) -> MessageEvent:
     """Create test MessageEvent."""
     return MessageEvent(
@@ -54,6 +62,7 @@ def make_message_event(
             sender_id=sender_id,
             sender_type=sender_type,
             room_id=room_id,
+            metadata=metadata,
         ),
     )
 
@@ -499,6 +508,121 @@ class TestHistoryLoadingErrors:
         # Should still return AgentInput with empty history
         assert result is not None
         assert len(result.history) == 0
+
+
+class TestDelegationLift:
+    """INT-992: the preprocessor is the single lift point for the platform's
+    identity envelope — parsed once off the inbound metadata and set on
+    ``ctx.delegation`` for handler/tool code. The LLM never sees it (the
+    formatter strips the key from history; format_for_llm renders name +
+    content only)."""
+
+    ENVELOPE = {
+        "version": 1,
+        "originator": {
+            "uuid": "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b",
+            "handle": "alice.asker",
+            "display_name": "Alice Asker",
+        },
+        "message_id": "7f3e9a1b-5c2d-4f6e-8a9b-1c3d5e7f9a2b",
+        "minted_at": "2026-08-13T09:30:00Z",
+        "hop": None,
+    }
+
+    async def _process(self, ctx, event):
+        preprocessor = DefaultPreprocessor()
+        with patch("band.preprocessing.default.AgentTools") as mock_tools:
+            mock_tools.from_context.return_value = MagicMock()
+            with patch(
+                "band.preprocessing.default.check_and_format_participants"
+            ) as mock_participants:
+                mock_participants.return_value = None
+                return await preprocessor.process(ctx, event, agent_id="agent-1")
+
+    async def test_lifts_the_envelope_onto_ctx(self):
+        ctx = make_mock_ctx()
+        metadata = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": dict(self.ENVELOPE)}
+        )
+        event = make_message_event(metadata=metadata)
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        assert isinstance(ctx.delegation, DelegationEnvelope)
+        assert ctx.delegation.originator is not None
+        assert ctx.delegation.originator.handle == "alice.asker"
+        assert ctx.delegation.message_id == self.ENVELOPE["message_id"]
+
+    async def test_clears_a_stale_envelope_when_the_next_message_is_not_delegated(
+        self,
+    ):
+        """ctx.delegation is per-message state: an undelegated message must
+        overwrite the previous turn's envelope with None."""
+        ctx = make_mock_ctx()
+        ctx.delegation = DelegationEnvelope.model_validate(self.ENVELOPE)  # stale
+        event = make_message_event()  # default metadata, no envelope
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        assert ctx.delegation is None
+
+    async def test_none_metadata_lifts_none(self):
+        ctx = make_mock_ctx()
+        ctx.delegation = "stale-sentinel"
+        event = make_message_event(metadata=None)
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        assert ctx.delegation is None
+
+    async def test_malformed_envelope_lifts_none_and_does_not_raise(self):
+        """I3 end to end: a malformed platform envelope arriving over the wire
+        must neither raise nor surface as anything but None."""
+        ctx = make_mock_ctx()
+        payload = MessageCreatedPayload.model_validate(
+            {
+                "id": "msg-1",
+                "content": "Hello",
+                "message_type": "text",
+                "metadata": {
+                    "mentions": [],
+                    "status": "sent",
+                    "delegation": "junk-not-an-envelope",
+                },
+                "sender_id": "user-1",
+                "sender_type": "User",
+                "chat_room_id": "room-1",
+                "inserted_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z",
+            }
+        )
+        event = MessageEvent(room_id="room-1", payload=payload)
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        assert ctx.delegation is None
+
+    async def test_the_envelope_does_not_leak_into_msg_content(self):
+        """The AgentInput message the adapters format for the model carries no
+        envelope content."""
+        ctx = make_mock_ctx()
+        metadata = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": dict(self.ENVELOPE)}
+        )
+        event = make_message_event(content="delegated ask", metadata=metadata)
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        rendered = result.msg.format_for_llm()
+        assert "alice.asker" not in rendered
+        assert "Alice Asker" not in rendered
+        assert "delegation" not in rendered
+        assert rendered.endswith("delegated ask")
 
 
 class TestBootstrapHistoryTruncation:

--- a/tests/runtime/test_execution.py
+++ b/tests/runtime/test_execution.py
@@ -103,6 +103,13 @@ class TestExecutionContextConstruction:
 
         assert ctx.is_llm_initialized is False
 
+    def test_init_no_delegation(self, mock_link, mock_handler):
+        """The identity envelope (INT-992) starts absent; the preprocessor
+        sets it per message."""
+        ctx = ExecutionContext("room-123", mock_link, mock_handler)
+
+        assert ctx.delegation is None
+
 
 class TestExecutionContextProtocol:
     """Test that ExecutionContext implements Execution protocol."""

--- a/tests/runtime/test_formatters.py
+++ b/tests/runtime/test_formatters.py
@@ -84,7 +84,12 @@ class TestFormatMessageForLlm:
         assert result["message_type"] == "text"
 
     def test_preserves_metadata(self):
-        """Should preserve metadata for adapters that need it (e.g., A2A)."""
+        """Should preserve metadata for adapters that need it (e.g., A2A).
+
+        The single exception is the platform's identity envelope
+        (``metadata["delegation"]``, INT-992): it is for handler/tool code,
+        never the model, so it is the ONLY key stripped at this seam.
+        """
         msg = {
             "sender_type": "Agent",
             "content": "A2A task completed",
@@ -93,6 +98,7 @@ class TestFormatMessageForLlm:
                 "a2a_context_id": "ctx-123",
                 "a2a_task_id": "task-456",
                 "a2a_task_state": "completed",
+                "delegation": _DELEGATION_ENVELOPE,
             },
         }
         result = format_message_for_llm(msg)
@@ -107,6 +113,114 @@ class TestFormatMessageForLlm:
         msg = {"sender_type": "Agent", "content": "Hello"}
         result = format_message_for_llm(msg)
         assert result["metadata"] == {}
+
+
+# The platform's frozen minted shape for the identity envelope (INT-992).
+_DELEGATION_ENVELOPE = {
+    "version": 1,
+    "originator": {
+        "uuid": "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b",
+        "handle": "alice.asker",
+        "display_name": "Alice Asker",
+    },
+    "message_id": "7f3e9a1b-5c2d-4f6e-8a9b-1c3d5e7f9a2b",
+    "minted_at": "2026-08-13T09:30:00Z",
+    "hop": None,
+}
+
+
+class TestDelegationNeverReachesTheLlm:
+    """I1 (INT-992): the identity envelope must never appear in anything
+    formatted for the model. format_message_for_llm is the single choke point
+    every history path goes through (bootstrap hydration and oneshot alike),
+    so the strip lives here and ONLY here — adapter-facing surfaces keep full
+    metadata."""
+
+    def test_strips_only_the_delegation_key(self):
+        msg = {
+            "sender_type": "User",
+            "content": "please check the forecast",
+            "sender_name": "Alice",
+            "metadata": {
+                "delegation": dict(_DELEGATION_ENVELOPE),
+                "a2a_context_id": "ctx-123",
+                "status": "sent",
+            },
+        }
+
+        result = format_message_for_llm(msg)
+
+        assert "delegation" not in result["metadata"]
+        # The adapter contract survives: every other key is untouched.
+        assert result["metadata"]["a2a_context_id"] == "ctx-123"
+        assert result["metadata"]["status"] == "sent"
+
+    def test_no_envelope_content_in_the_formatted_message(self):
+        msg = {
+            "sender_type": "User",
+            "content": "please check the forecast",
+            "sender_name": "Bob Broker",
+            "metadata": {"delegation": dict(_DELEGATION_ENVELOPE)},
+        }
+
+        result = format_message_for_llm(msg)
+
+        rendered = str(result)
+        assert "alice.asker" not in rendered
+        assert "Alice Asker" not in rendered
+        assert "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b" not in rendered
+        assert "delegation" not in rendered
+
+    def test_does_not_mutate_the_source_metadata(self):
+        """The source dict belongs to the hydrated context cache, which
+        adapter-facing paths keep reading — strip on a copy."""
+        metadata = {
+            "delegation": dict(_DELEGATION_ENVELOPE),
+            "a2a_context_id": "ctx-123",
+        }
+        msg = {"sender_type": "User", "content": "hi", "metadata": metadata}
+
+        format_message_for_llm(msg)
+
+        assert metadata["delegation"] == _DELEGATION_ENVELOPE
+        assert metadata["a2a_context_id"] == "ctx-123"
+
+    def test_metadata_without_envelope_passes_through_unchanged(self):
+        metadata = {"a2a_context_id": "ctx-123", "status": "sent"}
+        msg = {"sender_type": "User", "content": "hi", "metadata": metadata}
+
+        result = format_message_for_llm(msg)
+
+        assert result["metadata"] == {"a2a_context_id": "ctx-123", "status": "sent"}
+
+    def test_history_hydration_never_carries_the_envelope(self):
+        """End to end through format_history_for_llm: a delegated message in
+        hydrated history reaches the model without any envelope content."""
+        messages = [
+            {
+                "id": "m1",
+                "sender_type": "User",
+                "content": "earlier plain message",
+                "metadata": {"status": "sent"},
+            },
+            {
+                "id": "m2",
+                "sender_type": "User",
+                "content": "delegated ask",
+                "metadata": {
+                    "delegation": dict(_DELEGATION_ENVELOPE),
+                    "a2a_context_id": "ctx-123",
+                },
+            },
+        ]
+
+        result = format_history_for_llm(messages)
+
+        rendered = str(result)
+        assert "delegation" not in rendered
+        assert "alice.asker" not in rendered
+        assert result[1]["metadata"]["a2a_context_id"] == "ctx-123"
+        assert result[0]["metadata"] == {"status": "sent"}
 
 
 class TestFormatHistoryForLlm:


### PR DESCRIPTION
M1-S1 of Credential & Identity Propagation (INT-992). The platform now mints a secret-free identity envelope on `metadata["delegation"]` when a message crosses an ownership boundary (thenvoi-platform #2358/#2359). This PR gives agent code a typed, read-only view of it and proves the model can never see it.

## Invariants delivered
- **I1 — never in the model context**: the `delegation` key is stripped at `format_message_for_llm`, the single choke point every history path routes through (DefaultPreprocessor hydration, `get_history_for_llm`, oneshot). Live turns were already structurally safe: both `PlatformMessage.format_for_llm` implementations render `[name]: content` only — now pinned by a regression test per class.
- **I2 — typed read-only access**: `ctx.delegation` on `ExecutionContext` (set per message by the preprocessor) and `msg.delegation` on the runtime `PlatformMessage` (populated by `BandLink.get_next_message` / `get_stale_processing_messages`). Envelope models are `frozen=True`.
- **I3 — malformed never raises**: `parse_delegation` accepts `MessageMetadata`, plain dict, or `None`, and returns `None` on malformed input (logged); the REST re-wrap boundary (`MessageMetadata(**metadata)`) is guarded by a tolerant `mode="before"` validator. Six tolerance tests.
- **I4 — adapter contract untouched**: only the `delegation` key is stripped, only at the LLM-formatting seam — A2A/ACP/claude_sdk converters keep reading their session keys off metadata (`test_preserves_metadata` amended consciously; all other keys still pass through).

## Evidence
- CI-equivalent suite: 4586 passed, +44 new tests, **0 new failures** (the 1 failure + 11 errors in `tests/integrations/desktop_app/` reproduce identically at base `091a942` and pass in isolation — pre-existing ordering interaction, not this change).
- `ruff check` / `ruff format --check` / `pyrefly check` all clean.
- TDD throughout; each commit body records the injected mutation that proves its test bites (e.g. disabling the strip fails 4 formatter tests with the envelope present).

## Notes for review
- The preprocessor builds the **core** `PlatformMessage`, so the typed field lives on the **runtime** class it is actually constructed on; adapter-path code reads `ctx.delegation`. Core types stay untouched.
- Frozen platform shape this codes against: `{"version": 1, "originator": {"uuid", "handle", "display_name"}, "message_id", "minted_at", "hop": null}` — `extra="allow"` absorbs M2.5's future `hop` payload.

Linear: INT-992

🤖 Generated with [Claude Code](https://claude.com/claude-code)