### PR TITLE
feat(delegation): CredentialResolver — token_for(audience) with cache and injection [INT-993]

### DIFF
--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -15,9 +15,16 @@ from phoenix_channels_python_client.client import (
 from phoenix_channels_python_client.client_types import ReconnectPolicy
 from phoenix_channels_python_client.exceptions import PHXConnectionError
 from phoenix_channels_python_client.phx_messages import PHXMessage
-from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from band.client.streaming.errors import classify_initial_upgrade_error
+from band.core.delegation import DelegationEnvelope, parse_delegation_value
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +86,17 @@ class MessageMetadata(BaseModel):
     # ``attempts`` list. This is the same signal the runtime uses to dedup
     # already-handled messages.
     delivery_status: dict[str, Any] | None = None
+    # Cross-owner identity envelope minted by the platform (INT-992). Typed so
+    # handler code gets a real model instead of a raw extra; validated
+    # tolerantly because the REST backlog path re-wraps platform dicts with
+    # ``MessageMetadata(**metadata)`` and a malformed envelope must never fail
+    # the whole metadata parse (it is logged and treated as absent).
+    delegation: DelegationEnvelope | None = None
+
+    @field_validator("delegation", mode="before")
+    @classmethod
+    def _tolerate_malformed_delegation(cls, value: Any) -> DelegationEnvelope | None:
+        return parse_delegation_value(value)
 
 
 class MessageCreatedPayload(BaseModel):

--- a/src/band/core/delegation.py
+++ b/src/band/core/delegation.py
@@ -1,0 +1,102 @@
+"""Typed view of the platform's cross-owner identity envelope (INT-992).
+
+The platform mints ``metadata["delegation"]`` server-side on cross-owner
+messages so handler and tool code can see *who is asking*. The LLM must never
+see it: ``band.runtime.formatters.format_message_for_llm`` strips exactly this
+key at the history seam, and both ``PlatformMessage.format_for_llm``
+implementations render ``[name]: content`` only.
+
+Import-light on purpose (pydantic + logging): consumed by the wire models in
+``band.client.streaming``, the preprocessor, and ``BandLink`` without dragging
+runtime modules into ``band.core``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+class Originator(BaseModel):
+    """Who minted the delegated request. Platform-authored; read-only."""
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    uuid: str | None = None
+    handle: str | None = None
+    display_name: str | None = None
+
+
+class DelegationEnvelope(BaseModel):
+    """The identity envelope the platform mints on ``metadata["delegation"]``.
+
+    Every field is optional on purpose: the SDK must keep parsing envelopes
+    from newer platforms (``extra="allow"`` absorbs added keys; ``version != 1``
+    still parses), and a partially formed envelope is more useful than a
+    dropped one. Frozen because this is a read-only view — handler/tool code
+    consumes it, nothing in the SDK writes through it.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    version: int | None = None
+    originator: Originator | None = None
+    message_id: str | None = None
+    minted_at: str | None = None
+    # Reserved by the platform for delegation chains (M2.5); ``None`` today.
+    hop: Any | None = None
+
+
+def parse_delegation_value(value: Any) -> DelegationEnvelope | None:
+    """Tolerantly coerce a raw ``delegation`` value into an envelope.
+
+    Accepts an already-parsed :class:`DelegationEnvelope`, a dict in the
+    platform's minted shape, or anything else (malformed → ``None``). Never
+    raises: a platform bug must not take down the agent loop.
+    """
+    if value is None:
+        return None
+    if isinstance(value, DelegationEnvelope):
+        return value
+    try:
+        return DelegationEnvelope.model_validate(value)
+    except Exception:
+        logger.debug("Ignoring malformed delegation envelope: %r", value)
+        return None
+
+
+def parse_delegation(metadata: Any) -> DelegationEnvelope | None:
+    """Extract and parse the identity envelope off message ``metadata``.
+
+    ``metadata`` may be a plain dict (REST / Fern models dump to dicts), a
+    pydantic model such as ``MessageMetadata`` (the WebSocket wire type), or
+    ``None`` — the same dict-or-model split that
+    ``ExecutionContext._metadata_to_dict`` normalizes. Returns ``None`` when
+    the envelope is absent or malformed; never raises.
+    """
+    if metadata is None:
+        return None
+    try:
+        if isinstance(metadata, dict):
+            raw = metadata.get("delegation")
+        else:
+            # Covers typed fields and pydantic extra="allow" attributes alike.
+            raw = getattr(metadata, "delegation", None)
+    except Exception:
+        # Defensive: exotic metadata objects (broken __getattr__) must not
+        # take down preprocessing.
+        logger.debug("Could not read delegation off metadata: %r", metadata)
+        return None
+    return parse_delegation_value(raw)
+
+
+__all__ = [
+    "DelegationEnvelope",
+    "Originator",
+    "parse_delegation",
+    "parse_delegation_value",
+]

--- a/src/band/platform/__init__.py
+++ b/src/band/platform/__init__.py
@@ -4,12 +4,55 @@ Band Platform Layer - Wire-level connection to Band platform.
 Components:
     BandLink: WebSocket connection + event dispatch (REST via .rest)
     PlatformEvent: Single event type for all platform events
+    CredentialResolver: Delegated-credential exchange for cross-owner
+        messages (INT-993), with its typed DelegationError taxonomy
 """
 
-from .event import PlatformEvent
-from .link import BandLink
+from __future__ import annotations
 
-__all__ = [
-    "BandLink",
-    "PlatformEvent",
-]
+from typing import TYPE_CHECKING
+
+from band.exports import lazy_exports
+
+# Type-only imports for static analysis (pyrefly, mypy, etc.)
+if TYPE_CHECKING:
+    from band.platform.delegation_exchange import (
+        AudienceNotAllowed as AudienceNotAllowed,
+        ConsentMissing as ConsentMissing,
+        CredentialResolver as CredentialResolver,
+        CrossOrgBlocked as CrossOrgBlocked,
+        DelegatedToken as DelegatedToken,
+        DelegationDenied as DelegationDenied,
+        DelegationError as DelegationError,
+        DelegationUnavailable as DelegationUnavailable,
+        ExchangeRateLimited as ExchangeRateLimited,
+        NoDelegation as NoDelegation,
+        OnBehalfOf as OnBehalfOf,
+        ProviderNotConnected as ProviderNotConnected,
+        Revoked as Revoked,
+        WindowExpired as WindowExpired,
+    )
+    from band.platform.event import PlatformEvent as PlatformEvent
+    from band.platform.link import BandLink as BandLink
+
+__all__, __getattr__ = lazy_exports(
+    __name__,
+    event=["PlatformEvent"],
+    link=["BandLink"],
+    delegation_exchange=[
+        "AudienceNotAllowed",
+        "ConsentMissing",
+        "CredentialResolver",
+        "CrossOrgBlocked",
+        "DelegatedToken",
+        "DelegationDenied",
+        "DelegationError",
+        "DelegationUnavailable",
+        "ExchangeRateLimited",
+        "NoDelegation",
+        "OnBehalfOf",
+        "ProviderNotConnected",
+        "Revoked",
+        "WindowExpired",
+    ],
+)

--- a/src/band/platform/delegation_exchange.py
+++ b/src/band/platform/delegation_exchange.py
@@ -1,0 +1,344 @@
+"""Delegated-credential exchange: act with the ASKER's credentials (INT-993).
+
+Given the identity envelope the platform mints on cross-owner messages
+(``ctx.delegation``, INT-992), :class:`CredentialResolver` calls the frozen
+platform endpoint ``POST /api/v1/agent/delegation/token`` and returns a
+short-lived provider token for a named audience — the MCP connector id on the
+consent allowlist, not a name or URL.
+
+``band_rest`` 0.0.26 has no delegation client, so the POST is hand-rolled with
+httpx off ``BandLink``'s ``rest_url``/``api_key`` (the same ``X-API-Key``
+custody slot the Fern client uses). Revisit at M3 if the client group is
+regenerated — this module is one file to delete.
+
+Reuse policy (RFC 6749 no-store; the platform replies ``cache-control:
+no-store``): tokens are held in resolver memory only, keyed by audience,
+reused while ``expires_at`` clears :data:`EXPIRY_SKEW_SECONDS`, and NEVER
+reused when ``expires_at`` is null — null means the provider's expiry is
+unknown, not that the token is expired, and the SDK must not fabricate a TTL.
+A per-audience ``asyncio.Lock`` single-flights concurrent ``token_for`` calls
+so a tool fan-out cannot stampede the platform's per-message exchange cap
+(default 20).
+
+Error taxonomy mirrors the frozen contract: every wire ``error.code`` maps to
+a typed :class:`DelegationError` subclass; unknown codes fall back by HTTP
+status. The ``consent_missing`` / ``provider_not_connected`` pair is the
+first-run funnel — those classes carry the contract's remediation string, and
+``str(error)`` includes it so a rendered tool error already tells the human
+what to do next.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from pydantic import BaseModel, ConfigDict
+
+from band.core.exceptions import BandError
+
+if TYPE_CHECKING:
+    from band.core.delegation import DelegationEnvelope
+    from band.platform.link import BandLink
+
+logger = logging.getLogger(__name__)
+
+#: Path of the frozen exchange endpoint, relative to ``BandLink.rest_url``.
+EXCHANGE_PATH = "/api/v1/agent/delegation/token"
+
+#: A cached token is treated as expired this many seconds early, so a token
+#: cannot die between the freshness check and the provider call that uses it.
+EXPIRY_SKEW_SECONDS = 30.0
+
+_REQUEST_TIMEOUT_SECONDS = 30.0
+
+
+# --- Typed errors (one per frozen wire code + the client-side absence case) ---
+
+
+class DelegationError(BandError):
+    """Base for delegated-credential exchange failures.
+
+    Carries the wire error's ``code`` / ``request_id`` and the HTTP ``status``
+    when the failure came from the platform; a subclass with a class-level
+    ``remediation`` appends it to ``str(error)`` so tool-error rendering
+    surfaces the next step without any special-casing.
+    """
+
+    #: Frozen wire code (class default; instances may override for codes
+    #: without a dedicated subclass, e.g. ``forbidden`` / ``validation_error``).
+    code: str | None = None
+
+    #: Human next-step for the first-run funnel pair; ``None`` elsewhere.
+    remediation: str | None = None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        request_id: str | None = None,
+        status: int | None = None,
+    ) -> None:
+        if self.remediation:
+            message = f"{message} — {self.remediation}"
+        super().__init__(message)
+        if code is not None:
+            self.code = code
+        self.request_id = request_id
+        self.status = status
+
+
+class ConsentMissing(DelegationError):
+    """No consent for (originator, agent) — first-run funnel step 1."""
+
+    code = "consent_missing"
+    remediation = "Ask the user to grant consent, then retry."
+
+
+class ProviderNotConnected(DelegationError):
+    """Consent exists but the originator has no usable connection — funnel step 2."""
+
+    code = "provider_not_connected"
+    remediation = "Ask the user to connect the provider, then retry."
+
+
+class WindowExpired(DelegationError):
+    """Exchange attempted after the processing window (anchored on
+    ``minted_at``). Terminal for this message — a new request is required."""
+
+    code = "window_expired"
+
+
+class Revoked(DelegationError):
+    """Consent was revoked. Stop; the user must re-grant."""
+
+    code = "revoked"
+
+
+class AudienceNotAllowed(DelegationError):
+    """Connector not on the consent allowlist (or unknown/malformed id).
+    Do not retry the same audience value."""
+
+    code = "audience_not_allowed"
+
+
+class CrossOrgBlocked(DelegationError):
+    """Originator and agent owner are in different orgs — hard M2 block."""
+
+    code = "cross_org_blocked"
+
+
+class DelegationDenied(DelegationError):
+    """Deliberately undifferentiated platform denial (kill-switch off,
+    connector mode ``owner``, no envelope server-side, participant gone).
+    Terminal for this message."""
+
+    code = "delegation_denied"
+
+
+class ExchangeRateLimited(DelegationError):
+    """Per-(message, agent) exchange cap exhausted. Back off."""
+
+    code = "rate_limited"
+
+
+class DelegationUnavailable(DelegationError):
+    """The 404 family: message unknown, never delivered to this agent, or the
+    agent was not @mentioned — deliberately indistinguishable on the wire.
+    Terminal for this message."""
+
+    code = "not_found"
+
+
+class NoDelegation(DelegationError):
+    """Raised client-side when the current message has no delegation envelope
+    (owner-invoked or non-delegated), instead of letting the exchange 404."""
+
+
+_ERRORS_BY_CODE: dict[str, type[DelegationError]] = {
+    "consent_missing": ConsentMissing,
+    "provider_not_connected": ProviderNotConnected,
+    "window_expired": WindowExpired,
+    "revoked": Revoked,
+    "audience_not_allowed": AudienceNotAllowed,
+    "cross_org_blocked": CrossOrgBlocked,
+    "delegation_denied": DelegationDenied,
+    "rate_limited": ExchangeRateLimited,
+    "not_found": DelegationUnavailable,
+}
+
+_ERRORS_BY_STATUS: dict[int, type[DelegationError]] = {
+    404: DelegationUnavailable,
+    429: ExchangeRateLimited,
+}
+
+
+# --- Wire models -------------------------------------------------------------
+
+
+class OnBehalfOf(BaseModel):
+    """Whose authority the token carries. Platform-authored; read-only."""
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    originator_uuid: str | None = None
+    originator_handle: str | None = None
+    agent_uuid: str | None = None
+    #: The RESOLVED canonical connector id, even if the caller sent another
+    #: spelling/case of the same connector.
+    audience: str | None = None
+
+
+class DelegatedToken(BaseModel):
+    """A short-lived provider token acting as the originator.
+
+    ``expires_at`` is the PROVIDER's expiry, not platform-bounded; ``None``
+    means unknown — the resolver then never reuses the token.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    access_token: str
+    token_type: str = "bearer"
+    expires_at: datetime | None = None
+    obo: OnBehalfOf | None = None
+
+
+# --- Resolver ----------------------------------------------------------------
+
+
+class CredentialResolver:
+    """Resolve delegated provider tokens for the one envelope it was built on.
+
+    One resolver per (link, envelope): the cache is therefore keyed
+    (message_id, audience) by construction — a new message means a new
+    envelope means a new resolver, so a token can never outlive its message's
+    delegation. ``ExecutionContext.credentials`` owns that per-turn wiring.
+    """
+
+    def __init__(self, link: "BandLink", envelope: "DelegationEnvelope | None") -> None:
+        self._link = link
+        #: The envelope this resolver acts under; ``None`` for a non-delegated
+        #: message, in which case ``token_for`` raises :class:`NoDelegation`.
+        self.envelope = envelope
+        self._cache: dict[str, DelegatedToken] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    async def token_for(self, audience: str) -> DelegatedToken:
+        """Return a live delegated token for ``audience`` (an MCP connector id).
+
+        Raises a :class:`DelegationError` subclass per the frozen taxonomy;
+        :class:`NoDelegation` client-side when the current message carries no
+        envelope (I3 — owner-invoked messages are never delegated).
+        """
+        message_id = self.envelope.message_id if self.envelope else None
+        if not message_id:
+            raise NoDelegation(
+                "This message carries no delegation envelope (owner-invoked or "
+                "non-delegated), so there are no delegated credentials to "
+                "resolve. token_for() only works while handling a cross-owner "
+                "message."
+            )
+
+        lock = self._locks.setdefault(audience, asyncio.Lock())
+        async with lock:
+            cached = self._cache.get(audience)
+            if cached is not None and _is_fresh(cached):
+                return cached
+            token = await self._exchange(message_id, audience)
+            if token.expires_at is not None:
+                self._cache[audience] = token
+            else:
+                # Unknown expiry: no reuse, and drop any stale predecessor.
+                self._cache.pop(audience, None)
+            return token
+
+    async def _exchange(self, message_id: str, audience: str) -> DelegatedToken:
+        url = self._link.rest_url.rstrip("/") + EXCHANGE_PATH
+        async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                url,
+                json={"message_id": message_id, "audience": audience},
+                headers={"X-API-Key": self._link.api_key},
+            )
+
+        if response.status_code == 200:
+            try:
+                return DelegatedToken.model_validate(response.json())
+            except Exception as exc:
+                raise DelegationError(
+                    f"Malformed delegation token response: {exc}", status=200
+                ) from exc
+
+        raise _error_from_response(response)
+
+
+def _is_fresh(token: DelegatedToken) -> bool:
+    """Whether a cached token is still safely usable (expiry minus skew)."""
+    expires_at = token.expires_at
+    if expires_at is None:
+        return False
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    skew = timedelta(seconds=EXPIRY_SKEW_SECONDS)
+    return expires_at - skew > datetime.now(timezone.utc)
+
+
+def _error_from_response(response: httpx.Response) -> DelegationError:
+    """Map a non-200 exchange response to its typed error.
+
+    Primary key is the wire ``error.code``; an unknown or absent code falls
+    back by HTTP status (the auth plug's 401 has no error envelope at all).
+    """
+    code: str | None = None
+    message: str | None = None
+    request_id: str | None = None
+    try:
+        payload: Any = response.json()
+    except Exception:
+        payload = None
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            raw_code = error.get("code")
+            code = raw_code if isinstance(raw_code, str) else None
+            raw_message = error.get("message")
+            message = raw_message if isinstance(raw_message, str) else None
+            raw_request_id = error.get("request_id")
+            request_id = raw_request_id if isinstance(raw_request_id, str) else None
+
+    error_cls = (
+        _ERRORS_BY_CODE.get(code or "")
+        or _ERRORS_BY_STATUS.get(response.status_code)
+        or DelegationError
+    )
+    return error_cls(
+        message or f"Delegation exchange failed with HTTP {response.status_code}",
+        code=code,
+        request_id=request_id,
+        status=response.status_code,
+    )
+
+
+__all__ = [
+    "AudienceNotAllowed",
+    "ConsentMissing",
+    "CredentialResolver",
+    "CrossOrgBlocked",
+    "DelegatedToken",
+    "DelegationDenied",
+    "DelegationError",
+    "DelegationUnavailable",
+    "EXCHANGE_PATH",
+    "EXPIRY_SKEW_SECONDS",
+    "ExchangeRateLimited",
+    "NoDelegation",
+    "OnBehalfOf",
+    "ProviderNotConnected",
+    "Revoked",
+    "WindowExpired",
+]

--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 from band.client.rest import AsyncRestClient, DEFAULT_REQUEST_OPTIONS
 from band.client.streaming import WebSocketClient, WebSocketDisconnectReason
+from band.core.delegation import parse_delegation
 from band.runtime.types import PlatformMessage
 from band_rest.core.api_error import ApiError
 
@@ -675,6 +676,9 @@ class BandLink:
             message_type=item.message_type,
             metadata=item.metadata or {},
             created_at=item.inserted_at or datetime.now(timezone.utc),
+            # Typed view of the platform's identity envelope (INT-992);
+            # tolerant — a malformed envelope becomes None, never a raise.
+            delegation=parse_delegation(item.metadata),
         )
 
     async def get_stale_processing_messages(
@@ -721,6 +725,7 @@ class BandLink:
                             message_type=item.message_type,
                             metadata=item.metadata or {},
                             created_at=item.inserted_at or datetime.now(timezone.utc),
+                            delegation=parse_delegation(item.metadata),
                         )
                     )
 

--- a/src/band/preprocessing/default.py
+++ b/src/band/preprocessing/default.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime
 from typing import Any
 
+from band.core.delegation import parse_delegation
 from band.core.protocols import Preprocessor
 from band.core.types import AgentInput, HistoryProvider, PlatformMessage
 from band.platform.event import MessageEvent, PlatformEvent
@@ -60,6 +61,15 @@ class DefaultPreprocessor(Preprocessor):
         if msg_data.sender_type == "Agent" and msg_data.sender_id == agent_id:
             logger.debug("Room %s: Skipping own message %s", room_id, msg_data.id)
             return None
+
+        # Lift the platform-minted identity envelope (INT-992) once, at this
+        # single preprocessing seam: handler/tool code reads it off
+        # ctx.delegation; the LLM never sees it (format_message_for_llm strips
+        # the key from history, format_for_llm renders name + content only).
+        # Assigned unconditionally so an undelegated message clears any
+        # previous turn's envelope. parse_delegation never raises (a malformed
+        # envelope logs at DEBUG and lifts as None).
+        ctx.delegation = parse_delegation(msg_data.metadata)
 
         # Look up sender name from participants list
         sender_name = self._lookup_sender_name(ctx, msg_data.sender_id)

--- a/src/band/runtime/execution.py
+++ b/src/band/runtime/execution.py
@@ -55,6 +55,7 @@ from band.runtime.working_state import WorkingStateReporter
 
 if TYPE_CHECKING:
     from band.core.delegation import DelegationEnvelope
+    from band.platform.delegation_exchange import CredentialResolver
     from band.platform.link import BandLink
 
 logger = logging.getLogger(__name__)
@@ -288,6 +289,11 @@ class ExecutionContext:
         # read-only view for handler/tool code; never rendered for the LLM.
         self.delegation: DelegationEnvelope | None = None
 
+        # Lazily built delegated-credential resolver for the CURRENT envelope
+        # (INT-993). Invalidated by identity when self.delegation changes, so
+        # a token cache can never outlive its message's delegation.
+        self._credentials_resolver: CredentialResolver | None = None
+
         # Message ownership ledger (in-flight claims, completed LRU, pending
         # acks) shared by /next and WebSocket processing. Runtime-provided so
         # all contexts of one agent coordinate; private otherwise.
@@ -348,6 +354,31 @@ class ExecutionContext:
     def is_processing(self) -> bool:
         """Check if context is currently processing an event."""
         return self.state is ExecutionState.PROCESSING
+
+    @property
+    def credentials(self) -> "CredentialResolver":
+        """Delegated-credential resolver for the CURRENT message (INT-993).
+
+        Built lazily from ``self.link`` and ``self.delegation`` and kept
+        stable for the duration of the turn, so a tool fan-out shares one
+        per-audience token cache and single-flight lock. When the envelope
+        changes (the preprocessor assigns ``self.delegation`` on every
+        message), the next access builds a fresh resolver — a token can never
+        outlive its message's delegation. Without an envelope (owner-invoked
+        or non-delegated message) the resolver raises ``NoDelegation`` on
+        use, the typed I1 error, rather than this property failing.
+        """
+        # Import here to avoid a module cycle (platform.delegation_exchange
+        # is import-light, but runtime.execution is imported everywhere).
+        from band.platform.delegation_exchange import CredentialResolver
+
+        cached = self._credentials_resolver
+        if cached is not None and cached.envelope is self.delegation:
+            return cached
+
+        resolver = CredentialResolver(self.link, self.delegation)
+        self._credentials_resolver = resolver
+        return resolver
 
     def _set_state(self, new_state: ExecutionState) -> None:
         """

--- a/src/band/runtime/execution.py
+++ b/src/band/runtime/execution.py
@@ -54,6 +54,7 @@ from band.runtime.retry_tracker import MessageRetryTracker
 from band.runtime.working_state import WorkingStateReporter
 
 if TYPE_CHECKING:
+    from band.core.delegation import DelegationEnvelope
     from band.platform.link import BandLink
 
 logger = logging.getLogger(__name__)
@@ -279,6 +280,13 @@ class ExecutionContext:
 
         # LLM context tracking
         self._llm_initialized = False
+
+        # Cross-owner identity envelope for the message currently being
+        # processed (INT-992). DefaultPreprocessor.process assigns it on every
+        # message it lifts — the parsed envelope for a delegated message, None
+        # otherwise — so it can never carry over from a previous turn. Typed,
+        # read-only view for handler/tool code; never rendered for the LLM.
+        self.delegation: DelegationEnvelope | None = None
 
         # Message ownership ledger (in-flight claims, completed LRU, pending
         # acks) shared by /next and WebSocket processing. Runtime-provided so

--- a/src/band/runtime/formatters.py
+++ b/src/band/runtime/formatters.py
@@ -75,13 +75,25 @@ def format_message_for_llm(msg: dict, participants: list[dict] | None = None) ->
     if participants:
         content = replace_uuid_mentions(content, participants)
 
+    metadata = msg.get("metadata", {})
+    if isinstance(metadata, dict) and "delegation" in metadata:
+        # The platform's identity envelope (metadata["delegation"], INT-992)
+        # is for handler/tool code, never the model. This function is the
+        # single choke point every history path flows through (bootstrap
+        # hydration and oneshot alike), so the strip is enforced here and ONLY
+        # here. Strip ONLY this key: adapters keep reading their session keys
+        # (e.g. a2a_context_id) off history metadata — a deliberate contract
+        # pinned by test_preserves_metadata. Copy, don't mutate: the source
+        # dict belongs to the hydrated context cache.
+        metadata = {k: v for k, v in metadata.items() if k != "delegation"}
+
     return {
         "role": "assistant" if sender_type == "Agent" else "user",
         "content": content,
         "sender_name": sender_name,
         "sender_type": sender_type,
         "message_type": msg.get("message_type", "text"),
-        "metadata": msg.get("metadata", {}),
+        "metadata": metadata,
     }
 
 

--- a/src/band/runtime/types.py
+++ b/src/band/runtime/types.py
@@ -57,6 +57,7 @@ def normalize_handle(handle: str | None) -> str | None:
 
 
 if TYPE_CHECKING:
+    from band.core.delegation import DelegationEnvelope
     from band.platform.event import (
         ContactEvent,
         ParticipantAddedEvent,
@@ -177,6 +178,12 @@ class PlatformMessage:
     message_type: str
     metadata: dict[str, Any]
     created_at: datetime
+    # Typed view of the platform's cross-owner identity envelope
+    # (metadata["delegation"], INT-992). BandLink populates it when building
+    # messages off the REST backlog endpoints; None when the message is not
+    # delegated (or the envelope is malformed — parsing is tolerant). For
+    # handler/tool code only: format_for_llm never renders it.
+    delegation: "DelegationEnvelope | None" = None
 
     def format_for_llm(self) -> str:
         """

--- a/tests/core/test_delegation.py
+++ b/tests/core/test_delegation.py
@@ -1,0 +1,195 @@
+"""Tests for the platform identity-envelope parser (INT-992).
+
+The platform mints ``metadata["delegation"]`` server-side on cross-owner
+messages. The SDK must expose it to handler/tool code as a typed, read-only
+view and must never let a malformed envelope raise (a platform bug must not
+take down the agent loop).
+"""
+
+from __future__ import annotations
+
+import copy
+
+from band.client.streaming import MessageMetadata
+from band.core.delegation import (
+    DelegationEnvelope,
+    Originator,
+    parse_delegation,
+    parse_delegation_value,
+)
+
+# The platform's frozen minted shape (PLT-1075).
+ORIGINATOR_UUID = "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b"
+ENVELOPE_MESSAGE_ID = "7f3e9a1b-5c2d-4f6e-8a9b-1c3d5e7f9a2b"
+ENVELOPE = {
+    "version": 1,
+    "originator": {
+        "uuid": ORIGINATOR_UUID,
+        "handle": "alice.asker",
+        "display_name": "Alice Asker",
+    },
+    "message_id": ENVELOPE_MESSAGE_ID,
+    "minted_at": "2026-08-13T09:30:00Z",
+    "hop": None,
+}
+
+
+def make_envelope_dict() -> dict:
+    """A fresh copy of the frozen platform shape (tests may mutate it)."""
+    return copy.deepcopy(ENVELOPE)
+
+
+class TestParseDelegationHappyPath:
+    def test_parses_the_frozen_platform_shape_from_dict_metadata(self):
+        metadata = {
+            "mentions": [],
+            "status": "sent",
+            "delegation": make_envelope_dict(),
+        }
+
+        envelope = parse_delegation(metadata)
+
+        assert isinstance(envelope, DelegationEnvelope)
+        assert envelope.version == 1
+        assert isinstance(envelope.originator, Originator)
+        assert envelope.originator.uuid == ORIGINATOR_UUID
+        assert envelope.originator.handle == "alice.asker"
+        assert envelope.originator.display_name == "Alice Asker"
+        assert envelope.message_id == ENVELOPE_MESSAGE_ID
+        assert envelope.minted_at == "2026-08-13T09:30:00Z"
+        assert envelope.hop is None
+
+    def test_parses_from_message_metadata_model(self):
+        """The WS wire type (pydantic, extra="allow") is the other metadata
+        shape ``ExecutionContext._metadata_to_dict`` normalizes; the parser
+        accepts it directly."""
+        metadata = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": make_envelope_dict()}
+        )
+
+        envelope = parse_delegation(metadata)
+
+        assert isinstance(envelope, DelegationEnvelope)
+        assert envelope.originator is not None
+        assert envelope.originator.handle == "alice.asker"
+
+    def test_none_metadata_returns_none(self):
+        assert parse_delegation(None) is None
+
+    def test_dict_metadata_without_envelope_returns_none(self):
+        assert parse_delegation({"mentions": [], "status": "sent"}) is None
+
+    def test_model_metadata_without_envelope_returns_none(self):
+        assert parse_delegation(MessageMetadata(mentions=[], status="sent")) is None
+
+    def test_accepts_an_already_parsed_envelope(self):
+        envelope = DelegationEnvelope.model_validate(make_envelope_dict())
+        assert parse_delegation({"delegation": envelope}) is envelope
+
+
+class TestParseDelegationTolerance:
+    """I3: a malformed envelope never raises — log and treat as absent."""
+
+    def test_junk_string_envelope_returns_none(self):
+        assert parse_delegation({"delegation": "junk"}) is None
+
+    def test_junk_int_envelope_returns_none(self):
+        assert parse_delegation({"delegation": 42}) is None
+
+    def test_junk_list_envelope_returns_none(self):
+        assert parse_delegation({"delegation": ["not", "an", "envelope"]}) is None
+
+    def test_junk_version_returns_none(self):
+        envelope = make_envelope_dict()
+        envelope["version"] = "not-an-int"
+        assert parse_delegation({"delegation": envelope}) is None
+
+    def test_junk_originator_returns_none(self):
+        envelope = make_envelope_dict()
+        envelope["originator"] = "alice"
+        assert parse_delegation({"delegation": envelope}) is None
+
+    def test_junk_metadata_object_returns_none(self):
+        """Even a metadata object that is neither dict nor model is absorbed."""
+        assert parse_delegation(object()) is None
+        assert parse_delegation("metadata?") is None
+
+    def test_version_2_still_parses(self):
+        """Version-tolerant by design: a newer platform's envelope is parsed,
+        not dropped (M2.5 may bump the version)."""
+        envelope = make_envelope_dict()
+        envelope["version"] = 2
+
+        parsed = parse_delegation({"delegation": envelope})
+
+        assert parsed is not None
+        assert parsed.version == 2
+
+    def test_partial_envelope_parses(self):
+        """A partially formed envelope is better than a dropped one — every
+        field is optional."""
+        parsed = parse_delegation({"delegation": {"originator": {"handle": "a.b"}}})
+
+        assert parsed is not None
+        assert parsed.version is None
+        assert parsed.originator is not None
+        assert parsed.originator.handle == "a.b"
+
+    def test_unknown_keys_are_absorbed(self):
+        """extra="allow" absorbs platform additions (e.g. a future hop shape)."""
+        envelope = make_envelope_dict()
+        envelope["hop"] = {"via": "org/router"}
+        envelope["new_platform_key"] = "surprise"
+
+        parsed = parse_delegation({"delegation": envelope})
+
+        assert parsed is not None
+        assert parsed.hop == {"via": "org/router"}
+        assert parsed.model_extra is not None
+        assert parsed.model_extra["new_platform_key"] == "surprise"
+
+
+class TestParseDelegationValue:
+    """The value-level coercion used at the wire boundary (MessageMetadata)."""
+
+    def test_parses_a_dict_value(self):
+        parsed = parse_delegation_value(make_envelope_dict())
+        assert isinstance(parsed, DelegationEnvelope)
+        assert parsed.message_id == ENVELOPE_MESSAGE_ID
+
+    def test_passes_through_an_envelope_instance(self):
+        envelope = DelegationEnvelope.model_validate(make_envelope_dict())
+        assert parse_delegation_value(envelope) is envelope
+
+    def test_none_returns_none(self):
+        assert parse_delegation_value(None) is None
+
+    def test_junk_returns_none_without_raising(self):
+        assert parse_delegation_value("junk") is None
+        assert parse_delegation_value(3.14) is None
+
+
+class TestEnvelopeIsReadOnly:
+    """I2: handler code gets a read-only view — the envelope is platform-
+    authored and nothing in the SDK writes through it."""
+
+    def test_envelope_rejects_assignment(self):
+        envelope = DelegationEnvelope.model_validate(make_envelope_dict())
+        try:
+            envelope.message_id = "overwritten"
+        except Exception:
+            pass
+        else:
+            raise AssertionError("frozen envelope accepted attribute assignment")
+        assert envelope.message_id == ENVELOPE_MESSAGE_ID
+
+    def test_originator_rejects_assignment(self):
+        envelope = DelegationEnvelope.model_validate(make_envelope_dict())
+        assert envelope.originator is not None
+        try:
+            envelope.originator.handle = "mallory"
+        except Exception:
+            pass
+        else:
+            raise AssertionError("frozen originator accepted attribute assignment")
+        assert envelope.originator.handle == "alice.asker"

--- a/tests/core/test_delegation.py
+++ b/tests/core/test_delegation.py
@@ -221,6 +221,84 @@ class TestMessageMetadataWireBoundary:
         assert rewrapped.delegation.originator.uuid == ORIGINATOR_UUID
 
 
+class TestFormatForLlmNeverRendersTheEnvelope:
+    """I1 regression across BOTH PlatformMessage classes: the SDK has two
+    (band.core.types for adapters, band.runtime.types for MessageHandlers) and
+    neither may render envelope content for a delegated message — their
+    ``format_for_llm`` stays name + content only."""
+
+    def _assert_clean(self, rendered: str) -> None:
+        assert rendered == "[Bob Broker]: delegated ask"
+        for leaked in (
+            "delegation",
+            "alice.asker",
+            "Alice Asker",
+            ORIGINATOR_UUID,
+            ENVELOPE_MESSAGE_ID,
+        ):
+            assert leaked not in rendered
+
+    def test_core_platform_message_format_for_llm_is_clean(self):
+        from datetime import datetime, timezone
+
+        from band.core.types import PlatformMessage as CorePlatformMessage
+
+        msg = CorePlatformMessage(
+            id="msg-1",
+            room_id="room-1",
+            content="delegated ask",
+            sender_id="user-1",
+            sender_type="User",
+            sender_name="Bob Broker",
+            message_type="text",
+            metadata={"delegation": make_envelope_dict(), "status": "sent"},
+            created_at=datetime.now(timezone.utc),
+        )
+
+        self._assert_clean(msg.format_for_llm())
+
+    def test_runtime_platform_message_format_for_llm_is_clean(self):
+        from datetime import datetime, timezone
+
+        from band.runtime.types import PlatformMessage as RuntimePlatformMessage
+
+        msg = RuntimePlatformMessage(
+            id="msg-1",
+            room_id="room-1",
+            content="delegated ask",
+            sender_id="user-1",
+            sender_type="User",
+            sender_name="Bob Broker",
+            message_type="text",
+            metadata={"delegation": make_envelope_dict(), "status": "sent"},
+            created_at=datetime.now(timezone.utc),
+            delegation=DelegationEnvelope.model_validate(make_envelope_dict()),
+        )
+
+        self._assert_clean(msg.format_for_llm())
+
+    def test_runtime_platform_message_defaults_delegation_to_none(self):
+        """Existing construction sites (and the Slack adapter's synthesized
+        messages) build the runtime PlatformMessage without the field."""
+        from datetime import datetime, timezone
+
+        from band.runtime.types import PlatformMessage as RuntimePlatformMessage
+
+        msg = RuntimePlatformMessage(
+            id="msg-1",
+            room_id="room-1",
+            content="plain",
+            sender_id="user-1",
+            sender_type="User",
+            sender_name=None,
+            message_type="text",
+            metadata={},
+            created_at=datetime.now(timezone.utc),
+        )
+
+        assert msg.delegation is None
+
+
 class TestEnvelopeIsReadOnly:
     """I2: handler code gets a read-only view — the envelope is platform-
     authored and nothing in the SDK writes through it."""

--- a/tests/core/test_delegation.py
+++ b/tests/core/test_delegation.py
@@ -169,6 +169,58 @@ class TestParseDelegationValue:
         assert parse_delegation_value(3.14) is None
 
 
+class TestMessageMetadataWireBoundary:
+    """The WS wire type carries the envelope as a typed field, and the typed
+    field must stay tolerant: the REST backlog path re-wraps raw dicts with
+    ``MessageMetadata(**metadata)`` (execution.py), so a malformed envelope
+    must not fail the whole metadata parse (I3)."""
+
+    def test_wire_metadata_types_the_envelope(self):
+        metadata = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": make_envelope_dict()}
+        )
+
+        assert isinstance(metadata.delegation, DelegationEnvelope)
+        assert metadata.delegation.originator is not None
+        assert metadata.delegation.originator.handle == "alice.asker"
+
+    def test_absent_envelope_defaults_to_none(self):
+        assert MessageMetadata(mentions=[], status="sent").delegation is None
+
+    def test_rewrap_kwargs_path_tolerates_a_malformed_envelope(self):
+        """Mirrors ExecutionContext._process_claimed_backlog_message, which
+        constructs ``MessageMetadata(**metadata)`` from platform dicts."""
+        metadata = MessageMetadata(
+            **{"mentions": [], "status": "sent", "delegation": "junk"}
+        )
+
+        assert metadata.delegation is None
+
+    def test_rewrap_kwargs_path_tolerates_junk_version(self):
+        envelope = make_envelope_dict()
+        envelope["version"] = "not-an-int"
+
+        metadata = MessageMetadata(
+            **{"mentions": [], "status": "sent", "delegation": envelope}
+        )
+
+        assert metadata.delegation is None
+
+    def test_model_dump_then_rewrap_keeps_the_envelope(self):
+        """The backlog cycle dumps the WS model to a dict and re-wraps it;
+        the envelope must survive that round trip."""
+        original = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": make_envelope_dict()}
+        )
+
+        rewrapped = MessageMetadata(**original.model_dump())
+
+        assert rewrapped.delegation is not None
+        assert rewrapped.delegation.message_id == ENVELOPE_MESSAGE_ID
+        assert rewrapped.delegation.originator is not None
+        assert rewrapped.delegation.originator.uuid == ORIGINATOR_UUID
+
+
 class TestEnvelopeIsReadOnly:
     """I2: handler code gets a read-only view — the envelope is platform-
     authored and nothing in the SDK writes through it."""

--- a/tests/platform/test_delegation_exchange.py
+++ b/tests/platform/test_delegation_exchange.py
@@ -1,0 +1,423 @@
+"""CredentialResolver: the SDK half of the delegated-credential exchange (INT-993).
+
+The wire contract under test is the frozen platform endpoint
+``POST /api/v1/agent/delegation/token`` (agent API key in ``X-API-Key``; errors
+shaped ``{"error": {"code", "message", "request_id"}}``). ``band_rest`` 0.0.26
+has no delegation client, so the resolver hand-rolls the httpx POST off
+``BandLink``'s ``rest_url``/``api_key`` — interception here is the same global
+``pytest-httpx`` ``httpx_mock`` fixture ``test_link_credentials.py`` uses, so
+the observed request is the real outbound call, not an injected seam.
+
+Reuse policy pinned here (RFC 6749 no-store; the platform replies
+``cache-control: no-store``): tokens live in resolver memory only, keyed by
+audience, fresh while ``expires_at`` clears a 30 s skew, and are NEVER reused
+when ``expires_at`` is null — null means unknown, not expired, and the SDK
+must not fabricate a TTL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from band.core.delegation import DelegationEnvelope
+from band.platform.delegation_exchange import (
+    AudienceNotAllowed,
+    ConsentMissing,
+    CredentialResolver,
+    CrossOrgBlocked,
+    DelegatedToken,
+    DelegationDenied,
+    DelegationError,
+    DelegationUnavailable,
+    ExchangeRateLimited,
+    NoDelegation,
+    ProviderNotConnected,
+    Revoked,
+    WindowExpired,
+)
+from band.platform.link import BandLink
+
+REST_URL = "https://platform.test"
+EXCHANGE_URL = f"{REST_URL}/api/v1/agent/delegation/token"
+MESSAGE_ID = "8f7f2f6a-3f6e-4a3e-9b1a-2c4d5e6f7a8b"
+AUDIENCE = "1f2e3d4c-5b6a-7980-a1b2-c3d4e5f6a7b8"
+
+
+def make_link() -> BandLink:
+    return BandLink(agent_id="agent-1", api_key="sk-agent-key", rest_url=REST_URL)
+
+
+def make_envelope(message_id: str | None = MESSAGE_ID) -> DelegationEnvelope:
+    return DelegationEnvelope.model_validate(
+        {
+            "version": 1,
+            "originator": {
+                "uuid": "0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9",
+                "handle": "alice",
+                "display_name": "Alice",
+            },
+            "message_id": message_id,
+            "minted_at": "2026-08-14T00:00:00Z",
+        }
+    )
+
+
+def make_resolver(
+    envelope: DelegationEnvelope | None = None,
+) -> CredentialResolver:
+    return CredentialResolver(make_link(), envelope)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def token_body(
+    *,
+    expires_at: str | None,
+    access_token: str = "provider-token-1",
+) -> dict[str, object]:
+    return {
+        "access_token": access_token,
+        "token_type": "bearer",
+        "expires_at": expires_at,
+        "obo": {
+            "originator_uuid": "0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9",
+            "originator_handle": "alice",
+            "agent_uuid": "agent-1",
+            "audience": AUDIENCE,
+        },
+    }
+
+
+def error_body(code: str, message: str = "nope") -> dict[str, object]:
+    return {"error": {"code": code, "message": message, "request_id": "req-123"}}
+
+
+class TestWireRequest:
+    """The outbound POST matches the frozen contract exactly."""
+
+    async def test_posts_message_id_and_audience_with_api_key_header(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        expires = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(json=token_body(expires_at=expires))
+
+        resolver = make_resolver(make_envelope())
+        await resolver.token_for(AUDIENCE)
+
+        request = httpx_mock.get_request()
+        assert request is not None
+        assert request.method == "POST"
+        assert str(request.url) == EXCHANGE_URL
+        assert request.headers["X-API-Key"] == "sk-agent-key"
+        # Missing Content-Type is a 422 on the platform side — pin it.
+        assert request.headers["Content-Type"] == "application/json"
+        import json
+
+        assert json.loads(request.content) == {
+            "message_id": MESSAGE_ID,
+            "audience": AUDIENCE,
+        }
+
+    async def test_parses_a_success_response(self, httpx_mock: HTTPXMock) -> None:
+        expires = datetime.now(timezone.utc).replace(microsecond=0) + timedelta(hours=1)
+        httpx_mock.add_response(json=token_body(expires_at=_iso(expires)))
+
+        resolver = make_resolver(make_envelope())
+        token = await resolver.token_for(AUDIENCE)
+
+        assert isinstance(token, DelegatedToken)
+        assert token.access_token == "provider-token-1"
+        assert token.token_type == "bearer"
+        assert token.expires_at == expires
+        assert token.obo is not None
+        assert token.obo.originator_uuid == "0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9"
+        assert token.obo.originator_handle == "alice"
+        assert token.obo.agent_uuid == "agent-1"
+        # The platform echoes the RESOLVED canonical connector id.
+        assert token.obo.audience == AUDIENCE
+
+    async def test_malformed_success_body_raises_typed_error(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(json={"unexpected": "shape"})
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(DelegationError):
+            await resolver.token_for(AUDIENCE)
+
+
+class TestReusePolicy:
+    """In-memory only, expiry-aware with 30 s skew, never on null expiry."""
+
+    async def test_fresh_token_is_reused_without_a_second_request(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        expires = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(json=token_body(expires_at=expires))
+
+        resolver = make_resolver(make_envelope())
+        first = await resolver.token_for(AUDIENCE)
+        second = await resolver.token_for(AUDIENCE)
+
+        assert first is second
+        assert len(httpx_mock.get_requests()) == 1
+
+    async def test_null_expiry_is_never_reused(self, httpx_mock: HTTPXMock) -> None:
+        # null = UNKNOWN, not expired: each call must fetch a fresh token
+        # rather than fabricate a TTL for reuse.
+        httpx_mock.add_response(json=token_body(expires_at=None, access_token="tok-a"))
+        httpx_mock.add_response(json=token_body(expires_at=None, access_token="tok-b"))
+
+        resolver = make_resolver(make_envelope())
+        first = await resolver.token_for(AUDIENCE)
+        second = await resolver.token_for(AUDIENCE)
+
+        assert first.access_token == "tok-a"
+        assert second.access_token == "tok-b"
+        assert len(httpx_mock.get_requests()) == 2
+
+    async def test_expired_token_is_refetched(self, httpx_mock: HTTPXMock) -> None:
+        expired = _iso(datetime.now(timezone.utc) - timedelta(minutes=5))
+        fresh = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(json=token_body(expires_at=expired))
+        httpx_mock.add_response(
+            json=token_body(expires_at=fresh, access_token="tok-fresh")
+        )
+
+        resolver = make_resolver(make_envelope())
+        await resolver.token_for(AUDIENCE)
+        second = await resolver.token_for(AUDIENCE)
+
+        assert second.access_token == "tok-fresh"
+        assert len(httpx_mock.get_requests()) == 2
+
+    async def test_token_inside_the_skew_window_is_refetched(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        # Still nominally live (+10 s) but inside the 30 s skew: treat as
+        # expired so a token cannot die mid-provider-call.
+        nearly = _iso(datetime.now(timezone.utc) + timedelta(seconds=10))
+        fresh = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(json=token_body(expires_at=nearly))
+        httpx_mock.add_response(
+            json=token_body(expires_at=fresh, access_token="tok-fresh")
+        )
+
+        resolver = make_resolver(make_envelope())
+        await resolver.token_for(AUDIENCE)
+        second = await resolver.token_for(AUDIENCE)
+
+        assert second.access_token == "tok-fresh"
+        assert len(httpx_mock.get_requests()) == 2
+
+    async def test_audiences_cache_independently(self, httpx_mock: HTTPXMock) -> None:
+        other_audience = "9e8d7c6b-5a49-3827-b1a0-f9e8d7c6b5a4"
+        expires = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(json=token_body(expires_at=expires, access_token="a"))
+        httpx_mock.add_response(json=token_body(expires_at=expires, access_token="b"))
+
+        resolver = make_resolver(make_envelope())
+        first = await resolver.token_for(AUDIENCE)
+        second = await resolver.token_for(other_audience)
+
+        assert first.access_token == "a"
+        assert second.access_token == "b"
+        assert len(httpx_mock.get_requests()) == 2
+
+    async def test_a_new_resolver_does_not_inherit_tokens(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        # No-store means memory-of-this-resolver only: nothing on disk, nothing
+        # shared between resolver instances.
+        expires = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(json=token_body(expires_at=expires))
+        httpx_mock.add_response(json=token_body(expires_at=expires))
+
+        await make_resolver(make_envelope()).token_for(AUDIENCE)
+        await make_resolver(make_envelope()).token_for(AUDIENCE)
+
+        assert len(httpx_mock.get_requests()) == 2
+
+
+class TestSingleFlight:
+    async def test_concurrent_calls_for_one_audience_make_one_request(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        # The per-message exchange cap (default 20) makes a tool fan-out
+        # stampede expensive: concurrent token_for calls must coalesce. The
+        # callback suspends on a real await so all five tasks genuinely
+        # overlap — a plain add_response resolves without yielding, which
+        # would serialize the tasks and mask a missing lock.
+        expires = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+
+        async def slow_token(request: object) -> object:
+            import httpx
+
+            await asyncio.sleep(0.01)
+            return httpx.Response(200, json=token_body(expires_at=expires))
+
+        httpx_mock.add_callback(slow_token)
+
+        resolver = make_resolver(make_envelope())
+        tokens = await asyncio.gather(*(resolver.token_for(AUDIENCE) for _ in range(5)))
+
+        assert len(httpx_mock.get_requests()) == 1
+        assert all(token is tokens[0] for token in tokens)
+
+
+class TestErrorTaxonomy:
+    """Every frozen error code maps to its typed exception."""
+
+    @pytest.mark.parametrize(
+        ("status", "code", "expected"),
+        [
+            (403, "window_expired", WindowExpired),
+            (403, "consent_missing", ConsentMissing),
+            (403, "provider_not_connected", ProviderNotConnected),
+            (403, "revoked", Revoked),
+            (403, "audience_not_allowed", AudienceNotAllowed),
+            (403, "cross_org_blocked", CrossOrgBlocked),
+            (403, "delegation_denied", DelegationDenied),
+            (429, "rate_limited", ExchangeRateLimited),
+            (404, "not_found", DelegationUnavailable),
+        ],
+    )
+    async def test_maps_code_to_typed_error(
+        self,
+        httpx_mock: HTTPXMock,
+        status: int,
+        code: str,
+        expected: type[DelegationError],
+    ) -> None:
+        httpx_mock.add_response(status_code=status, json=error_body(code))
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(expected) as excinfo:
+            await resolver.token_for(AUDIENCE)
+
+        assert excinfo.value.code == code
+        assert excinfo.value.status == status
+        assert excinfo.value.request_id == "req-123"
+        assert "nope" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            # Fern's auth plug rejects without the error envelope.
+            (401, DelegationError),
+            (404, DelegationUnavailable),
+            (429, ExchangeRateLimited),
+        ],
+    )
+    async def test_falls_back_by_http_status_without_a_known_code(
+        self,
+        httpx_mock: HTTPXMock,
+        status: int,
+        expected: type[DelegationError],
+    ) -> None:
+        httpx_mock.add_response(status_code=status, text="denied")
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(expected) as excinfo:
+            await resolver.token_for(AUDIENCE)
+
+        assert excinfo.value.status == status
+
+    async def test_unknown_code_stays_a_delegation_error(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        # forbidden (wrong credential type) and validation_error (422) have no
+        # dedicated class; they surface as the typed base with code intact.
+        httpx_mock.add_response(status_code=403, json=error_body("forbidden"))
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(DelegationError) as excinfo:
+            await resolver.token_for(AUDIENCE)
+
+        assert type(excinfo.value) is DelegationError
+        assert excinfo.value.code == "forbidden"
+
+    async def test_errors_are_not_cached(self, httpx_mock: HTTPXMock) -> None:
+        expires = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(status_code=403, json=error_body("consent_missing"))
+        httpx_mock.add_response(json=token_body(expires_at=expires))
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(ConsentMissing):
+            await resolver.token_for(AUDIENCE)
+        token = await resolver.token_for(AUDIENCE)
+
+        assert token.access_token == "provider-token-1"
+        assert len(httpx_mock.get_requests()) == 2
+
+
+class TestFirstRunFunnel:
+    """The funnel pair carries the contract's remediation, ready to render."""
+
+    async def test_consent_missing_carries_the_grant_remediation(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            status_code=403,
+            json=error_body("consent_missing", "No consent for this agent"),
+        )
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(ConsentMissing) as excinfo:
+            await resolver.token_for(AUDIENCE)
+
+        error = excinfo.value
+        assert error.remediation == "Ask the user to grant consent, then retry."
+        # str(e) is what a tool-error path shows the model/human — the
+        # remediation must ride along with the platform's own message.
+        assert "No consent for this agent" in str(error)
+        assert error.remediation in str(error)
+
+    async def test_provider_not_connected_carries_the_connect_remediation(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            status_code=403,
+            json=error_body("provider_not_connected", "No usable connection"),
+        )
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(ProviderNotConnected) as excinfo:
+            await resolver.token_for(AUDIENCE)
+
+        error = excinfo.value
+        assert error.remediation == "Ask the user to connect the provider, then retry."
+        assert "No usable connection" in str(error)
+        assert error.remediation in str(error)
+
+
+class TestNoDelegation:
+    """I3: the resolver never runs without an envelope."""
+
+    async def test_none_envelope_raises_before_any_request(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        resolver = make_resolver(None)
+
+        with pytest.raises(NoDelegation) as excinfo:
+            await resolver.token_for(AUDIENCE)
+
+        assert len(httpx_mock.get_requests()) == 0
+        # The absence-error explains itself instead of letting the exchange 404.
+        assert "delegation" in str(excinfo.value).lower()
+
+    async def test_envelope_without_message_id_raises_before_any_request(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        resolver = make_resolver(make_envelope(message_id=None))
+
+        with pytest.raises(NoDelegation):
+            await resolver.token_for(AUDIENCE)
+
+        assert len(httpx_mock.get_requests()) == 0

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -816,6 +816,111 @@ class TestGetStaleProcessingMessages:
         link.rest.agent_api_messages.list_agent_messages.assert_awaited_once()
 
 
+class TestRestMessagesCarryTheDelegationEnvelope:
+    """INT-992: the REST backlog wrappers build the runtime PlatformMessage,
+    the message handler-facing type — its ``delegation`` field is the typed
+    view of ``metadata["delegation"]``. Parsing is tolerant: a malformed
+    envelope yields ``None``, never an exception (the recovery sweep must not
+    die on a platform bug)."""
+
+    ENVELOPE = {
+        "version": 1,
+        "originator": {
+            "uuid": "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b",
+            "handle": "alice.asker",
+            "display_name": "Alice Asker",
+        },
+        "message_id": "7f3e9a1b-5c2d-4f6e-8a9b-1c3d5e7f9a2b",
+        "minted_at": "2026-08-13T09:30:00Z",
+        "hop": None,
+    }
+
+    @staticmethod
+    def _rest_item(metadata):
+        item = MagicMock()
+        item.id = "msg-1"
+        item.chat_room_id = "room-1"
+        item.content = "delegated ask"
+        item.sender_id = "user-1"
+        item.sender_type = "User"
+        item.sender_name = "Bob Broker"
+        item.message_type = "text"
+        item.metadata = metadata
+        item.inserted_at = None
+        return item
+
+    @pytest.mark.asyncio
+    async def test_get_next_message_parses_the_envelope(self):
+        from band.core.delegation import DelegationEnvelope
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        response = MagicMock()
+        response.data = self._rest_item({"delegation": dict(self.ENVELOPE)})
+        link.rest.agent_api_messages.get_agent_next_message = AsyncMock(
+            return_value=response
+        )
+
+        msg = await link.get_next_message("room-1")
+
+        assert msg is not None
+        assert isinstance(msg.delegation, DelegationEnvelope)
+        assert msg.delegation.originator is not None
+        assert msg.delegation.originator.handle == "alice.asker"
+        # The raw metadata still carries the envelope for the backlog re-wrap;
+        # only LLM-facing formatting strips it.
+        assert msg.metadata["delegation"] == self.ENVELOPE
+
+    @pytest.mark.asyncio
+    async def test_get_next_message_without_envelope_yields_none(self):
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        response = MagicMock()
+        response.data = self._rest_item({})
+        link.rest.agent_api_messages.get_agent_next_message = AsyncMock(
+            return_value=response
+        )
+
+        msg = await link.get_next_message("room-1")
+
+        assert msg is not None
+        assert msg.delegation is None
+
+    @pytest.mark.asyncio
+    async def test_get_next_message_tolerates_a_malformed_envelope(self):
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        response = MagicMock()
+        response.data = self._rest_item({"delegation": "junk-not-an-envelope"})
+        link.rest.agent_api_messages.get_agent_next_message = AsyncMock(
+            return_value=response
+        )
+
+        msg = await link.get_next_message("room-1")
+
+        assert msg is not None
+        assert msg.delegation is None
+
+    @pytest.mark.asyncio
+    async def test_stale_processing_messages_parse_the_envelope(self):
+        from band.core.delegation import DelegationEnvelope
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        response = MagicMock()
+        response.data = [self._rest_item({"delegation": dict(self.ENVELOPE)})]
+        response.metadata = MagicMock(total_pages=1)
+        link.rest.agent_api_messages.list_agent_messages = AsyncMock(
+            return_value=response
+        )
+
+        messages = await link.get_stale_processing_messages("room-1")
+
+        assert len(messages) == 1
+        assert isinstance(messages[0].delegation, DelegationEnvelope)
+        assert messages[0].delegation.message_id == self.ENVELOPE["message_id"]
+
+
 class TestReportActivity:
     """Tests for BandLink.report_activity (boolean working-state reporting)."""
 

--- a/tests/preprocessing/test_default.py
+++ b/tests/preprocessing/test_default.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 
 from band.client.streaming import MessageCreatedPayload, MessageMetadata
+from band.core.delegation import DelegationEnvelope
 from band.core.protocols import Preprocessor
 from band.core.types import AgentInput, HistoryProvider
 from band.platform.event import (
@@ -15,6 +16,9 @@ from band.preprocessing.default import DefaultPreprocessor
 from band.runtime.types import SessionConfig
 
 
+_DEFAULT_METADATA = object()  # sentinel: "caller didn't pass metadata"
+
+
 def make_message_payload(
     *,
     id: str = "msg-1",
@@ -23,13 +27,16 @@ def make_message_payload(
     sender_type: str = "User",
     room_id: str = "room-1",
     message_type: str = "text",
+    metadata: MessageMetadata | None | object = _DEFAULT_METADATA,
 ) -> MessageCreatedPayload:
     """Create test MessageCreatedPayload."""
+    if metadata is _DEFAULT_METADATA:
+        metadata = MessageMetadata(mentions=[], status="sent")
     return MessageCreatedPayload(
         id=id,
         content=content,
         message_type=message_type,
-        metadata=MessageMetadata(mentions=[], status="sent"),
+        metadata=metadata,  # type: ignore[arg-type]
         sender_id=sender_id,
         sender_type=sender_type,
         chat_room_id=room_id,
@@ -45,6 +52,7 @@ def make_message_event(
     content: str = "Hello",
     sender_id: str = "user-1",
     sender_type: str = "User",
+    metadata: MessageMetadata | None | object = _DEFAULT_METADATA,
 ) -> MessageEvent:
     """Create test MessageEvent."""
     return MessageEvent(
@@ -54,6 +62,7 @@ def make_message_event(
             sender_id=sender_id,
             sender_type=sender_type,
             room_id=room_id,
+            metadata=metadata,
         ),
     )
 
@@ -499,6 +508,121 @@ class TestHistoryLoadingErrors:
         # Should still return AgentInput with empty history
         assert result is not None
         assert len(result.history) == 0
+
+
+class TestDelegationLift:
+    """INT-992: the preprocessor is the single lift point for the platform's
+    identity envelope — parsed once off the inbound metadata and set on
+    ``ctx.delegation`` for handler/tool code. The LLM never sees it (the
+    formatter strips the key from history; format_for_llm renders name +
+    content only)."""
+
+    ENVELOPE = {
+        "version": 1,
+        "originator": {
+            "uuid": "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b",
+            "handle": "alice.asker",
+            "display_name": "Alice Asker",
+        },
+        "message_id": "7f3e9a1b-5c2d-4f6e-8a9b-1c3d5e7f9a2b",
+        "minted_at": "2026-08-13T09:30:00Z",
+        "hop": None,
+    }
+
+    async def _process(self, ctx, event):
+        preprocessor = DefaultPreprocessor()
+        with patch("band.preprocessing.default.AgentTools") as mock_tools:
+            mock_tools.from_context.return_value = MagicMock()
+            with patch(
+                "band.preprocessing.default.check_and_format_participants"
+            ) as mock_participants:
+                mock_participants.return_value = None
+                return await preprocessor.process(ctx, event, agent_id="agent-1")
+
+    async def test_lifts_the_envelope_onto_ctx(self):
+        ctx = make_mock_ctx()
+        metadata = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": dict(self.ENVELOPE)}
+        )
+        event = make_message_event(metadata=metadata)
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        assert isinstance(ctx.delegation, DelegationEnvelope)
+        assert ctx.delegation.originator is not None
+        assert ctx.delegation.originator.handle == "alice.asker"
+        assert ctx.delegation.message_id == self.ENVELOPE["message_id"]
+
+    async def test_clears_a_stale_envelope_when_the_next_message_is_not_delegated(
+        self,
+    ):
+        """ctx.delegation is per-message state: an undelegated message must
+        overwrite the previous turn's envelope with None."""
+        ctx = make_mock_ctx()
+        ctx.delegation = DelegationEnvelope.model_validate(self.ENVELOPE)  # stale
+        event = make_message_event()  # default metadata, no envelope
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        assert ctx.delegation is None
+
+    async def test_none_metadata_lifts_none(self):
+        ctx = make_mock_ctx()
+        ctx.delegation = "stale-sentinel"
+        event = make_message_event(metadata=None)
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        assert ctx.delegation is None
+
+    async def test_malformed_envelope_lifts_none_and_does_not_raise(self):
+        """I3 end to end: a malformed platform envelope arriving over the wire
+        must neither raise nor surface as anything but None."""
+        ctx = make_mock_ctx()
+        payload = MessageCreatedPayload.model_validate(
+            {
+                "id": "msg-1",
+                "content": "Hello",
+                "message_type": "text",
+                "metadata": {
+                    "mentions": [],
+                    "status": "sent",
+                    "delegation": "junk-not-an-envelope",
+                },
+                "sender_id": "user-1",
+                "sender_type": "User",
+                "chat_room_id": "room-1",
+                "inserted_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z",
+            }
+        )
+        event = MessageEvent(room_id="room-1", payload=payload)
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        assert ctx.delegation is None
+
+    async def test_the_envelope_does_not_leak_into_msg_content(self):
+        """The AgentInput message the adapters format for the model carries no
+        envelope content."""
+        ctx = make_mock_ctx()
+        metadata = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": dict(self.ENVELOPE)}
+        )
+        event = make_message_event(content="delegated ask", metadata=metadata)
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        rendered = result.msg.format_for_llm()
+        assert "alice.asker" not in rendered
+        assert "Alice Asker" not in rendered
+        assert "delegation" not in rendered
+        assert rendered.endswith("delegated ask")
 
 
 class TestBootstrapHistoryTruncation:

--- a/tests/runtime/test_execution.py
+++ b/tests/runtime/test_execution.py
@@ -103,6 +103,13 @@ class TestExecutionContextConstruction:
 
         assert ctx.is_llm_initialized is False
 
+    def test_init_no_delegation(self, mock_link, mock_handler):
+        """The identity envelope (INT-992) starts absent; the preprocessor
+        sets it per message."""
+        ctx = ExecutionContext("room-123", mock_link, mock_handler)
+
+        assert ctx.delegation is None
+
 
 class TestExecutionContextProtocol:
     """Test that ExecutionContext implements Execution protocol."""

--- a/tests/runtime/test_execution.py
+++ b/tests/runtime/test_execution.py
@@ -111,6 +111,62 @@ class TestExecutionContextConstruction:
         assert ctx.delegation is None
 
 
+class TestCredentials:
+    """ctx.credentials — the per-turn delegated-credential resolver (INT-993)."""
+
+    def test_returns_a_resolver_bound_to_the_current_envelope(
+        self, mock_link, mock_handler
+    ):
+        from band.core.delegation import DelegationEnvelope
+        from band.platform.delegation_exchange import CredentialResolver
+
+        ctx = ExecutionContext("room-123", mock_link, mock_handler)
+        envelope = DelegationEnvelope(message_id="msg-1")
+        ctx.delegation = envelope
+
+        resolver = ctx.credentials
+
+        assert isinstance(resolver, CredentialResolver)
+        assert resolver.envelope is envelope
+
+    def test_is_stable_within_one_turn(self, mock_link, mock_handler):
+        """A tool fan-out must share one resolver, or its per-audience cache
+        and single-flight lock would be useless."""
+        from band.core.delegation import DelegationEnvelope
+
+        ctx = ExecutionContext("room-123", mock_link, mock_handler)
+        ctx.delegation = DelegationEnvelope(message_id="msg-1")
+
+        assert ctx.credentials is ctx.credentials
+
+    def test_rebuilds_when_the_envelope_changes(self, mock_link, mock_handler):
+        """A new message's envelope must never see the previous message's
+        token cache — the exchange is scoped to (message, audience)."""
+        from band.core.delegation import DelegationEnvelope
+
+        ctx = ExecutionContext("room-123", mock_link, mock_handler)
+        ctx.delegation = DelegationEnvelope(message_id="msg-1")
+        first = ctx.credentials
+
+        ctx.delegation = DelegationEnvelope(message_id="msg-2")
+        second = ctx.credentials
+
+        assert second is not first
+        assert second.envelope is ctx.delegation
+
+    async def test_without_envelope_token_for_raises_no_delegation(
+        self, mock_link, mock_handler
+    ):
+        """I3: owner-invoked messages have no envelope; the resolver's
+        absence-error explains that instead of an AttributeError or a 404."""
+        from band.platform.delegation_exchange import NoDelegation
+
+        ctx = ExecutionContext("room-123", mock_link, mock_handler)
+
+        with pytest.raises(NoDelegation):
+            await ctx.credentials.token_for("some-connector-id")
+
+
 class TestExecutionContextProtocol:
     """Test that ExecutionContext implements Execution protocol."""
 

--- a/tests/runtime/test_formatters.py
+++ b/tests/runtime/test_formatters.py
@@ -84,7 +84,12 @@ class TestFormatMessageForLlm:
         assert result["message_type"] == "text"
 
     def test_preserves_metadata(self):
-        """Should preserve metadata for adapters that need it (e.g., A2A)."""
+        """Should preserve metadata for adapters that need it (e.g., A2A).
+
+        The single exception is the platform's identity envelope
+        (``metadata["delegation"]``, INT-992): it is for handler/tool code,
+        never the model, so it is the ONLY key stripped at this seam.
+        """
         msg = {
             "sender_type": "Agent",
             "content": "A2A task completed",
@@ -93,6 +98,7 @@ class TestFormatMessageForLlm:
                 "a2a_context_id": "ctx-123",
                 "a2a_task_id": "task-456",
                 "a2a_task_state": "completed",
+                "delegation": _DELEGATION_ENVELOPE,
             },
         }
         result = format_message_for_llm(msg)
@@ -107,6 +113,114 @@ class TestFormatMessageForLlm:
         msg = {"sender_type": "Agent", "content": "Hello"}
         result = format_message_for_llm(msg)
         assert result["metadata"] == {}
+
+
+# The platform's frozen minted shape for the identity envelope (INT-992).
+_DELEGATION_ENVELOPE = {
+    "version": 1,
+    "originator": {
+        "uuid": "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b",
+        "handle": "alice.asker",
+        "display_name": "Alice Asker",
+    },
+    "message_id": "7f3e9a1b-5c2d-4f6e-8a9b-1c3d5e7f9a2b",
+    "minted_at": "2026-08-13T09:30:00Z",
+    "hop": None,
+}
+
+
+class TestDelegationNeverReachesTheLlm:
+    """I1 (INT-992): the identity envelope must never appear in anything
+    formatted for the model. format_message_for_llm is the single choke point
+    every history path goes through (bootstrap hydration and oneshot alike),
+    so the strip lives here and ONLY here — adapter-facing surfaces keep full
+    metadata."""
+
+    def test_strips_only_the_delegation_key(self):
+        msg = {
+            "sender_type": "User",
+            "content": "please check the forecast",
+            "sender_name": "Alice",
+            "metadata": {
+                "delegation": dict(_DELEGATION_ENVELOPE),
+                "a2a_context_id": "ctx-123",
+                "status": "sent",
+            },
+        }
+
+        result = format_message_for_llm(msg)
+
+        assert "delegation" not in result["metadata"]
+        # The adapter contract survives: every other key is untouched.
+        assert result["metadata"]["a2a_context_id"] == "ctx-123"
+        assert result["metadata"]["status"] == "sent"
+
+    def test_no_envelope_content_in_the_formatted_message(self):
+        msg = {
+            "sender_type": "User",
+            "content": "please check the forecast",
+            "sender_name": "Bob Broker",
+            "metadata": {"delegation": dict(_DELEGATION_ENVELOPE)},
+        }
+
+        result = format_message_for_llm(msg)
+
+        rendered = str(result)
+        assert "alice.asker" not in rendered
+        assert "Alice Asker" not in rendered
+        assert "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b" not in rendered
+        assert "delegation" not in rendered
+
+    def test_does_not_mutate_the_source_metadata(self):
+        """The source dict belongs to the hydrated context cache, which
+        adapter-facing paths keep reading — strip on a copy."""
+        metadata = {
+            "delegation": dict(_DELEGATION_ENVELOPE),
+            "a2a_context_id": "ctx-123",
+        }
+        msg = {"sender_type": "User", "content": "hi", "metadata": metadata}
+
+        format_message_for_llm(msg)
+
+        assert metadata["delegation"] == _DELEGATION_ENVELOPE
+        assert metadata["a2a_context_id"] == "ctx-123"
+
+    def test_metadata_without_envelope_passes_through_unchanged(self):
+        metadata = {"a2a_context_id": "ctx-123", "status": "sent"}
+        msg = {"sender_type": "User", "content": "hi", "metadata": metadata}
+
+        result = format_message_for_llm(msg)
+
+        assert result["metadata"] == {"a2a_context_id": "ctx-123", "status": "sent"}
+
+    def test_history_hydration_never_carries_the_envelope(self):
+        """End to end through format_history_for_llm: a delegated message in
+        hydrated history reaches the model without any envelope content."""
+        messages = [
+            {
+                "id": "m1",
+                "sender_type": "User",
+                "content": "earlier plain message",
+                "metadata": {"status": "sent"},
+            },
+            {
+                "id": "m2",
+                "sender_type": "User",
+                "content": "delegated ask",
+                "metadata": {
+                    "delegation": dict(_DELEGATION_ENVELOPE),
+                    "a2a_context_id": "ctx-123",
+                },
+            },
+        ]
+
+        result = format_history_for_llm(messages)
+
+        rendered = str(result)
+        assert "delegation" not in rendered
+        assert "alice.asker" not in rendered
+        assert result[1]["metadata"]["a2a_context_id"] == "ctx-123"
+        assert result[0]["metadata"] == {"status": "sent"}
 
 
 class TestFormatHistoryForLlm:

--- a/tests/test_lazy_exports.py
+++ b/tests/test_lazy_exports.py
@@ -18,7 +18,7 @@ import pytest
 
 from tests.paths import SRC_ROOT
 
-_LAZY_PACKAGES = ("adapters", "converters", "testing")
+_LAZY_PACKAGES = ("adapters", "converters", "platform", "testing")
 
 
 def _package_source(package: str) -> ast.Module:
@@ -97,3 +97,18 @@ def test_unknown_attribute_raises_attribute_error() -> None:
 
     with pytest.raises(AttributeError, match="NoSuchAdapter"):
         band.adapters.NoSuchAdapter
+
+
+def test_platform_exports_the_delegation_exchange_surface() -> None:
+    """The INT-993 public names resolve through band.platform's lazy surface."""
+    from band.platform import (
+        ConsentMissing,
+        CredentialResolver,
+        DelegationError,
+        NoDelegation,
+    )
+    from band.platform import delegation_exchange
+
+    assert CredentialResolver is delegation_exchange.CredentialResolver
+    assert issubclass(ConsentMissing, DelegationError)
+    assert issubclass(NoDelegation, DelegationError)


### PR DESCRIPTION
M2 SDK 1/3. **Stacked on #538 (INT-992)** — until #538 merges, this diff shows both changes; the INT-993 increment is the last 3 commits.

Adds the credential-exchange client for M2 ("your tokens, their agent"):

- `band.platform.CredentialResolver` — `await resolver.token_for(audience)` calls `POST /api/v1/agent/delegation/token` (hand-rolled httpx; `band_rest` 0.0.26 has no delegation client) with `X-API-Key` from the link, returning a frozen `DelegatedToken` (`access_token`, `token_type`, `expires_at: datetime | None`, `obo`).
- **Typed error taxonomy** mirroring the platform's frozen codes 1:1 — the first-run funnel pair `ConsentMissing` / `ProviderNotConnected` carries the platform's remediation strings; `WindowExpired`/`Revoked`/`AudienceNotAllowed`/`CrossOrgBlocked`/`DelegationDenied` are terminal; `NoDelegation` raised client-side when the turn has no envelope.
- **Cache discipline per the token-endpoint contract**: memory only (response is `cache-control: no-store`), expiry-aware with 30s skew, **no reuse when `expires_at` is null** (null = unknown, never fabricate a TTL), single-flight per audience so tool fan-out can't stampede the per-message exchange cap (default 20).
- `ctx.credentials` — per-turn resolver on `ExecutionContext`, rebuilt when the envelope identity changes; reads `ctx.delegation` from INT-992.

Evidence: TDD throughout, mutation recorded per commit (e.g. disabling the expiry check or the lock fails the matching test); suite 4620 passed with the pre-existing desktop_app reds byte-identical to base; ruff + pyrefly clean. Testing note: pytest-httpx resolves without yielding, so the single-flight test uses a suspending async callback to make concurrency real.

Linear: INT-993

🤖 Generated with [Claude Code](https://claude.com/claude-code)