### PR TITLE
docs(examples): two-user delegation example + first-run funnel [INT-995]

### DIFF
--- a/examples/delegation/01_crm_specialist.py
+++ b/examples/delegation/01_crm_specialist.py
@@ -1,0 +1,187 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[anthropic]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""CRM specialist — an agent that acts with the ASKER's credentials (M2).
+
+Bob owns and runs this agent. When ALICE @mentions it, the platform mints a
+delegation envelope on the message (who is asking — INT-992); the agent's
+custom tool exchanges that envelope for a short-lived CRM token that acts as
+Alice — her consent, her provider connection — via
+``ctx.credentials.token_for(<connector-id>)`` (INT-993/994).
+
+The interesting part is the FIRST-RUN FUNNEL: on a fresh pairing the exchange
+fails in a specific, typed order, and this tool renders each failure as
+guidance the humans can act on:
+
+    1. ``ConsentMissing``       -> Alice must grant this agent consent
+    2. ``ProviderNotConnected`` -> Alice must connect the provider
+    3. success                  -> a token acting as Alice
+
+READ THE README FIRST: on a stock deployment the exchange endpoint is inert
+(every call returns ``delegation_denied``) until the target connector's
+``delegation_credential_mode`` is seeded to ``originator``/``any`` — that
+field currently has no API/UI surface.
+
+Run with (from repo root, as BOB's agent):
+    CRM_CONNECTOR_ID=<mcp-connector-uuid> uv run examples/delegation/01_crm_specialist.py
+
+Then, as ALICE (a different user, in the web app), @mention the agent and ask
+it to look up a customer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from dotenv import load_dotenv
+from pydantic import BaseModel, Field
+
+from setup_logging import setup_logging
+from band import Agent, ExecutionContext
+from band.adapters import AnthropicAdapter
+from band.platform import (
+    ConsentMissing,
+    DelegationError,
+    NoDelegation,
+    ProviderNotConnected,
+)
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+# The audience for the exchange: the MCP CONNECTOR ID (a UUID) that is on the
+# asker's consent allowlist. Not a name, not a URL, not a scope.
+CRM_CONNECTOR_ID = os.getenv("CRM_CONNECTOR_ID", "")
+
+
+class LookupCustomerInput(BaseModel):
+    """Look up a customer's record in the CRM, acting as the person who asked."""
+
+    customer: str = Field(description="Customer name or account id to look up")
+
+
+async def lookup_customer(
+    args: LookupCustomerInput, ctx: ExecutionContext | None
+) -> str:
+    """Exchange the asker's delegation for a CRM token, or explain what's missing.
+
+    Declaring the SECOND parameter is the INT-994 opt-in: the adapter threads
+    the per-message ``ExecutionContext`` into it (``None`` if unavailable).
+    ``ctx.delegation`` is the typed identity envelope; ``ctx.credentials`` is
+    the per-message resolver — it caches per audience, respects the
+    provider's ``expires_at`` (30 s skew, no reuse when null), and
+    single-flights concurrent calls so a tool fan-out cannot burn the
+    per-message exchange cap (default 20).
+    """
+    if ctx is None:
+        return (
+            "Tool context is unavailable in this adapter, so I cannot resolve "
+            "delegated credentials."
+        )
+
+    envelope = ctx.delegation
+    if envelope is None:
+        return (
+            "This message is owner-invoked — it carries no delegation "
+            "envelope, so there is nobody to act on behalf of. Have a "
+            "DIFFERENT user @mention me to see the delegated flow."
+        )
+
+    originator = envelope.originator
+    asker = (originator.handle or originator.uuid) if originator else "the requester"
+
+    if not CRM_CONNECTOR_ID:
+        return (
+            "CRM_CONNECTOR_ID is not set. Export the MCP connector id (a UUID "
+            "from the asker's consent allowlist) and restart me."
+        )
+
+    try:
+        token = await ctx.credentials.token_for(CRM_CONNECTOR_ID)
+    except ConsentMissing as error:
+        # First-run funnel, step 1 of 2. str(error) already carries the
+        # contract's remediation ("Ask the user to grant consent, then retry.")
+        return (
+            f"I can't act on behalf of @{asker} yet: {error} "
+            f"(@{asker}: grant it under Settings -> Agent consents, or via "
+            "the /api/v1/me consent API, then ask me again.)"
+        )
+    except ProviderNotConnected as error:
+        # First-run funnel, step 2 of 2: consent exists, connection doesn't.
+        return (
+            f"@{asker} has granted consent, but I still can't reach the CRM "
+            f"as them: {error} "
+            f"(@{asker}: connect the provider under Settings -> Connected "
+            "apps, then ask me again.)"
+        )
+    except NoDelegation as error:
+        # Client-side absence error (I3) — reachable when the envelope lost
+        # its message_id; the exchange was never attempted.
+        return str(error)
+    except DelegationError as error:
+        # Terminal for this message: window_expired, revoked,
+        # audience_not_allowed, cross_org_blocked, delegation_denied,
+        # rate_limited, the 404 family — nothing the humans can fix mid-turn.
+        code = error.code or "delegation_error"
+        return f"Delegated credentials are unavailable ({code}): {error}"
+
+    acting_as = (
+        token.obo.originator_handle
+        if token.obo and token.obo.originator_handle
+        else asker
+    )
+    expires = (
+        token.expires_at.isoformat() if token.expires_at else "unknown (never reused)"
+    )
+    # NEVER put token.access_token in a message — it is a live provider
+    # credential. Use it in an API call and let it expire.
+    return (
+        f"(demo) I hold a short-lived CRM credential acting as @{acting_as} "
+        f"(type={token.token_type}, expires={expires}). A real tool would now "
+        f"call the CRM API with it to look up {args.customer!r}; this demo "
+        "stops at the exchange so the credential never leaves the process."
+    )
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    adapter = AnthropicAdapter(
+        model="claude-sonnet-4-5-20250929",
+        prompt=(
+            "You are a CRM specialist agent owned by Bob. When someone asks "
+            "about a customer, use the lookupcustomer tool. The tool acts "
+            "with the ASKER's credentials; if it reports that consent or a "
+            "provider connection is missing, relay its guidance verbatim — "
+            "it tells the asker exactly what to do next."
+        ),
+        additional_tools=[(LookupCustomerInput, lookup_customer)],
+    )
+
+    agent = Agent.from_config(
+        "crm_specialist",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("CRM specialist online — have another user @mention it.")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/delegation/README.md
+++ b/examples/delegation/README.md
@@ -1,0 +1,141 @@
+# Delegated Credentials — the Two-User Example (M2)
+
+An agent that acts with the **asker's** credentials, not its owner's.
+
+Bob owns and runs `01_crm_specialist.py`. When **Alice** (a different user)
+@mentions it, the platform mints a server-side identity envelope on her
+message — *who is asking* — and the agent's custom tool exchanges that
+envelope for a short-lived provider token that acts **as Alice**: her
+consent, her provider connection. Bob's credentials are never used for
+Alice's request, and Alice's token never outlives the message that earned it.
+
+---
+
+## ⚠️ Precondition: the exchange is INERT on a stock deployment
+
+> **Read this before filing a bug.** The token exchange has a server-side
+> opt-in that ships **dark** in M2:
+>
+> - Every MCP connector has a `delegation_credential_mode` field that
+>   defaults to **`owner`** — "this connector only ever uses the agent
+>   owner's credentials."
+> - The exchange only issues delegated tokens for connectors whose mode is
+>   **`originator`** or **`any`**.
+> - That field currently has **no API or UI surface** — it can only be set
+>   by seeding the database directly (a platform-side operation).
+>
+> Until your deployment has a connector seeded to `originator`/`any` (and
+> the org's delegation switch on), **every** exchange call answers
+> `403 delegation_denied` — deliberately undifferentiated, and exactly what
+> this example will show you. That is the endpoint working as specified,
+> not a bug in your setup.
+
+## Prerequisites
+
+1. **Two platform users** — Bob (owns the agent) and Alice (will @mention it),
+   in the **same org** (cross-org delegation is hard-blocked in M2).
+2. **A remote agent** created by Bob, with its `agent_id`/`api_key` in
+   `agent_config.yaml` under `crm_specialist` (see
+   `agent_config.yaml.example`).
+3. **An MCP connector** on the deployment whose id (a UUID) you export as
+   `CRM_CONNECTOR_ID` — seeded per the precondition box above.
+4. **Anthropic API key** — `ANTHROPIC_API_KEY` in the environment (the agent's
+   reasoning model; unrelated to the delegated token).
+
+## The two-user flow
+
+```text
+Terminal (Bob)                        Web app (Alice)
+--------------                        ---------------
+uv run examples/delegation/\
+  01_crm_specialist.py
+                                      1. Add the agent to a room
+                                      2. "@crm-specialist look up ACME-042"
+   <- message arrives with metadata.delegation
+      (originator=alice, message_id, minted_at)
+   tool calls ctx.credentials.token_for(CRM_CONNECTOR_ID)
+   -> first run: ConsentMissing -> agent tells Alice to grant consent
+                                      3. Alice grants the agent consent
+                                         (Settings -> Agent consents, or the
+                                         /api/v1/me consent API)
+                                      4. Alice asks again
+   -> ProviderNotConnected -> agent tells Alice to connect the provider
+                                      5. Alice connects the provider
+                                         (Settings -> Connected apps)
+                                      6. Alice asks again
+   -> 200: a short-lived token acting AS ALICE — the tool answers
+```
+
+Run it:
+
+```bash
+export CRM_CONNECTOR_ID=<mcp-connector-uuid>   # the consent-allowlist id
+uv run examples/delegation/01_crm_specialist.py
+```
+
+An **owner-invoked** message (Bob @mentions his own agent) carries **no**
+envelope — `ctx.delegation` is `None` and `ctx.credentials.token_for(...)`
+raises the client-side `NoDelegation` error without touching the network.
+The example renders that too.
+
+## What the tool demonstrates
+
+```python notest
+async def lookup_customer(args: LookupCustomerInput, ctx: ExecutionContext | None) -> str:
+    token = await ctx.credentials.token_for(CRM_CONNECTOR_ID)
+    # token.access_token acts as the ASKER; use it, never echo it.
+```
+
+- **Opting in to context (INT-994)** — a custom tool handler that declares a
+  *second* parameter receives the per-message `ExecutionContext`; one-arg
+  handlers are untouched.
+- **`ctx.delegation` (INT-992)** — the typed envelope: `originator`
+  (uuid/handle/display_name), `message_id`, `minted_at`.
+- **`ctx.credentials` (INT-993)** — the per-message resolver. It caches by
+  audience in memory only, honors the provider's `expires_at` with a 30 s
+  safety skew, **never** reuses a token whose `expires_at` is `null`
+  (null = unknown, not expired), and single-flights concurrent calls —
+  the platform caps exchanges per message (default 20).
+
+## The error contract (first-run funnel)
+
+`token_for(audience)` raises one **typed** error per platform code
+(`band.platform.DelegationError` subclasses). The first two are the
+**funnel** — they carry remediation text in `str(error)` and mean "fix, then
+ask again". The rest are terminal for the triggering message:
+
+| Error | Wire code | Meaning | Next step |
+|---|---|---|---|
+| `ConsentMissing` | `consent_missing` | The asker has not granted this agent consent | **Funnel:** asker grants consent, then retries |
+| `ProviderNotConnected` | `provider_not_connected` | Consent exists, but the asker has no usable provider connection | **Funnel:** asker connects the provider, then retries |
+| `WindowExpired` | `window_expired` | Exchange attempted after the processing window (anchored on the envelope's `minted_at`, default 600 s) | New request required |
+| `Revoked` | `revoked` | Consent was revoked | Asker must re-grant |
+| `AudienceNotAllowed` | `audience_not_allowed` | Connector not on the consent allowlist (or unknown id) | Fix the audience; do not retry the same value |
+| `CrossOrgBlocked` | `cross_org_blocked` | Asker and owner are in different orgs | Terminal (hard M2 block) |
+| `DelegationDenied` | `delegation_denied` | Deliberately undifferentiated denial — org switch off, connector mode `owner` (see the precondition box), or participants changed | Terminal for this message |
+| `ExchangeRateLimited` | `rate_limited` | Per-message exchange cap exhausted | Back off |
+| `DelegationUnavailable` | `not_found` | Message unknown / not delivered to this agent / agent not @mentioned — indistinguishable by design | Terminal for this message |
+| `NoDelegation` | — (client-side) | The current message carries no envelope (owner-invoked) | Only delegated messages can exchange |
+
+There is **no pending-approval state** — consent is active or revoked, nothing
+in between.
+
+## Rules worth knowing
+
+- **Clock starts at `minted_at`**, not at receipt: the exchange window
+  (default 600 s, org-tunable) is anchored on the server-minted envelope
+  timestamp. A message replayed after a crash may already be outside it.
+- **Audience = MCP connector id.** The same UUID that appears on the asker's
+  consent allowlist. Not a name, not a URL, not a scope.
+- **`expires_at` is the provider's**, not platform-bounded. `null` means
+  *unknown* — the resolver fetches fresh every time rather than invent a TTL.
+- **No storage.** The platform answers `cache-control: no-store`; the SDK
+  keeps tokens in process memory only, scoped to the triggering message.
+- **Never echo `access_token`** into a room, a log, or an LLM prompt. Use it
+  in the provider call and let it expire.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `01_crm_specialist.py` | Bob's agent: a `lookupcustomer` custom tool that exchanges the asker's delegation for a CRM token and renders the full funnel. |

--- a/examples/delegation/setup_logging.py
+++ b/examples/delegation/setup_logging.py
@@ -1,0 +1,11 @@
+"""Shared logging configuration for examples."""
+
+from __future__ import annotations
+
+from band import LogLevel, LogSettings
+
+
+def setup_logging(level: LogLevel | None = None) -> None:
+    """Configure logging to show band logs, hiding other noisy dependencies."""
+    settings = LogSettings.create(log_level=level)
+    settings.configure()

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -28,6 +28,7 @@ from band.core.types import (
 from band.converters.anthropic import AnthropicHistoryConverter, AnthropicMessages
 from band.runtime.custom_tools import (
     CustomToolDef,
+    ctx_from_tools,
     custom_tools_to_schemas,
     execute_custom_tool,
     find_custom_tool,
@@ -470,7 +471,9 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
             try:
                 custom_tool = find_custom_tool(self._custom_tools, tool_name)
                 if custom_tool:
-                    result = await execute_custom_tool(custom_tool, tool_input)
+                    result = await execute_custom_tool(
+                        custom_tool, tool_input, ctx=ctx_from_tools(tools)
+                    )
                 else:
                     result = await tools.execute_tool_call(tool_name, tool_input)
                 result_str = (

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -46,6 +46,7 @@ from band.integrations.codex.types import (
 )
 from band.runtime.custom_tools import (
     CustomToolDef,
+    ctx_from_tools,
     custom_tool_to_openai_schema,
     execute_custom_tool,
     find_custom_tool,
@@ -1355,7 +1356,9 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             try:
                 custom_tool = find_custom_tool(self._custom_tools, tool_name)
                 if custom_tool:
-                    result = await execute_custom_tool(custom_tool, arguments)
+                    result = await execute_custom_tool(
+                        custom_tool, arguments, ctx=ctx_from_tools(tools)
+                    )
                     success = True
                 else:
                     # Structured: a base tool (e.g. band_send_message) can fail without

--- a/src/band/adapters/copilot_sdk.py
+++ b/src/band/adapters/copilot_sdk.py
@@ -36,6 +36,7 @@ from band.integrations.copilot_sdk.room_ask_user import (
     room_inactive_answer,
 )
 from band.runtime.custom_tools import (
+    ctx_from_tools,
     custom_tools_to_schemas,
     execute_custom_tool,
     find_custom_tool,
@@ -701,7 +702,9 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
         try:
             custom_tool = find_custom_tool(self._custom_tools, tool_name)
             if custom_tool:
-                result = await execute_custom_tool(custom_tool, arguments)
+                result = await execute_custom_tool(
+                    custom_tool, arguments, ctx=ctx_from_tools(room_tools)
+                )
             else:
                 # Structured variant: a base tool (e.g. band_send_message) can fail
                 # without raising (bad args, API error) — that surfaces as ok=False,

--- a/src/band/adapters/crewai_flow.py
+++ b/src/band/adapters/crewai_flow.py
@@ -55,6 +55,7 @@ from band.core.types import (
 )
 from band.runtime.custom_tools import (
     CustomToolDef,
+    ctx_from_tools,
     custom_tools_to_schemas,
     execute_custom_tool,
     get_custom_tool_name,
@@ -575,7 +576,9 @@ class CrewAIFlowCustomTools:
         input_data = dict(arguments or kwargs)
         await self._report_call(name, input_data)
         try:
-            result = await execute_custom_tool(tool, input_data)
+            result = await execute_custom_tool(
+                tool, input_data, ctx=ctx_from_tools(self._tools)
+            )
         except Exception as exc:
             await self._report_result(name, str(exc), is_error=True)
             raise

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -37,6 +37,7 @@ from band.core.types import (
 from band.converters.gemini import GeminiHistoryConverter, GeminiMessages
 from band.runtime.custom_tools import (
     CustomToolDef,
+    ctx_from_tools,
     execute_custom_tool,
     find_custom_tool,
     format_validation_error,
@@ -537,7 +538,9 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
             try:
                 custom_tool = find_custom_tool(self._custom_tools, tool_name)
                 if custom_tool:
-                    result = await execute_custom_tool(custom_tool, tool_input)
+                    result = await execute_custom_tool(
+                        custom_tool, tool_input, ctx=ctx_from_tools(tools)
+                    )
                 else:
                     result = await tools.execute_tool_call(tool_name, tool_input)
                 result_str = (

--- a/src/band/adapters/google_adk.py
+++ b/src/band/adapters/google_adk.py
@@ -33,6 +33,7 @@ from band.core.types import (
 from band.converters.google_adk import GoogleADKHistoryConverter, GoogleADKMessages
 from band.runtime.custom_tools import (
     CustomToolDef,
+    ctx_from_tools,
     custom_tools_to_schemas,
     execute_custom_tool,
     find_custom_tool,
@@ -210,7 +211,9 @@ def _get_tool_bridge_class() -> type:
             try:
                 custom_tool = find_custom_tool(self._custom_tools, self.name)
                 if custom_tool:
-                    result = await execute_custom_tool(custom_tool, args)
+                    result = await execute_custom_tool(
+                        custom_tool, args, ctx=ctx_from_tools(self._tools)
+                    )
                 else:
                     result = await self._tools.execute_tool_call(self.name, args)
 

--- a/src/band/adapters/langgraph.py
+++ b/src/band/adapters/langgraph.py
@@ -133,26 +133,24 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
             features=features,
         )
 
-        # Accept the SDK's portable custom-tool form: convert any CustomToolDef
-        # (InputModel, handler) tuples in additional_tools to LangChain tools — the
-        # same shape every other adapter takes — while passing ready-made LangChain
-        # tools through untouched. Done once here so both the simple and advanced
-        # patterns get a uniform tool list, and a tool written once works across
-        # adapters (LangChain would otherwise reject a bare tuple).
+        # Accept the SDK's portable custom-tool form — (InputModel, handler)
+        # tuples — alongside ready-made LangChain tools. Tuples are NOT
+        # converted here: conversion happens per turn (see on_message) so the
+        # tool closure can bind that turn's ExecutionContext (INT-994) — an
+        # init-time StructuredTool could never see it. Native tools pass
+        # through untouched, exactly as before.
+        custom_tool_defs: list[Any] = []
         if additional_tools:
-            from band.integrations.langgraph.langchain_tools import (
-                custom_tool_defs_to_langchain,
-            )
-
-            normalized: list[Any] = []
+            passthrough: list[Any] = []
             for item in additional_tools:
                 if isinstance(
                     item, tuple
                 ):  # a band CustomToolDef (InputModel, handler)
-                    normalized.extend(custom_tool_defs_to_langchain([item]))
+                    custom_tool_defs.append(item)
                 else:  # already a LangChain tool / callable
-                    normalized.append(item)
-            additional_tools = normalized
+                    passthrough.append(item)
+            additional_tools = passthrough
+        self._custom_tool_defs = custom_tool_defs
 
         uses_simple_pattern = (
             llm is not None and graph_factory is None and graph is None
@@ -275,17 +273,23 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
         """Handle message with LangGraph."""
         from band.integrations.langgraph.langchain_tools import (
             agent_tools_to_langchain,
+            custom_tool_defs_to_langchain,
         )
+        from band.runtime.custom_tools import ctx_from_tools
 
         logger.info("[HANDLE] Message %s in room %s", msg.id, room_id)
 
-        # Get LangChain tools
+        # Get LangChain tools. CustomToolDef tuples convert HERE, per turn,
+        # so their closures carry this turn's ExecutionContext (INT-994).
         langchain_tools = (
             agent_tools_to_langchain(
                 tools,
                 features=self.features,
             )
             + self.additional_tools
+            + custom_tool_defs_to_langchain(
+                self._custom_tool_defs, ctx=ctx_from_tools(tools)
+            )
         )
 
         # Build or get graph

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -54,6 +54,8 @@ from band.converters.pydantic_ai import (
 )
 from band.runtime.custom_tools import (
     CustomToolDef,
+    ctx_from_tools,
+    custom_tool_accepts_ctx,
     get_custom_tool_name,
     invoke_validated_custom_tool,
     is_marked_terminal,
@@ -162,15 +164,37 @@ def _custom_tool_def_to_callable(tool_def: CustomToolDef) -> Callable[..., Any]:
     models using field aliases. The wrapper carries the stable tool name (derived
     from the model) and the ``band_terminal`` marker, so the tool name and the
     terminal-tool contract match the tuple adapters exactly.
+
+    A handler that opted in to the INT-994 ctx parameter — ``handler(args,
+    ctx)`` — instead gets a ``RunContext``-taking wrapper (routed to
+    ``agent.tool`` by ``_takes_run_context``): pydantic-ai owns the tool call
+    chain, and its ``deps`` carry the turn's AgentTools, so the wrapper reads
+    the ExecutionContext off ``run_ctx.deps`` at call time. One-param handlers
+    keep the exact context-free shape above.
     """
     input_model, handler = tool_def
 
-    async def native(args: Any) -> Any:
-        return await invoke_validated_custom_tool(tool_def, args)
+    if custom_tool_accepts_ctx(handler):
+
+        async def native(run_ctx: RunContext[AgentToolsProtocol], args: Any) -> Any:
+            return await invoke_validated_custom_tool(
+                tool_def, args, ctx=ctx_from_tools(run_ctx.deps)
+            )
+
+        native.__annotations__ = {
+            "run_ctx": RunContext[AgentToolsProtocol],
+            "args": input_model,
+            "return": str,
+        }
+    else:
+
+        async def native(args: Any) -> Any:  # type: ignore[misc]
+            return await invoke_validated_custom_tool(tool_def, args)
+
+        native.__annotations__ = {"args": input_model, "return": str}
 
     native.__name__ = get_custom_tool_name(input_model)
     native.__doc__ = input_model.__doc__ or native.__name__
-    native.__annotations__ = {"args": input_model, "return": str}
     if is_marked_terminal(handler):
         native.band_terminal = True  # type: ignore[attr-defined]
     return native

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -46,6 +46,7 @@ from band.core.types import (
 from band.converters.strands import StrandsHistoryConverter, StrandsMessages
 from band.runtime.custom_tools import (
     CustomToolDef,
+    ctx_from_tools,
     execute_custom_tool,
     get_custom_tool_name,
     is_marked_terminal,
@@ -192,10 +193,18 @@ class StrandsToolBridge(AgentTool):
 
 
 class CustomToolBridge(StrandsToolBridge):
-    """Expose a portable custom tool through Strands' native tool protocol."""
+    """Expose a portable custom tool through Strands' native tool protocol.
 
-    def __init__(self, tool_def: CustomToolDef):
+    ``ctx`` is the turn's ExecutionContext (INT-994). Bridges are built once
+    at adapter init for validation, then REBUILT per turn by
+    ``_custom_tools_for_turn`` so each turn's bridge carries that turn's
+    context — the adapter is shared across rooms, so a mutable slot here
+    would race concurrent turns.
+    """
+
+    def __init__(self, tool_def: CustomToolDef, ctx: Any = None):
         self._tool_def = tool_def
+        self._ctx = ctx
         input_model, _ = tool_def
         name = get_custom_tool_name(input_model)
         super().__init__(name, input_model, input_model.__doc__ or name)
@@ -209,7 +218,7 @@ class CustomToolBridge(StrandsToolBridge):
         del invocation_state, kwargs
         try:
             result = await execute_custom_tool(
-                self._tool_def, dict(tool_use["input"] or {})
+                self._tool_def, dict(tool_use["input"] or {}), ctx=self._ctx
             )
         except Exception as error:
             yield _tool_result(
@@ -398,7 +407,9 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         overflow, keeping toolUse/toolResult pairs intact. The persisted room
         transcript is therefore capped by the framework, not unbounded.
         """
-        framework_tools = self._build_platform_tools(tools) + self._custom_tools
+        framework_tools = self._build_platform_tools(
+            tools
+        ) + self._custom_tools_for_turn(tools)
         return Agent(
             model=self.model,
             messages=messages,
@@ -410,6 +421,25 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             callback_handler=None,
             name=self.agent_name or None,
         )
+
+    def _custom_tools_for_turn(
+        self, tools: AgentToolsProtocol
+    ) -> list[AgentTool | Callable[..., Any]]:
+        """Custom tools for one turn: tuples re-bridged with this turn's ctx.
+
+        The init-built bridges validated names and terminal markers; per-turn
+        rebridging binds the current ExecutionContext (read defensively off
+        the AgentTools) and keeps each turn's tool spec unshared — Strands
+        writes normalization into the spec's nested schema in place. Native
+        tools (plain callables / AgentTool) pass through by identity.
+        """
+        ctx = ctx_from_tools(tools)
+        return [
+            CustomToolBridge(tool._tool_def, ctx=ctx)
+            if isinstance(tool, CustomToolBridge)
+            else tool
+            for tool in self._custom_tools
+        ]
 
     def _build_platform_tools(self, tools: AgentToolsProtocol) -> list[AgentTool]:
         """Adapt the central Band tool registry to Strands for this turn.

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -15,9 +15,16 @@ from phoenix_channels_python_client.client import (
 from phoenix_channels_python_client.client_types import ReconnectPolicy
 from phoenix_channels_python_client.exceptions import PHXConnectionError
 from phoenix_channels_python_client.phx_messages import PHXMessage
-from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from band.client.streaming.errors import classify_initial_upgrade_error
+from band.core.delegation import DelegationEnvelope, parse_delegation_value
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +86,17 @@ class MessageMetadata(BaseModel):
     # ``attempts`` list. This is the same signal the runtime uses to dedup
     # already-handled messages.
     delivery_status: dict[str, Any] | None = None
+    # Cross-owner identity envelope minted by the platform (INT-992). Typed so
+    # handler code gets a real model instead of a raw extra; validated
+    # tolerantly because the REST backlog path re-wraps platform dicts with
+    # ``MessageMetadata(**metadata)`` and a malformed envelope must never fail
+    # the whole metadata parse (it is logged and treated as absent).
+    delegation: DelegationEnvelope | None = None
+
+    @field_validator("delegation", mode="before")
+    @classmethod
+    def _tolerate_malformed_delegation(cls, value: Any) -> DelegationEnvelope | None:
+        return parse_delegation_value(value)
 
 
 class MessageCreatedPayload(BaseModel):

--- a/src/band/core/delegation.py
+++ b/src/band/core/delegation.py
@@ -1,0 +1,102 @@
+"""Typed view of the platform's cross-owner identity envelope (INT-992).
+
+The platform mints ``metadata["delegation"]`` server-side on cross-owner
+messages so handler and tool code can see *who is asking*. The LLM must never
+see it: ``band.runtime.formatters.format_message_for_llm`` strips exactly this
+key at the history seam, and both ``PlatformMessage.format_for_llm``
+implementations render ``[name]: content`` only.
+
+Import-light on purpose (pydantic + logging): consumed by the wire models in
+``band.client.streaming``, the preprocessor, and ``BandLink`` without dragging
+runtime modules into ``band.core``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+class Originator(BaseModel):
+    """Who minted the delegated request. Platform-authored; read-only."""
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    uuid: str | None = None
+    handle: str | None = None
+    display_name: str | None = None
+
+
+class DelegationEnvelope(BaseModel):
+    """The identity envelope the platform mints on ``metadata["delegation"]``.
+
+    Every field is optional on purpose: the SDK must keep parsing envelopes
+    from newer platforms (``extra="allow"`` absorbs added keys; ``version != 1``
+    still parses), and a partially formed envelope is more useful than a
+    dropped one. Frozen because this is a read-only view — handler/tool code
+    consumes it, nothing in the SDK writes through it.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    version: int | None = None
+    originator: Originator | None = None
+    message_id: str | None = None
+    minted_at: str | None = None
+    # Reserved by the platform for delegation chains (M2.5); ``None`` today.
+    hop: Any | None = None
+
+
+def parse_delegation_value(value: Any) -> DelegationEnvelope | None:
+    """Tolerantly coerce a raw ``delegation`` value into an envelope.
+
+    Accepts an already-parsed :class:`DelegationEnvelope`, a dict in the
+    platform's minted shape, or anything else (malformed → ``None``). Never
+    raises: a platform bug must not take down the agent loop.
+    """
+    if value is None:
+        return None
+    if isinstance(value, DelegationEnvelope):
+        return value
+    try:
+        return DelegationEnvelope.model_validate(value)
+    except Exception:
+        logger.debug("Ignoring malformed delegation envelope: %r", value)
+        return None
+
+
+def parse_delegation(metadata: Any) -> DelegationEnvelope | None:
+    """Extract and parse the identity envelope off message ``metadata``.
+
+    ``metadata`` may be a plain dict (REST / Fern models dump to dicts), a
+    pydantic model such as ``MessageMetadata`` (the WebSocket wire type), or
+    ``None`` — the same dict-or-model split that
+    ``ExecutionContext._metadata_to_dict`` normalizes. Returns ``None`` when
+    the envelope is absent or malformed; never raises.
+    """
+    if metadata is None:
+        return None
+    try:
+        if isinstance(metadata, dict):
+            raw = metadata.get("delegation")
+        else:
+            # Covers typed fields and pydantic extra="allow" attributes alike.
+            raw = getattr(metadata, "delegation", None)
+    except Exception:
+        # Defensive: exotic metadata objects (broken __getattr__) must not
+        # take down preprocessing.
+        logger.debug("Could not read delegation off metadata: %r", metadata)
+        return None
+    return parse_delegation_value(raw)
+
+
+__all__ = [
+    "DelegationEnvelope",
+    "Originator",
+    "parse_delegation",
+    "parse_delegation_value",
+]

--- a/src/band/integrations/claude_sdk/tools.py
+++ b/src/band/integrations/claude_sdk/tools.py
@@ -28,6 +28,7 @@ from band.core.exceptions import BandToolError
 from band.core.protocols import AgentToolsProtocol
 from band.runtime.custom_tools import (
     CustomToolDef,
+    ctx_from_tools,
     execute_custom_tool,
     get_custom_tool_name,
 )
@@ -241,6 +242,7 @@ def _build_builtin_sdk_tool(
 def _build_custom_sdk_tool(
     tool_def: CustomToolDef,
     *,
+    get_tools: ToolResolver,
     include_room_id: bool,
 ) -> SdkMcpTool[Any]:
     input_model, _ = tool_def
@@ -255,7 +257,12 @@ def _build_custom_sdk_tool(
     async def handler(args: dict[str, Any]) -> dict[str, Any]:
         try:
             tool_args = {k: v for k, v in args.items() if k != "room_id"}
-            result = await execute_custom_tool(tool_def, tool_args)
+            # Resolve this room's tools only to read their ExecutionContext
+            # (INT-994); a custom tool still runs when no tools resolve.
+            room_tools = get_tools(str(args.get("room_id", "")))
+            result = await execute_custom_tool(
+                tool_def, tool_args, ctx=ctx_from_tools(room_tools)
+            )
             return _make_result(result)
         except Exception as error:
             logger.exception("Custom tool %s failed: %s", tool_name, error)
@@ -289,6 +296,7 @@ def build_band_sdk_tools(
         sdk_tools.append(
             _build_custom_sdk_tool(
                 custom_tool,
+                get_tools=get_tools,
                 include_room_id=include_room_id,
             )
         )

--- a/src/band/integrations/crewai/tools.py
+++ b/src/band/integrations/crewai/tools.py
@@ -63,6 +63,7 @@ from band.core.types import (
 from band.integrations.crewai.runtime import run_async
 from band.runtime.custom_tools import (
     CustomToolDef,
+    ctx_from_tools,
     execute_custom_tool,
     get_custom_tool_name,
     is_marked_terminal,
@@ -1049,7 +1050,11 @@ def _make_custom_tools(
                     async def execute(_tools: AgentToolsProtocol) -> str:
                         try:
                             await reporter.report_call(_tools, _tool_name, kwargs)
-                            result = await execute_custom_tool((model, handler), kwargs)
+                            result = await execute_custom_tool(
+                                (model, handler),
+                                kwargs,
+                                ctx=ctx_from_tools(_tools),
+                            )
                             await reporter.report_result(_tools, _tool_name, result)
                             if isinstance(result, str):
                                 return json.dumps(

--- a/src/band/integrations/langgraph/langchain_tools.py
+++ b/src/band/integrations/langgraph/langchain_tools.py
@@ -138,7 +138,11 @@ def agent_tools_to_langchain(
     return platform_tools
 
 
-def custom_tool_defs_to_langchain(tools: list[CustomToolDef]) -> list[StructuredTool]:
+def custom_tool_defs_to_langchain(
+    tools: list[CustomToolDef],
+    *,
+    ctx: Any = None,
+) -> list[StructuredTool]:
     """Convert band ``CustomToolDef`` tuples to LangChain ``StructuredTool``s.
 
     Lets the LangGraph adapter accept the SDK's portable custom-tool form —
@@ -146,6 +150,11 @@ def custom_tool_defs_to_langchain(tools: list[CustomToolDef]) -> list[Structured
     than only ready-made LangChain tools. Each tuple becomes a StructuredTool whose
     schema is the ``InputModel`` and whose body validates + runs the handler via
     ``execute_custom_tool`` (which handles sync and async handlers alike).
+
+    ``ctx`` is the turn's ExecutionContext (INT-994), bound into the tool
+    closure at conversion time — LangChain's tool call carries only model
+    kwargs, so the adapter converts tuples per turn to thread it. Handlers
+    that declare the second parameter receive it; others are untouched.
     """
     langchain_tools: list[StructuredTool] = []
     for input_model, handler in tools:
@@ -156,10 +165,11 @@ def custom_tool_defs_to_langchain(tools: list[CustomToolDef]) -> list[Structured
             *,
             _tool: CustomToolDef = (input_model, handler),
             _name: str = name,
+            _ctx: Any = ctx,
             **kwargs: Any,
         ) -> Any:
             try:
-                return await execute_custom_tool(_tool, kwargs)
+                return await execute_custom_tool(_tool, kwargs, ctx=_ctx)
             except ValueError as e:
                 # Bad-argument / validation errors feed back to the LLM to retry.
                 return str(e)

--- a/src/band/platform/__init__.py
+++ b/src/band/platform/__init__.py
@@ -4,12 +4,55 @@ Band Platform Layer - Wire-level connection to Band platform.
 Components:
     BandLink: WebSocket connection + event dispatch (REST via .rest)
     PlatformEvent: Single event type for all platform events
+    CredentialResolver: Delegated-credential exchange for cross-owner
+        messages (INT-993), with its typed DelegationError taxonomy
 """
 
-from .event import PlatformEvent
-from .link import BandLink
+from __future__ import annotations
 
-__all__ = [
-    "BandLink",
-    "PlatformEvent",
-]
+from typing import TYPE_CHECKING
+
+from band.exports import lazy_exports
+
+# Type-only imports for static analysis (pyrefly, mypy, etc.)
+if TYPE_CHECKING:
+    from band.platform.delegation_exchange import (
+        AudienceNotAllowed as AudienceNotAllowed,
+        ConsentMissing as ConsentMissing,
+        CredentialResolver as CredentialResolver,
+        CrossOrgBlocked as CrossOrgBlocked,
+        DelegatedToken as DelegatedToken,
+        DelegationDenied as DelegationDenied,
+        DelegationError as DelegationError,
+        DelegationUnavailable as DelegationUnavailable,
+        ExchangeRateLimited as ExchangeRateLimited,
+        NoDelegation as NoDelegation,
+        OnBehalfOf as OnBehalfOf,
+        ProviderNotConnected as ProviderNotConnected,
+        Revoked as Revoked,
+        WindowExpired as WindowExpired,
+    )
+    from band.platform.event import PlatformEvent as PlatformEvent
+    from band.platform.link import BandLink as BandLink
+
+__all__, __getattr__ = lazy_exports(
+    __name__,
+    event=["PlatformEvent"],
+    link=["BandLink"],
+    delegation_exchange=[
+        "AudienceNotAllowed",
+        "ConsentMissing",
+        "CredentialResolver",
+        "CrossOrgBlocked",
+        "DelegatedToken",
+        "DelegationDenied",
+        "DelegationError",
+        "DelegationUnavailable",
+        "ExchangeRateLimited",
+        "NoDelegation",
+        "OnBehalfOf",
+        "ProviderNotConnected",
+        "Revoked",
+        "WindowExpired",
+    ],
+)

--- a/src/band/platform/delegation_exchange.py
+++ b/src/band/platform/delegation_exchange.py
@@ -1,0 +1,344 @@
+"""Delegated-credential exchange: act with the ASKER's credentials (INT-993).
+
+Given the identity envelope the platform mints on cross-owner messages
+(``ctx.delegation``, INT-992), :class:`CredentialResolver` calls the frozen
+platform endpoint ``POST /api/v1/agent/delegation/token`` and returns a
+short-lived provider token for a named audience — the MCP connector id on the
+consent allowlist, not a name or URL.
+
+``band_rest`` 0.0.26 has no delegation client, so the POST is hand-rolled with
+httpx off ``BandLink``'s ``rest_url``/``api_key`` (the same ``X-API-Key``
+custody slot the Fern client uses). Revisit at M3 if the client group is
+regenerated — this module is one file to delete.
+
+Reuse policy (RFC 6749 no-store; the platform replies ``cache-control:
+no-store``): tokens are held in resolver memory only, keyed by audience,
+reused while ``expires_at`` clears :data:`EXPIRY_SKEW_SECONDS`, and NEVER
+reused when ``expires_at`` is null — null means the provider's expiry is
+unknown, not that the token is expired, and the SDK must not fabricate a TTL.
+A per-audience ``asyncio.Lock`` single-flights concurrent ``token_for`` calls
+so a tool fan-out cannot stampede the platform's per-message exchange cap
+(default 20).
+
+Error taxonomy mirrors the frozen contract: every wire ``error.code`` maps to
+a typed :class:`DelegationError` subclass; unknown codes fall back by HTTP
+status. The ``consent_missing`` / ``provider_not_connected`` pair is the
+first-run funnel — those classes carry the contract's remediation string, and
+``str(error)`` includes it so a rendered tool error already tells the human
+what to do next.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from pydantic import BaseModel, ConfigDict
+
+from band.core.exceptions import BandError
+
+if TYPE_CHECKING:
+    from band.core.delegation import DelegationEnvelope
+    from band.platform.link import BandLink
+
+logger = logging.getLogger(__name__)
+
+#: Path of the frozen exchange endpoint, relative to ``BandLink.rest_url``.
+EXCHANGE_PATH = "/api/v1/agent/delegation/token"
+
+#: A cached token is treated as expired this many seconds early, so a token
+#: cannot die between the freshness check and the provider call that uses it.
+EXPIRY_SKEW_SECONDS = 30.0
+
+_REQUEST_TIMEOUT_SECONDS = 30.0
+
+
+# --- Typed errors (one per frozen wire code + the client-side absence case) ---
+
+
+class DelegationError(BandError):
+    """Base for delegated-credential exchange failures.
+
+    Carries the wire error's ``code`` / ``request_id`` and the HTTP ``status``
+    when the failure came from the platform; a subclass with a class-level
+    ``remediation`` appends it to ``str(error)`` so tool-error rendering
+    surfaces the next step without any special-casing.
+    """
+
+    #: Frozen wire code (class default; instances may override for codes
+    #: without a dedicated subclass, e.g. ``forbidden`` / ``validation_error``).
+    code: str | None = None
+
+    #: Human next-step for the first-run funnel pair; ``None`` elsewhere.
+    remediation: str | None = None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        request_id: str | None = None,
+        status: int | None = None,
+    ) -> None:
+        if self.remediation:
+            message = f"{message} — {self.remediation}"
+        super().__init__(message)
+        if code is not None:
+            self.code = code
+        self.request_id = request_id
+        self.status = status
+
+
+class ConsentMissing(DelegationError):
+    """No consent for (originator, agent) — first-run funnel step 1."""
+
+    code = "consent_missing"
+    remediation = "Ask the user to grant consent, then retry."
+
+
+class ProviderNotConnected(DelegationError):
+    """Consent exists but the originator has no usable connection — funnel step 2."""
+
+    code = "provider_not_connected"
+    remediation = "Ask the user to connect the provider, then retry."
+
+
+class WindowExpired(DelegationError):
+    """Exchange attempted after the processing window (anchored on
+    ``minted_at``). Terminal for this message — a new request is required."""
+
+    code = "window_expired"
+
+
+class Revoked(DelegationError):
+    """Consent was revoked. Stop; the user must re-grant."""
+
+    code = "revoked"
+
+
+class AudienceNotAllowed(DelegationError):
+    """Connector not on the consent allowlist (or unknown/malformed id).
+    Do not retry the same audience value."""
+
+    code = "audience_not_allowed"
+
+
+class CrossOrgBlocked(DelegationError):
+    """Originator and agent owner are in different orgs — hard M2 block."""
+
+    code = "cross_org_blocked"
+
+
+class DelegationDenied(DelegationError):
+    """Deliberately undifferentiated platform denial (kill-switch off,
+    connector mode ``owner``, no envelope server-side, participant gone).
+    Terminal for this message."""
+
+    code = "delegation_denied"
+
+
+class ExchangeRateLimited(DelegationError):
+    """Per-(message, agent) exchange cap exhausted. Back off."""
+
+    code = "rate_limited"
+
+
+class DelegationUnavailable(DelegationError):
+    """The 404 family: message unknown, never delivered to this agent, or the
+    agent was not @mentioned — deliberately indistinguishable on the wire.
+    Terminal for this message."""
+
+    code = "not_found"
+
+
+class NoDelegation(DelegationError):
+    """Raised client-side when the current message has no delegation envelope
+    (owner-invoked or non-delegated), instead of letting the exchange 404."""
+
+
+_ERRORS_BY_CODE: dict[str, type[DelegationError]] = {
+    "consent_missing": ConsentMissing,
+    "provider_not_connected": ProviderNotConnected,
+    "window_expired": WindowExpired,
+    "revoked": Revoked,
+    "audience_not_allowed": AudienceNotAllowed,
+    "cross_org_blocked": CrossOrgBlocked,
+    "delegation_denied": DelegationDenied,
+    "rate_limited": ExchangeRateLimited,
+    "not_found": DelegationUnavailable,
+}
+
+_ERRORS_BY_STATUS: dict[int, type[DelegationError]] = {
+    404: DelegationUnavailable,
+    429: ExchangeRateLimited,
+}
+
+
+# --- Wire models -------------------------------------------------------------
+
+
+class OnBehalfOf(BaseModel):
+    """Whose authority the token carries. Platform-authored; read-only."""
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    originator_uuid: str | None = None
+    originator_handle: str | None = None
+    agent_uuid: str | None = None
+    #: The RESOLVED canonical connector id, even if the caller sent another
+    #: spelling/case of the same connector.
+    audience: str | None = None
+
+
+class DelegatedToken(BaseModel):
+    """A short-lived provider token acting as the originator.
+
+    ``expires_at`` is the PROVIDER's expiry, not platform-bounded; ``None``
+    means unknown — the resolver then never reuses the token.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    access_token: str
+    token_type: str = "bearer"
+    expires_at: datetime | None = None
+    obo: OnBehalfOf | None = None
+
+
+# --- Resolver ----------------------------------------------------------------
+
+
+class CredentialResolver:
+    """Resolve delegated provider tokens for the one envelope it was built on.
+
+    One resolver per (link, envelope): the cache is therefore keyed
+    (message_id, audience) by construction — a new message means a new
+    envelope means a new resolver, so a token can never outlive its message's
+    delegation. ``ExecutionContext.credentials`` owns that per-turn wiring.
+    """
+
+    def __init__(self, link: "BandLink", envelope: "DelegationEnvelope | None") -> None:
+        self._link = link
+        #: The envelope this resolver acts under; ``None`` for a non-delegated
+        #: message, in which case ``token_for`` raises :class:`NoDelegation`.
+        self.envelope = envelope
+        self._cache: dict[str, DelegatedToken] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    async def token_for(self, audience: str) -> DelegatedToken:
+        """Return a live delegated token for ``audience`` (an MCP connector id).
+
+        Raises a :class:`DelegationError` subclass per the frozen taxonomy;
+        :class:`NoDelegation` client-side when the current message carries no
+        envelope (I3 — owner-invoked messages are never delegated).
+        """
+        message_id = self.envelope.message_id if self.envelope else None
+        if not message_id:
+            raise NoDelegation(
+                "This message carries no delegation envelope (owner-invoked or "
+                "non-delegated), so there are no delegated credentials to "
+                "resolve. token_for() only works while handling a cross-owner "
+                "message."
+            )
+
+        lock = self._locks.setdefault(audience, asyncio.Lock())
+        async with lock:
+            cached = self._cache.get(audience)
+            if cached is not None and _is_fresh(cached):
+                return cached
+            token = await self._exchange(message_id, audience)
+            if token.expires_at is not None:
+                self._cache[audience] = token
+            else:
+                # Unknown expiry: no reuse, and drop any stale predecessor.
+                self._cache.pop(audience, None)
+            return token
+
+    async def _exchange(self, message_id: str, audience: str) -> DelegatedToken:
+        url = self._link.rest_url.rstrip("/") + EXCHANGE_PATH
+        async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                url,
+                json={"message_id": message_id, "audience": audience},
+                headers={"X-API-Key": self._link.api_key},
+            )
+
+        if response.status_code == 200:
+            try:
+                return DelegatedToken.model_validate(response.json())
+            except Exception as exc:
+                raise DelegationError(
+                    f"Malformed delegation token response: {exc}", status=200
+                ) from exc
+
+        raise _error_from_response(response)
+
+
+def _is_fresh(token: DelegatedToken) -> bool:
+    """Whether a cached token is still safely usable (expiry minus skew)."""
+    expires_at = token.expires_at
+    if expires_at is None:
+        return False
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    skew = timedelta(seconds=EXPIRY_SKEW_SECONDS)
+    return expires_at - skew > datetime.now(timezone.utc)
+
+
+def _error_from_response(response: httpx.Response) -> DelegationError:
+    """Map a non-200 exchange response to its typed error.
+
+    Primary key is the wire ``error.code``; an unknown or absent code falls
+    back by HTTP status (the auth plug's 401 has no error envelope at all).
+    """
+    code: str | None = None
+    message: str | None = None
+    request_id: str | None = None
+    try:
+        payload: Any = response.json()
+    except Exception:
+        payload = None
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            raw_code = error.get("code")
+            code = raw_code if isinstance(raw_code, str) else None
+            raw_message = error.get("message")
+            message = raw_message if isinstance(raw_message, str) else None
+            raw_request_id = error.get("request_id")
+            request_id = raw_request_id if isinstance(raw_request_id, str) else None
+
+    error_cls = (
+        _ERRORS_BY_CODE.get(code or "")
+        or _ERRORS_BY_STATUS.get(response.status_code)
+        or DelegationError
+    )
+    return error_cls(
+        message or f"Delegation exchange failed with HTTP {response.status_code}",
+        code=code,
+        request_id=request_id,
+        status=response.status_code,
+    )
+
+
+__all__ = [
+    "AudienceNotAllowed",
+    "ConsentMissing",
+    "CredentialResolver",
+    "CrossOrgBlocked",
+    "DelegatedToken",
+    "DelegationDenied",
+    "DelegationError",
+    "DelegationUnavailable",
+    "EXCHANGE_PATH",
+    "EXPIRY_SKEW_SECONDS",
+    "ExchangeRateLimited",
+    "NoDelegation",
+    "OnBehalfOf",
+    "ProviderNotConnected",
+    "Revoked",
+    "WindowExpired",
+]

--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 from band.client.rest import AsyncRestClient, DEFAULT_REQUEST_OPTIONS
 from band.client.streaming import WebSocketClient, WebSocketDisconnectReason
+from band.core.delegation import parse_delegation
 from band.runtime.types import PlatformMessage
 from band_rest.core.api_error import ApiError
 
@@ -675,6 +676,9 @@ class BandLink:
             message_type=item.message_type,
             metadata=item.metadata or {},
             created_at=item.inserted_at or datetime.now(timezone.utc),
+            # Typed view of the platform's identity envelope (INT-992);
+            # tolerant — a malformed envelope becomes None, never a raise.
+            delegation=parse_delegation(item.metadata),
         )
 
     async def get_stale_processing_messages(
@@ -721,6 +725,7 @@ class BandLink:
                             message_type=item.message_type,
                             metadata=item.metadata or {},
                             created_at=item.inserted_at or datetime.now(timezone.utc),
+                            delegation=parse_delegation(item.metadata),
                         )
                     )
 

--- a/src/band/preprocessing/default.py
+++ b/src/band/preprocessing/default.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime
 from typing import Any
 
+from band.core.delegation import parse_delegation
 from band.core.protocols import Preprocessor
 from band.core.types import AgentInput, HistoryProvider, PlatformMessage
 from band.platform.event import MessageEvent, PlatformEvent
@@ -60,6 +61,15 @@ class DefaultPreprocessor(Preprocessor):
         if msg_data.sender_type == "Agent" and msg_data.sender_id == agent_id:
             logger.debug("Room %s: Skipping own message %s", room_id, msg_data.id)
             return None
+
+        # Lift the platform-minted identity envelope (INT-992) once, at this
+        # single preprocessing seam: handler/tool code reads it off
+        # ctx.delegation; the LLM never sees it (format_message_for_llm strips
+        # the key from history, format_for_llm renders name + content only).
+        # Assigned unconditionally so an undelegated message clears any
+        # previous turn's envelope. parse_delegation never raises (a malformed
+        # envelope logs at DEBUG and lifts as None).
+        ctx.delegation = parse_delegation(msg_data.metadata)
 
         # Look up sender name from participants list
         sender_name = self._lookup_sender_name(ctx, msg_data.sender_id)

--- a/src/band/runtime/custom_tools.py
+++ b/src/band/runtime/custom_tools.py
@@ -9,14 +9,30 @@ from __future__ import annotations
 
 import inspect
 import logging
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from pydantic import BaseModel, ValidationError
+
+if TYPE_CHECKING:
+    from band.runtime.execution import ExecutionContext
 
 logger = logging.getLogger(__name__)
 
 # Type alias for custom tool definition: (InputModel, callable)
 CustomToolDef = tuple[type[BaseModel], Callable[..., Any]]
+
+
+def ctx_from_tools(tools: Any) -> "ExecutionContext | None":
+    """Best-effort ``ExecutionContext`` behind an AgentTools instance.
+
+    ``AgentTools.from_context`` stashes the per-execution context on ``_ctx``;
+    every custom-tool call site threads it from there into
+    :func:`execute_custom_tool` (INT-994). Deliberately defensive: adapter
+    tests drive these paths with ``FakeAgentTools`` (no ``_ctx``), plain
+    mocks, or ``None`` — all of those mean "no context available", never an
+    error.
+    """
+    return getattr(tools, "_ctx", None)
 
 
 def custom_tool_to_mcp_schema(
@@ -171,16 +187,58 @@ def format_validation_error(exc: ValidationError) -> str:
     )
 
 
-def _custom_tool_accepts_input(func: Callable[..., Any]) -> bool:
+# Handler positional arity, memoized: signatures are immutable, and the tool
+# loop re-inspects the same handler on every call otherwise. Keyed by the
+# callable itself; an unhashable callable (custom __eq__ without __hash__)
+# simply skips the cache.
+_HANDLER_ARITY_CACHE: dict[Callable[..., Any], int] = {}
+
+
+def _custom_tool_positional_arity(func: Callable[..., Any]) -> int:
+    """How many positional parameters the handler declares, capped at 2.
+
+    0 = zero-argument handler (empty InputModel required); 1 = the classic
+    ``handler(args)`` shape; 2 = the INT-994 opt-in ``handler(args, ctx)``
+    that also receives the ``ExecutionContext`` (or ``None`` when the call
+    site has none). Only POSITIONAL_ONLY / POSITIONAL_OR_KEYWORD parameters
+    count — ``*args`` is NOT an opt-in, so pre-INT-994 handlers keep their
+    exact call shape. Uninspectable callables fall back to the classic shape.
+    """
     try:
-        return len(inspect.signature(func).parameters) > 0
+        return _HANDLER_ARITY_CACHE[func]
+    except KeyError:
+        pass
+    except TypeError:  # unhashable callable: inspect without caching
+        return _inspect_positional_arity(func)
+
+    arity = _inspect_positional_arity(func)
+    _HANDLER_ARITY_CACHE[func] = arity
+    return arity
+
+
+def _inspect_positional_arity(func: Callable[..., Any]) -> int:
+    try:
+        parameters = inspect.signature(func).parameters.values()
     except (TypeError, ValueError):
-        return True
+        return 1
+    positional = [
+        parameter
+        for parameter in parameters
+        if parameter.kind
+        in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    return min(len(positional), 2)
+
+
+def _custom_tool_accepts_input(func: Callable[..., Any]) -> bool:
+    return _custom_tool_positional_arity(func) > 0
 
 
 async def execute_custom_tool(
     tool: CustomToolDef,
     arguments: dict[str, Any],
+    *,
+    ctx: "ExecutionContext | None" = None,
 ) -> Any:
     """
     Execute custom tool with Pydantic validation.
@@ -188,6 +246,10 @@ async def execute_custom_tool(
     Args:
         tool: (InputModel, callable) tuple
         arguments: Raw arguments dict from LLM
+        ctx: Optional per-execution context (INT-994). Delivered as the
+            handler's second positional argument when — and only when — the
+            handler declares one; zero-arg and one-arg handlers are called
+            exactly as before.
 
     Returns:
         Tool execution result
@@ -212,12 +274,14 @@ async def execute_custom_tool(
         raise ValueError(
             f"Invalid handler for {tool_name}: zero-argument handlers require an empty InputModel and no arguments"
         )
-    return await invoke_validated_custom_tool(tool, validated)
+    return await invoke_validated_custom_tool(tool, validated, ctx=ctx)
 
 
 async def invoke_validated_custom_tool(
     tool: CustomToolDef,
     validated: Any,
+    *,
+    ctx: "ExecutionContext | None" = None,
 ) -> Any:
     """
     Execute a custom tool whose arguments are already a validated InputModel
@@ -226,18 +290,23 @@ async def invoke_validated_custom_tool(
     For callers whose framework has already constructed the InputModel (e.g.
     pydantic-ai validates tool args natively): re-serializing the instance to
     a dict and re-validating would break models using field aliases, so the
-    instance is passed through as-is. Async/zero-argument handler semantics
-    match :func:`execute_custom_tool` exactly.
+    instance is passed through as-is. Async/zero-argument handler and ``ctx``
+    opt-in semantics match :func:`execute_custom_tool` exactly.
     """
     model, func = tool
 
-    accepts_input = _custom_tool_accepts_input(func)
-    if not accepts_input and model.model_fields:
+    arity = _custom_tool_positional_arity(func)
+    if arity == 0 and model.model_fields:
         tool_name = get_custom_tool_name(model)
         raise ValueError(
             f"Invalid handler for {tool_name}: zero-argument handlers require an empty InputModel and no arguments"
         )
-    args = (validated,) if accepts_input else ()
+    if arity == 0:
+        args: tuple[Any, ...] = ()
+    elif arity == 1:
+        args = (validated,)
+    else:
+        args = (validated, ctx)
 
     # Call the handler, then await if it produced an awaitable. This covers plain
     # sync/async functions AND callable objects with an async __call__ (for which

--- a/src/band/runtime/custom_tools.py
+++ b/src/band/runtime/custom_tools.py
@@ -234,6 +234,15 @@ def _custom_tool_accepts_input(func: Callable[..., Any]) -> bool:
     return _custom_tool_positional_arity(func) > 0
 
 
+def custom_tool_accepts_ctx(func: Callable[..., Any]) -> bool:
+    """Whether a handler opted in to the INT-994 second (ctx) parameter.
+
+    Adapters whose framework owns the call chain (pydantic-ai's RunContext
+    registration) use this to pick the wrapper shape once, at conversion time.
+    """
+    return _custom_tool_positional_arity(func) >= 2
+
+
 async def execute_custom_tool(
     tool: CustomToolDef,
     arguments: dict[str, Any],

--- a/src/band/runtime/execution.py
+++ b/src/band/runtime/execution.py
@@ -55,6 +55,7 @@ from band.runtime.working_state import WorkingStateReporter
 
 if TYPE_CHECKING:
     from band.core.delegation import DelegationEnvelope
+    from band.platform.delegation_exchange import CredentialResolver
     from band.platform.link import BandLink
 
 logger = logging.getLogger(__name__)
@@ -288,6 +289,11 @@ class ExecutionContext:
         # read-only view for handler/tool code; never rendered for the LLM.
         self.delegation: DelegationEnvelope | None = None
 
+        # Lazily built delegated-credential resolver for the CURRENT envelope
+        # (INT-993). Invalidated by identity when self.delegation changes, so
+        # a token cache can never outlive its message's delegation.
+        self._credentials_resolver: CredentialResolver | None = None
+
         # Message ownership ledger (in-flight claims, completed LRU, pending
         # acks) shared by /next and WebSocket processing. Runtime-provided so
         # all contexts of one agent coordinate; private otherwise.
@@ -348,6 +354,31 @@ class ExecutionContext:
     def is_processing(self) -> bool:
         """Check if context is currently processing an event."""
         return self.state is ExecutionState.PROCESSING
+
+    @property
+    def credentials(self) -> "CredentialResolver":
+        """Delegated-credential resolver for the CURRENT message (INT-993).
+
+        Built lazily from ``self.link`` and ``self.delegation`` and kept
+        stable for the duration of the turn, so a tool fan-out shares one
+        per-audience token cache and single-flight lock. When the envelope
+        changes (the preprocessor assigns ``self.delegation`` on every
+        message), the next access builds a fresh resolver — a token can never
+        outlive its message's delegation. Without an envelope (owner-invoked
+        or non-delegated message) the resolver raises ``NoDelegation`` on
+        use, the typed I1 error, rather than this property failing.
+        """
+        # Import here to avoid a module cycle (platform.delegation_exchange
+        # is import-light, but runtime.execution is imported everywhere).
+        from band.platform.delegation_exchange import CredentialResolver
+
+        cached = self._credentials_resolver
+        if cached is not None and cached.envelope is self.delegation:
+            return cached
+
+        resolver = CredentialResolver(self.link, self.delegation)
+        self._credentials_resolver = resolver
+        return resolver
 
     def _set_state(self, new_state: ExecutionState) -> None:
         """

--- a/src/band/runtime/execution.py
+++ b/src/band/runtime/execution.py
@@ -54,6 +54,7 @@ from band.runtime.retry_tracker import MessageRetryTracker
 from band.runtime.working_state import WorkingStateReporter
 
 if TYPE_CHECKING:
+    from band.core.delegation import DelegationEnvelope
     from band.platform.link import BandLink
 
 logger = logging.getLogger(__name__)
@@ -279,6 +280,13 @@ class ExecutionContext:
 
         # LLM context tracking
         self._llm_initialized = False
+
+        # Cross-owner identity envelope for the message currently being
+        # processed (INT-992). DefaultPreprocessor.process assigns it on every
+        # message it lifts — the parsed envelope for a delegated message, None
+        # otherwise — so it can never carry over from a previous turn. Typed,
+        # read-only view for handler/tool code; never rendered for the LLM.
+        self.delegation: DelegationEnvelope | None = None
 
         # Message ownership ledger (in-flight claims, completed LRU, pending
         # acks) shared by /next and WebSocket processing. Runtime-provided so

--- a/src/band/runtime/formatters.py
+++ b/src/band/runtime/formatters.py
@@ -75,13 +75,25 @@ def format_message_for_llm(msg: dict, participants: list[dict] | None = None) ->
     if participants:
         content = replace_uuid_mentions(content, participants)
 
+    metadata = msg.get("metadata", {})
+    if isinstance(metadata, dict) and "delegation" in metadata:
+        # The platform's identity envelope (metadata["delegation"], INT-992)
+        # is for handler/tool code, never the model. This function is the
+        # single choke point every history path flows through (bootstrap
+        # hydration and oneshot alike), so the strip is enforced here and ONLY
+        # here. Strip ONLY this key: adapters keep reading their session keys
+        # (e.g. a2a_context_id) off history metadata — a deliberate contract
+        # pinned by test_preserves_metadata. Copy, don't mutate: the source
+        # dict belongs to the hydrated context cache.
+        metadata = {k: v for k, v in metadata.items() if k != "delegation"}
+
     return {
         "role": "assistant" if sender_type == "Agent" else "user",
         "content": content,
         "sender_name": sender_name,
         "sender_type": sender_type,
         "message_type": msg.get("message_type", "text"),
-        "metadata": msg.get("metadata", {}),
+        "metadata": metadata,
     }
 
 

--- a/src/band/runtime/mcp_server.py
+++ b/src/band/runtime/mcp_server.py
@@ -25,6 +25,7 @@ import uvicorn
 
 from band.runtime.custom_tools import (
     CustomToolDef,
+    ctx_from_tools,
     execute_custom_tool,
     get_custom_tool_name,
 )
@@ -171,7 +172,8 @@ def build_band_mcp_tool_registrations(
         for definition in definitions
     ]
     registrations.extend(
-        _build_custom_registration(tool_def) for tool_def in additional_tools or []
+        _build_custom_registration(agent_tools, tool_def)
+        for tool_def in additional_tools or []
     )
     _validate_unique_tool_names(registrations)
     return registrations
@@ -201,7 +203,7 @@ def build_resolved_band_mcp_tool_registrations(
         for definition in definitions
     ]
     registrations.extend(
-        _build_resolved_custom_registration(tool_def)
+        _build_resolved_custom_registration(get_tools, tool_def)
         for tool_def in additional_tools or []
     )
     _validate_unique_tool_names(registrations)
@@ -262,12 +264,19 @@ def _build_resolved_builtin_registration(
     )
 
 
-def _build_custom_registration(tool_def: CustomToolDef) -> MCPToolRegistration:
+def _build_custom_registration(
+    agent_tools: AgentToolsProtocol,
+    tool_def: CustomToolDef,
+) -> MCPToolRegistration:
     input_model, _ = tool_def
     tool_name = get_custom_tool_name(input_model)
 
     async def execute(arguments: dict[str, Any]) -> Any:
-        return await execute_custom_tool(tool_def, arguments)
+        # ctx resolved at call time: AgentTools.from_context stashes the
+        # ExecutionContext after this registration is built (INT-994).
+        return await execute_custom_tool(
+            tool_def, arguments, ctx=ctx_from_tools(agent_tools)
+        )
 
     return MCPToolRegistration(
         name=tool_name,
@@ -277,14 +286,21 @@ def _build_custom_registration(tool_def: CustomToolDef) -> MCPToolRegistration:
     )
 
 
-def _build_resolved_custom_registration(tool_def: CustomToolDef) -> MCPToolRegistration:
+def _build_resolved_custom_registration(
+    get_tools: RoomToolResolver,
+    tool_def: CustomToolDef,
+) -> MCPToolRegistration:
     input_model, _ = tool_def
     tool_name = get_custom_tool_name(input_model)
 
     async def execute(arguments: dict[str, Any]) -> Any:
+        # Unlike builtin registrations, a custom tool does not require room
+        # tools to run — an unknown room simply yields ctx=None (INT-994).
+        room_id = str(arguments.get("room_id", ""))
         return await execute_custom_tool(
             tool_def,
             {key: value for key, value in arguments.items() if key != "room_id"},
+            ctx=ctx_from_tools(get_tools(room_id)),
         )
 
     return MCPToolRegistration(

--- a/src/band/runtime/types.py
+++ b/src/band/runtime/types.py
@@ -57,6 +57,7 @@ def normalize_handle(handle: str | None) -> str | None:
 
 
 if TYPE_CHECKING:
+    from band.core.delegation import DelegationEnvelope
     from band.platform.event import (
         ContactEvent,
         ParticipantAddedEvent,
@@ -177,6 +178,12 @@ class PlatformMessage:
     message_type: str
     metadata: dict[str, Any]
     created_at: datetime
+    # Typed view of the platform's cross-owner identity envelope
+    # (metadata["delegation"], INT-992). BandLink populates it when building
+    # messages off the REST backlog endpoints; None when the message is not
+    # delegated (or the envelope is malformed — parsing is tolerant). For
+    # handler/tool code only: format_for_llm never renders it.
+    delegation: "DelegationEnvelope | None" = None
 
     def format_for_llm(self) -> str:
         """

--- a/tests/adapters/copilot_sdk/test_tool_bridging.py
+++ b/tests/adapters/copilot_sdk/test_tool_bridging.py
@@ -199,3 +199,37 @@ class TestToolBridging:
 
         assert not first_tools.tool_calls
         assert second_tools.tool_calls
+
+
+class TestCtxThreading:
+    """INT-994: the session tool handler threads room tools._ctx to custom handlers."""
+
+    @pytest.mark.asyncio
+    async def test_ctx_threads_to_custom_handler(self):
+        class CtxProbeInput(BaseModel):
+            text: str
+
+        received = []
+
+        async def probe(params: CtxProbeInput, ctx) -> str:
+            received.append(ctx)
+            return f"probe: {params.text}"
+
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(
+            client, additional_tools=[(CtxProbeInput, probe)]
+        )
+        tools = ToolSchemaFakeTools()
+        sentinel_ctx = object()
+        tools._ctx = sentinel_ctx
+        await run_message(adapter, tools)
+
+        session = client.sessions[0]
+        result = await session.find_tool("ctxprobe").handler(
+            ToolInvocation(
+                tool_call_id="c1", tool_name="ctxprobe", arguments={"text": "hi"}
+            )
+        )
+
+        assert result.text_result_for_llm == "probe: hi"
+        assert received == [sentinel_ctx]

--- a/tests/adapters/langgraph/test_message_input.py
+++ b/tests/adapters/langgraph/test_message_input.py
@@ -251,6 +251,64 @@ class TestOnMessage:
         )
 
     @pytest.mark.asyncio
+    async def test_simple_pattern_threads_ctx_to_tuple_custom_tools(
+        self, sample_message, mock_tools, mock_llm, mock_checkpointer
+    ):
+        """INT-994: a CustomToolDef tuple is converted per turn, binding the
+        turn's ExecutionContext (tools._ctx) into the tool closure — the
+        init-time conversion could never see it."""
+        from pydantic import BaseModel
+
+        class ProbeInput(BaseModel):
+            """Report who is asking."""
+
+            text: str
+
+        received = []
+
+        async def probe(args: ProbeInput, ctx) -> str:
+            received.append(ctx)
+            return "probed"
+
+        created_graph, _inputs, _kwargs = make_capture_graph()
+
+        with patch("langchain.agents.create_agent") as mock_create:
+            mock_create.return_value = created_graph
+            adapter = LangGraphAdapter(
+                llm=mock_llm,
+                checkpointer=mock_checkpointer,
+                additional_tools=[(ProbeInput, probe)],
+            )
+            await adapter.on_started("TestBot", "Test bot")
+
+            sentinel_ctx = object()
+            mock_tools._ctx = sentinel_ctx
+
+            with patch(
+                "band.integrations.langgraph.langchain_tools.agent_tools_to_langchain"
+            ) as mock_convert:
+                mock_convert.return_value = []
+
+                await adapter.on_message(
+                    msg=sample_message,
+                    tools=mock_tools,
+                    history=[],
+                    participants_msg=None,
+                    contacts_msg=None,
+                    is_session_bootstrap=True,
+                    room_id="room-123",
+                )
+
+        (call,) = mock_create.call_args_list
+        turn_tools = call.kwargs["tools"]
+        (probe_tool,) = [
+            tool for tool in turn_tools if getattr(tool, "name", "") == "probe"
+        ]
+
+        assert await probe_tool.ainvoke({"text": "hi"}) == "probed"
+        assert received == [sentinel_ctx]
+
+    @pytest.mark.asyncio
     async def test_feature_capabilities_control_tool_groups(
         self, sample_message, mock_tools, mock_llm, mock_checkpointer
     ):

--- a/tests/adapters/test_anthropic_adapter.py
+++ b/tests/adapters/test_anthropic_adapter.py
@@ -868,3 +868,95 @@ class TestCustomTools:
         assert (
             "message" in results[0]["content"].lower()
         )  # Error mentions missing field
+
+
+class TestCtxThreading:
+    """INT-994: the tool loop threads the ExecutionContext to custom handlers."""
+
+    @pytest.mark.asyncio
+    async def test_ctx_threads_from_tools_to_custom_handler_end_to_end(
+        self, sample_message, mock_tools
+    ):
+        """End-to-end proof: on_message -> tool loop -> execute_custom_tool
+        delivers the ExecutionContext stashed on tools._ctx, with the INT-992
+        envelope and the INT-993 resolver live on it."""
+        from anthropic.types import ToolUseBlock
+
+        from band.core.delegation import DelegationEnvelope
+        from band.platform.delegation_exchange import CredentialResolver
+        from band.runtime.execution import ExecutionContext
+
+        class CtxProbeInput(BaseModel):
+            """Report who is asking."""
+
+            question: str
+
+        received = []
+
+        async def probe(args: CtxProbeInput, ctx) -> str:
+            received.append(ctx)
+            return "probed"
+
+        adapter = AnthropicAdapter(additional_tools=[(CtxProbeInput, probe)])
+        await adapter.on_started("TestBot", "Test bot")
+
+        ctx = ExecutionContext("room-123", MagicMock(), AsyncMock())
+        ctx.delegation = DelegationEnvelope(message_id="msg-123")
+        mock_tools._ctx = ctx
+        mock_tools.get_anthropic_tool_schemas = MagicMock(return_value=[])
+
+        tool_response = MagicMock()
+        tool_response.stop_reason = "tool_use"
+        tool_response.content = [
+            ToolUseBlock(
+                type="tool_use",
+                id="t1",
+                name="ctxprobe",
+                input={"question": "who is asking?"},
+            )
+        ]
+        tool_response.usage = make_usage(1, 1)
+        final_response = MagicMock()
+        final_response.stop_reason = "end_turn"
+        final_response.content = []
+        final_response.usage = make_usage(1, 1)
+
+        with patch.object(
+            adapter,
+            "_call_anthropic",
+            AsyncMock(side_effect=[tool_response, final_response]),
+        ):
+            await adapter.on_message(
+                msg=sample_message,
+                tools=mock_tools,
+                history=[],
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-123",
+            )
+
+        assert len(received) == 1
+        assert received[0] is ctx
+        assert received[0].delegation is ctx.delegation
+        assert isinstance(received[0].credentials, CredentialResolver)
+        assert received[0].credentials.envelope is ctx.delegation
+
+    @pytest.mark.asyncio
+    async def test_legacy_one_param_handler_unchanged(self, mock_tools):
+        """A pre-INT-994 handler keeps its exact call shape even with a live
+        _ctx on the tools."""
+        from anthropic.types import ToolUseBlock
+
+        adapter = AnthropicAdapter(additional_tools=[(EchoInput, echo_message)])
+        mock_tools._ctx = object()
+
+        mock_response = MagicMock()
+        mock_response.content = [
+            ToolUseBlock(type="tool_use", id="t1", name="echo", input={"message": "hi"})
+        ]
+
+        results = await adapter._process_tool_calls(mock_response, mock_tools)
+
+        assert results[0]["is_error"] is False
+        assert "Echo: hi" in results[0]["content"]

--- a/tests/adapters/test_claude_sdk_adapter.py
+++ b/tests/adapters/test_claude_sdk_adapter.py
@@ -2295,3 +2295,72 @@ class TestSendMessageDedupWiring:
                     room_id="room-1",
                 )
                 mock_update.assert_not_awaited()
+
+
+class TestCtxThreading:
+    """INT-994: the custom SDK tool resolves room tools and threads their ctx."""
+
+    @pytest.mark.asyncio
+    async def test_custom_sdk_tool_threads_ctx_from_resolver(self):
+        import json
+
+        from pydantic import BaseModel
+
+        from band.integrations.claude_sdk.tools import build_band_sdk_tools
+        from band.runtime.tools import AgentTools
+
+        class CtxProbeInput(BaseModel):
+            """Report who is asking."""
+
+            text: str
+
+        received = []
+
+        async def probe(args: CtxProbeInput, ctx) -> str:
+            received.append(ctx)
+            return f"probe: {args.text}"
+
+        room_tools = AgentTools("room-123", MagicMock(), [])
+        sentinel_ctx = object()
+        room_tools._ctx = sentinel_ctx
+
+        (probe_tool,) = build_band_sdk_tools(
+            tool_definitions=[],
+            get_tools={"room-123": room_tools}.get,
+            additional_tools=[(CtxProbeInput, probe)],
+        )
+
+        result = await probe_tool.handler({"room_id": "room-123", "text": "hi"})
+
+        assert json.loads(result["content"][0]["text"]) == "probe: hi"
+        assert received == [sentinel_ctx]
+
+    @pytest.mark.asyncio
+    async def test_custom_sdk_tool_runs_with_unresolvable_room(self):
+        import json
+
+        from pydantic import BaseModel
+
+        from band.integrations.claude_sdk.tools import build_band_sdk_tools
+
+        class CtxProbeInput(BaseModel):
+            """Report who is asking."""
+
+            text: str
+
+        received = []
+
+        async def probe(args: CtxProbeInput, ctx) -> str:
+            received.append(ctx)
+            return f"probe: {args.text}"
+
+        (probe_tool,) = build_band_sdk_tools(
+            tool_definitions=[],
+            get_tools=lambda _room_id: None,
+            additional_tools=[(CtxProbeInput, probe)],
+        )
+
+        result = await probe_tool.handler({"room_id": "ghost", "text": "hi"})
+
+        assert json.loads(result["content"][0]["text"]) == "probe: hi"
+        assert received == [None]

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -7271,3 +7271,66 @@ class TestDoubleEmitStartupWarning:
         assert not any(
             "two task events per turn" in record.message for record in caplog.records
         )
+
+
+class TestCtxThreading:
+    """INT-994: the tool-call loop threads tools._ctx to custom handlers."""
+
+    @pytest.mark.asyncio
+    async def test_custom_tool_receives_ctx(self) -> None:
+        class CtxCalcInput(BaseModel):
+            """Simple calculator."""
+
+            expression: str
+
+        received: list[Any] = []
+
+        async def calculate(inp: CtxCalcInput, ctx: Any) -> str:
+            received.append(ctx)
+            return "42"
+
+        custom_tools: list[CustomToolDef] = [(CtxCalcInput, calculate)]
+        events = [
+            _event_request(
+                99,
+                "item/tool/call",
+                {
+                    "tool": "ctxcalc",
+                    "arguments": {"expression": "6*7"},
+                    "callId": "call-99",
+                },
+            ),
+            _event_notification(
+                "turn/completed",
+                {
+                    "turn": {
+                        "id": "turn-1",
+                        "status": "completed",
+                        "items": [],
+                        "error": None,
+                    }
+                },
+            ),
+        ]
+        fake_client = FakeCodexClient(events=events)
+        adapter = CodexAdapter(
+            config=CodexAdapterConfig(transport="ws"),
+            additional_tools=custom_tools,
+            client_factory=lambda _config: fake_client,
+        )
+        tools = ToolSchemaFakeTools()
+        sentinel_ctx = object()
+        tools._ctx = sentinel_ctx
+
+        await adapter.on_started("Codex Agent", "A coding agent")
+        await adapter.on_message(
+            make_platform_message(),
+            tools,
+            CodexSessionState(),
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-1",
+        )
+
+        assert received == [sentinel_ctx]

--- a/tests/adapters/test_crewai_flow_adapter.py
+++ b/tests/adapters/test_crewai_flow_adapter.py
@@ -498,3 +498,38 @@ class TestPublicImportPath:
         adapter._band_agent_id = "crewai-flow-router-id"
         await adapter.on_started("crewai_flow_router", "")
         assert adapter.metadata_namespace == "crewai_flow:crewai-flow-router-id"
+
+
+class TestCtxThreading:
+    """INT-994: CrewAIFlowCustomTools.call_tool threads tools._ctx to handlers."""
+
+    @pytest.mark.asyncio
+    async def test_call_tool_threads_ctx(self):
+        from band.adapters.crewai_flow import CrewAIFlowCustomTools
+        from band.core.types import AdapterFeatures
+
+        class CtxProbeInput(BaseModel):
+            """Report who is asking."""
+
+            text: str
+
+        received = []
+
+        async def probe(args: CtxProbeInput, ctx) -> str:
+            received.append(ctx)
+            return "probed"
+
+        mock_tools = MagicMock()
+        sentinel_ctx = object()
+        mock_tools._ctx = sentinel_ctx
+
+        runtime_tools = CrewAIFlowCustomTools(
+            custom_tools={"ctxprobe": (CtxProbeInput, probe)},
+            tools=mock_tools,
+            features=AdapterFeatures(),
+        )
+
+        result = await runtime_tools.call_tool("ctxprobe", {"text": "hi"})
+
+        assert result == "probed"
+        assert received == [sentinel_ctx]

--- a/tests/adapters/test_gemini_adapter.py
+++ b/tests/adapters/test_gemini_adapter.py
@@ -658,3 +658,35 @@ class TestEmptyCandidates:
 
         content = adapter._extract_candidate_content(response)
         assert content is None
+
+
+class TestCtxThreading:
+    """INT-994: _process_function_calls threads tools._ctx to custom handlers."""
+
+    @pytest.mark.asyncio
+    async def test_ctx_threads_to_custom_handler(self, mock_tools):
+        class CtxEchoInput(BaseModel):
+            text: str = Field(...)
+
+        received = []
+
+        async def ctx_echo(inp: CtxEchoInput, ctx) -> str:
+            received.append(ctx)
+            return inp.text
+
+        adapter = GeminiAdapter(
+            additional_tools=[(CtxEchoInput, ctx_echo)],
+            provider_key="test-key",
+        )
+        sentinel_ctx = object()
+        mock_tools._ctx = sentinel_ctx
+
+        function_calls = [
+            types.FunctionCall(name="ctxecho", args={"text": "hello"}, id="c1")
+        ]
+        parts = await adapter._process_function_calls(function_calls, mock_tools)
+
+        assert received == [sentinel_ctx]
+        function_response = parts[0].function_response
+        assert function_response is not None
+        assert function_response.response == {"output": "hello"}

--- a/tests/adapters/test_google_adk_adapter.py
+++ b/tests/adapters/test_google_adk_adapter.py
@@ -1446,3 +1446,42 @@ class TestConcurrentMessages:
 async def _empty_async_iter(**kwargs):
     return
     yield  # Make it an async generator
+
+
+class TestCtxThreading:
+    """INT-994: the tool bridge threads tools._ctx to custom handlers."""
+
+    @pytest.mark.asyncio
+    async def test_ctx_threads_to_custom_handler(self):
+        class CtxProbeInput(BaseModel):
+            """Report who is asking."""
+
+            question: str
+
+        received = []
+
+        async def probe(args: CtxProbeInput, ctx) -> str:
+            received.append(ctx)
+            return "probed"
+
+        mock_tools = MagicMock()
+        sentinel_ctx = object()
+        mock_tools._ctx = sentinel_ctx
+
+        bridge = _BandToolBridge(
+            tool_name="ctxprobe",
+            tool_description="Report who is asking.",
+            parameters_schema={
+                "type": "object",
+                "properties": {"question": {"type": "string"}},
+            },
+            tools=mock_tools,
+            custom_tools=[(CtxProbeInput, probe)],
+        )
+
+        result = await bridge.run_async(
+            args={"question": "who?"}, tool_context=MagicMock()
+        )
+
+        assert result == "probed"
+        assert received == [sentinel_ctx]

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -1852,3 +1852,90 @@ class TestPortableCustomToolDef:
         (content,) = self._tool_return_contents(result)
         assert isinstance(content, str)
         assert content.startswith("user:")
+
+
+class TestCtxThreading:
+    """INT-994: a ctx-opt-in tuple handler reaches the deps' ExecutionContext."""
+
+    @staticmethod
+    def _tool_return_contents(result) -> list:
+        from pydantic_ai.messages import ToolReturnPart
+
+        return [
+            part.content
+            for message in result.all_messages()
+            for part in message.parts
+            if isinstance(part, ToolReturnPart)
+        ]
+
+    def test_opt_in_tuple_converts_to_a_run_context_callable(self):
+        """A two-param handler produces a RunContext-taking wrapper (routed to
+        agent.tool by the registration classifier); a one-param handler keeps
+        the exact context-free shape."""
+        from pydantic import BaseModel
+
+        from band.adapters.pydantic_ai import (
+            _custom_tool_def_to_callable,
+            _takes_run_context,
+        )
+
+        class LookupInput(BaseModel):
+            """look up a code."""
+
+            key: str
+
+        async def legacy(args: LookupInput) -> str:
+            return "x"
+
+        async def opted_in(args: LookupInput, ctx) -> str:
+            return "y"
+
+        assert not _takes_run_context(
+            _custom_tool_def_to_callable((LookupInput, legacy))
+        )
+        assert _takes_run_context(_custom_tool_def_to_callable((LookupInput, opted_in)))
+
+    @pytest.mark.asyncio
+    async def test_opt_in_tuple_receives_ctx_through_a_real_run(self):
+        """End-to-end through pydantic-ai: the wrapper reads the turn's tools
+        off RunContext.deps and threads tools._ctx into the handler, and the
+        single model param still flattens into the tool schema."""
+        from unittest.mock import MagicMock
+
+        from pydantic import BaseModel
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        from band.adapters.pydantic_ai import _custom_tool_def_to_callable
+        from band.core.protocols import AgentToolsProtocol
+
+        class LookupInput(BaseModel):
+            """look up a code."""
+
+            key: str
+
+        received = []
+
+        async def lookup(args: LookupInput, ctx) -> str:
+            received.append(ctx)
+            return f"code:{args.key}"
+
+        native = _custom_tool_def_to_callable((LookupInput, lookup))
+        agent: Agent = Agent(TestModel(), output_type=str, deps_type=AgentToolsProtocol)
+        agent.tool(native)
+
+        (tool,) = agent._function_toolset.tools.values()
+        schema = tool.function_schema.json_schema
+        assert tool.name == "lookup"
+        assert sorted((schema.get("properties") or {}).keys()) == ["key"]
+
+        deps = MagicMock()
+        sentinel_ctx = object()
+        deps._ctx = sentinel_ctx
+
+        result = await agent.run("go", deps=deps)
+
+        (content,) = self._tool_return_contents(result)
+        assert isinstance(content, str)
+        assert content.startswith("code:")
+        assert received == [sentinel_ctx]

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -679,3 +679,67 @@ class TestCleanup:
         await adapter.on_cleanup(ROOM)
 
         assert ROOM not in adapter._message_history
+
+
+class TestCtxThreading:
+    """INT-994: each turn's custom-tool bridges carry that turn's ctx."""
+
+    async def test_custom_tool_receives_the_turns_ctx(self, tools, scripted):
+        class CtxProbeInput(BaseModel):
+            """Report who is asking."""
+
+            question: str
+
+        received = []
+
+        async def probe(args: CtxProbeInput, ctx) -> str:
+            received.append(ctx)
+            return "probed"
+
+        adapter = await scripted(
+            ToolTurn("ctxprobe", {"question": "who?"}),
+            additional_tools=[(CtxProbeInput, probe)],
+        )
+        sentinel_ctx = object()
+        tools._ctx = sentinel_ctx
+
+        await _run_message(adapter, tools)
+
+        assert received == [sentinel_ctx]
+        assert _tool_results(adapter) == ["probed"]
+
+    async def test_turns_do_not_share_a_ctx_binding(self, scripted):
+        """The bridge is rebuilt per turn: a second turn with different tools
+        must see the second tools' ctx, not the first's."""
+
+        class CtxProbeInput(BaseModel):
+            """Report who is asking."""
+
+            question: str
+
+        received = []
+
+        async def probe(args: CtxProbeInput, ctx) -> str:
+            received.append(ctx)
+            return "probed"
+
+        from band.testing import TextTurn
+
+        adapter = await scripted(
+            ToolTurn("ctxprobe", {"question": "first?"}),
+            TextTurn("first turn done"),
+            ToolTurn("ctxprobe", {"question": "second?"}),
+            additional_tools=[(CtxProbeInput, probe)],
+        )
+
+        first_tools = FakeAgentTools(room_id=ROOM)
+        first_ctx = object()
+        first_tools._ctx = first_ctx
+        await _run_message(adapter, first_tools)
+
+        second_tools = FakeAgentTools(room_id=ROOM)
+        second_ctx = object()
+        second_tools._ctx = second_ctx
+        await _run_message(adapter, second_tools, is_session_bootstrap=False)
+
+        assert received == [first_ctx, second_ctx]

--- a/tests/core/test_delegation.py
+++ b/tests/core/test_delegation.py
@@ -1,0 +1,195 @@
+"""Tests for the platform identity-envelope parser (INT-992).
+
+The platform mints ``metadata["delegation"]`` server-side on cross-owner
+messages. The SDK must expose it to handler/tool code as a typed, read-only
+view and must never let a malformed envelope raise (a platform bug must not
+take down the agent loop).
+"""
+
+from __future__ import annotations
+
+import copy
+
+from band.client.streaming import MessageMetadata
+from band.core.delegation import (
+    DelegationEnvelope,
+    Originator,
+    parse_delegation,
+    parse_delegation_value,
+)
+
+# The platform's frozen minted shape (PLT-1075).
+ORIGINATOR_UUID = "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b"
+ENVELOPE_MESSAGE_ID = "7f3e9a1b-5c2d-4f6e-8a9b-1c3d5e7f9a2b"
+ENVELOPE = {
+    "version": 1,
+    "originator": {
+        "uuid": ORIGINATOR_UUID,
+        "handle": "alice.asker",
+        "display_name": "Alice Asker",
+    },
+    "message_id": ENVELOPE_MESSAGE_ID,
+    "minted_at": "2026-08-13T09:30:00Z",
+    "hop": None,
+}
+
+
+def make_envelope_dict() -> dict:
+    """A fresh copy of the frozen platform shape (tests may mutate it)."""
+    return copy.deepcopy(ENVELOPE)
+
+
+class TestParseDelegationHappyPath:
+    def test_parses_the_frozen_platform_shape_from_dict_metadata(self):
+        metadata = {
+            "mentions": [],
+            "status": "sent",
+            "delegation": make_envelope_dict(),
+        }
+
+        envelope = parse_delegation(metadata)
+
+        assert isinstance(envelope, DelegationEnvelope)
+        assert envelope.version == 1
+        assert isinstance(envelope.originator, Originator)
+        assert envelope.originator.uuid == ORIGINATOR_UUID
+        assert envelope.originator.handle == "alice.asker"
+        assert envelope.originator.display_name == "Alice Asker"
+        assert envelope.message_id == ENVELOPE_MESSAGE_ID
+        assert envelope.minted_at == "2026-08-13T09:30:00Z"
+        assert envelope.hop is None
+
+    def test_parses_from_message_metadata_model(self):
+        """The WS wire type (pydantic, extra="allow") is the other metadata
+        shape ``ExecutionContext._metadata_to_dict`` normalizes; the parser
+        accepts it directly."""
+        metadata = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": make_envelope_dict()}
+        )
+
+        envelope = parse_delegation(metadata)
+
+        assert isinstance(envelope, DelegationEnvelope)
+        assert envelope.originator is not None
+        assert envelope.originator.handle == "alice.asker"
+
+    def test_none_metadata_returns_none(self):
+        assert parse_delegation(None) is None
+
+    def test_dict_metadata_without_envelope_returns_none(self):
+        assert parse_delegation({"mentions": [], "status": "sent"}) is None
+
+    def test_model_metadata_without_envelope_returns_none(self):
+        assert parse_delegation(MessageMetadata(mentions=[], status="sent")) is None
+
+    def test_accepts_an_already_parsed_envelope(self):
+        envelope = DelegationEnvelope.model_validate(make_envelope_dict())
+        assert parse_delegation({"delegation": envelope}) is envelope
+
+
+class TestParseDelegationTolerance:
+    """I3: a malformed envelope never raises — log and treat as absent."""
+
+    def test_junk_string_envelope_returns_none(self):
+        assert parse_delegation({"delegation": "junk"}) is None
+
+    def test_junk_int_envelope_returns_none(self):
+        assert parse_delegation({"delegation": 42}) is None
+
+    def test_junk_list_envelope_returns_none(self):
+        assert parse_delegation({"delegation": ["not", "an", "envelope"]}) is None
+
+    def test_junk_version_returns_none(self):
+        envelope = make_envelope_dict()
+        envelope["version"] = "not-an-int"
+        assert parse_delegation({"delegation": envelope}) is None
+
+    def test_junk_originator_returns_none(self):
+        envelope = make_envelope_dict()
+        envelope["originator"] = "alice"
+        assert parse_delegation({"delegation": envelope}) is None
+
+    def test_junk_metadata_object_returns_none(self):
+        """Even a metadata object that is neither dict nor model is absorbed."""
+        assert parse_delegation(object()) is None
+        assert parse_delegation("metadata?") is None
+
+    def test_version_2_still_parses(self):
+        """Version-tolerant by design: a newer platform's envelope is parsed,
+        not dropped (M2.5 may bump the version)."""
+        envelope = make_envelope_dict()
+        envelope["version"] = 2
+
+        parsed = parse_delegation({"delegation": envelope})
+
+        assert parsed is not None
+        assert parsed.version == 2
+
+    def test_partial_envelope_parses(self):
+        """A partially formed envelope is better than a dropped one — every
+        field is optional."""
+        parsed = parse_delegation({"delegation": {"originator": {"handle": "a.b"}}})
+
+        assert parsed is not None
+        assert parsed.version is None
+        assert parsed.originator is not None
+        assert parsed.originator.handle == "a.b"
+
+    def test_unknown_keys_are_absorbed(self):
+        """extra="allow" absorbs platform additions (e.g. a future hop shape)."""
+        envelope = make_envelope_dict()
+        envelope["hop"] = {"via": "org/router"}
+        envelope["new_platform_key"] = "surprise"
+
+        parsed = parse_delegation({"delegation": envelope})
+
+        assert parsed is not None
+        assert parsed.hop == {"via": "org/router"}
+        assert parsed.model_extra is not None
+        assert parsed.model_extra["new_platform_key"] == "surprise"
+
+
+class TestParseDelegationValue:
+    """The value-level coercion used at the wire boundary (MessageMetadata)."""
+
+    def test_parses_a_dict_value(self):
+        parsed = parse_delegation_value(make_envelope_dict())
+        assert isinstance(parsed, DelegationEnvelope)
+        assert parsed.message_id == ENVELOPE_MESSAGE_ID
+
+    def test_passes_through_an_envelope_instance(self):
+        envelope = DelegationEnvelope.model_validate(make_envelope_dict())
+        assert parse_delegation_value(envelope) is envelope
+
+    def test_none_returns_none(self):
+        assert parse_delegation_value(None) is None
+
+    def test_junk_returns_none_without_raising(self):
+        assert parse_delegation_value("junk") is None
+        assert parse_delegation_value(3.14) is None
+
+
+class TestEnvelopeIsReadOnly:
+    """I2: handler code gets a read-only view — the envelope is platform-
+    authored and nothing in the SDK writes through it."""
+
+    def test_envelope_rejects_assignment(self):
+        envelope = DelegationEnvelope.model_validate(make_envelope_dict())
+        try:
+            envelope.message_id = "overwritten"
+        except Exception:
+            pass
+        else:
+            raise AssertionError("frozen envelope accepted attribute assignment")
+        assert envelope.message_id == ENVELOPE_MESSAGE_ID
+
+    def test_originator_rejects_assignment(self):
+        envelope = DelegationEnvelope.model_validate(make_envelope_dict())
+        assert envelope.originator is not None
+        try:
+            envelope.originator.handle = "mallory"
+        except Exception:
+            pass
+        else:
+            raise AssertionError("frozen originator accepted attribute assignment")
+        assert envelope.originator.handle == "alice.asker"

--- a/tests/core/test_delegation.py
+++ b/tests/core/test_delegation.py
@@ -221,6 +221,84 @@ class TestMessageMetadataWireBoundary:
         assert rewrapped.delegation.originator.uuid == ORIGINATOR_UUID
 
 
+class TestFormatForLlmNeverRendersTheEnvelope:
+    """I1 regression across BOTH PlatformMessage classes: the SDK has two
+    (band.core.types for adapters, band.runtime.types for MessageHandlers) and
+    neither may render envelope content for a delegated message — their
+    ``format_for_llm`` stays name + content only."""
+
+    def _assert_clean(self, rendered: str) -> None:
+        assert rendered == "[Bob Broker]: delegated ask"
+        for leaked in (
+            "delegation",
+            "alice.asker",
+            "Alice Asker",
+            ORIGINATOR_UUID,
+            ENVELOPE_MESSAGE_ID,
+        ):
+            assert leaked not in rendered
+
+    def test_core_platform_message_format_for_llm_is_clean(self):
+        from datetime import datetime, timezone
+
+        from band.core.types import PlatformMessage as CorePlatformMessage
+
+        msg = CorePlatformMessage(
+            id="msg-1",
+            room_id="room-1",
+            content="delegated ask",
+            sender_id="user-1",
+            sender_type="User",
+            sender_name="Bob Broker",
+            message_type="text",
+            metadata={"delegation": make_envelope_dict(), "status": "sent"},
+            created_at=datetime.now(timezone.utc),
+        )
+
+        self._assert_clean(msg.format_for_llm())
+
+    def test_runtime_platform_message_format_for_llm_is_clean(self):
+        from datetime import datetime, timezone
+
+        from band.runtime.types import PlatformMessage as RuntimePlatformMessage
+
+        msg = RuntimePlatformMessage(
+            id="msg-1",
+            room_id="room-1",
+            content="delegated ask",
+            sender_id="user-1",
+            sender_type="User",
+            sender_name="Bob Broker",
+            message_type="text",
+            metadata={"delegation": make_envelope_dict(), "status": "sent"},
+            created_at=datetime.now(timezone.utc),
+            delegation=DelegationEnvelope.model_validate(make_envelope_dict()),
+        )
+
+        self._assert_clean(msg.format_for_llm())
+
+    def test_runtime_platform_message_defaults_delegation_to_none(self):
+        """Existing construction sites (and the Slack adapter's synthesized
+        messages) build the runtime PlatformMessage without the field."""
+        from datetime import datetime, timezone
+
+        from band.runtime.types import PlatformMessage as RuntimePlatformMessage
+
+        msg = RuntimePlatformMessage(
+            id="msg-1",
+            room_id="room-1",
+            content="plain",
+            sender_id="user-1",
+            sender_type="User",
+            sender_name=None,
+            message_type="text",
+            metadata={},
+            created_at=datetime.now(timezone.utc),
+        )
+
+        assert msg.delegation is None
+
+
 class TestEnvelopeIsReadOnly:
     """I2: handler code gets a read-only view — the envelope is platform-
     authored and nothing in the SDK writes through it."""

--- a/tests/core/test_delegation.py
+++ b/tests/core/test_delegation.py
@@ -169,6 +169,58 @@ class TestParseDelegationValue:
         assert parse_delegation_value(3.14) is None
 
 
+class TestMessageMetadataWireBoundary:
+    """The WS wire type carries the envelope as a typed field, and the typed
+    field must stay tolerant: the REST backlog path re-wraps raw dicts with
+    ``MessageMetadata(**metadata)`` (execution.py), so a malformed envelope
+    must not fail the whole metadata parse (I3)."""
+
+    def test_wire_metadata_types_the_envelope(self):
+        metadata = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": make_envelope_dict()}
+        )
+
+        assert isinstance(metadata.delegation, DelegationEnvelope)
+        assert metadata.delegation.originator is not None
+        assert metadata.delegation.originator.handle == "alice.asker"
+
+    def test_absent_envelope_defaults_to_none(self):
+        assert MessageMetadata(mentions=[], status="sent").delegation is None
+
+    def test_rewrap_kwargs_path_tolerates_a_malformed_envelope(self):
+        """Mirrors ExecutionContext._process_claimed_backlog_message, which
+        constructs ``MessageMetadata(**metadata)`` from platform dicts."""
+        metadata = MessageMetadata(
+            **{"mentions": [], "status": "sent", "delegation": "junk"}
+        )
+
+        assert metadata.delegation is None
+
+    def test_rewrap_kwargs_path_tolerates_junk_version(self):
+        envelope = make_envelope_dict()
+        envelope["version"] = "not-an-int"
+
+        metadata = MessageMetadata(
+            **{"mentions": [], "status": "sent", "delegation": envelope}
+        )
+
+        assert metadata.delegation is None
+
+    def test_model_dump_then_rewrap_keeps_the_envelope(self):
+        """The backlog cycle dumps the WS model to a dict and re-wraps it;
+        the envelope must survive that round trip."""
+        original = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": make_envelope_dict()}
+        )
+
+        rewrapped = MessageMetadata(**original.model_dump())
+
+        assert rewrapped.delegation is not None
+        assert rewrapped.delegation.message_id == ENVELOPE_MESSAGE_ID
+        assert rewrapped.delegation.originator is not None
+        assert rewrapped.delegation.originator.uuid == ORIGINATOR_UUID
+
+
 class TestEnvelopeIsReadOnly:
     """I2: handler code gets a read-only view — the envelope is platform-
     authored and nothing in the SDK writes through it."""

--- a/tests/example_agents/test_delegation_crm_specialist.py
+++ b/tests/example_agents/test_delegation_crm_specialist.py
@@ -1,0 +1,156 @@
+"""Offline tests for the two-user delegation example (INT-995).
+
+The example is the SDK's demonstration of the M2 first-run funnel: its custom
+tool must opt in to the INT-994 ctx parameter, exchange via
+``ctx.credentials`` (INT-993), and render each funnel error as guidance a
+human can act on. These tests drive the handler with fakes — no platform, no
+Anthropic — and pin the README's inert-endpoint precondition (contract caveat
+1) so it cannot be silently dropped.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from band.core.delegation import DelegationEnvelope
+from band.platform.delegation_exchange import (
+    ConsentMissing,
+    DelegatedToken,
+    DelegationDenied,
+    NoDelegation,
+    ProviderNotConnected,
+)
+from band.runtime.custom_tools import custom_tool_accepts_ctx
+from tests.loaders import load_script_module
+from tests.paths import REPO_ROOT
+
+pytest.importorskip("anthropic", reason="example uses the anthropic extra")
+
+crm = load_script_module(
+    "examples/delegation/01_crm_specialist.py", "delegation_crm_specialist"
+)
+
+ENVELOPE = DelegationEnvelope.model_validate(
+    {
+        "version": 1,
+        "originator": {"uuid": "alice-uuid", "handle": "alice"},
+        "message_id": "7e2a9c04-1111-2222-3333-444455556666",
+        "minted_at": "2026-08-14T00:00:00Z",
+    }
+)
+
+
+class FakeResolver:
+    def __init__(self, outcome):
+        self._outcome = outcome
+        self.requested: list[str] = []
+
+    async def token_for(self, audience: str):
+        self.requested.append(audience)
+        if isinstance(self._outcome, Exception):
+            raise self._outcome
+        return self._outcome
+
+
+def make_ctx(outcome, envelope=ENVELOPE):
+    return SimpleNamespace(delegation=envelope, credentials=FakeResolver(outcome))
+
+
+def make_args():
+    return crm.LookupCustomerInput(customer="ACME-042")
+
+
+async def run_handler(ctx, monkeypatch=None):
+    return await crm.lookup_customer(make_args(), ctx)
+
+
+class TestHandlerContract:
+    def test_handler_opts_in_to_the_ctx_parameter(self):
+        assert custom_tool_accepts_ctx(crm.lookup_customer)
+
+    async def test_success_reports_who_the_token_acts_as(self, monkeypatch):
+        monkeypatch.setattr(
+            crm, "CRM_CONNECTOR_ID", "11112222-3333-4444-5555-666677778888"
+        )
+        token = DelegatedToken.model_validate(
+            {
+                "access_token": "secret-token",
+                "token_type": "bearer",
+                "expires_at": "2026-08-14T01:00:00Z",
+                "obo": {
+                    "originator_uuid": "alice-uuid",
+                    "originator_handle": "alice",
+                    "agent_uuid": "agent-1",
+                    "audience": "11112222-3333-4444-5555-666677778888",
+                },
+            }
+        )
+        ctx = make_ctx(token)
+
+        reply = await run_handler(ctx)
+
+        assert "alice" in reply
+        assert "ACME-042" in reply
+        # The provider credential itself must never be echoed into the room.
+        assert "secret-token" not in reply
+        assert ctx.credentials.requested == ["11112222-3333-4444-5555-666677778888"]
+
+    async def test_owner_invoked_message_is_explained(self):
+        ctx = SimpleNamespace(delegation=None, credentials=FakeResolver(None))
+
+        reply = await crm.lookup_customer(make_args(), ctx)
+
+        assert "owner" in reply.lower() or "envelope" in reply.lower()
+        assert ctx.credentials.requested == []
+
+
+class TestFirstRunFunnel:
+    async def test_consent_missing_renders_grant_guidance(self, monkeypatch):
+        monkeypatch.setattr(crm, "CRM_CONNECTOR_ID", "conn-id")
+        error = ConsentMissing("No consent for this agent")
+        reply = await run_handler(make_ctx(error))
+
+        assert "alice" in reply
+        # The contract's remediation string must reach the human.
+        assert "grant consent" in reply.lower()
+
+    async def test_provider_not_connected_renders_connect_guidance(self, monkeypatch):
+        monkeypatch.setattr(crm, "CRM_CONNECTOR_ID", "conn-id")
+        error = ProviderNotConnected("No usable connection")
+        reply = await run_handler(make_ctx(error))
+
+        assert "connect the provider" in reply.lower()
+        # The example's own funnel rendering, not just the error passthrough:
+        # it addresses the asker by handle.
+        assert "alice" in reply
+
+    async def test_no_delegation_is_rendered_not_raised(self, monkeypatch):
+        monkeypatch.setattr(crm, "CRM_CONNECTOR_ID", "conn-id")
+        error = NoDelegation("This message carries no delegation envelope")
+        reply = await run_handler(make_ctx(error))
+
+        assert "envelope" in reply.lower()
+
+    async def test_terminal_errors_surface_their_code(self, monkeypatch):
+        monkeypatch.setattr(crm, "CRM_CONNECTOR_ID", "conn-id")
+        error = DelegationDenied("Delegation denied", status=403)
+        reply = await run_handler(make_ctx(error))
+
+        assert "delegation_denied" in reply
+
+
+class TestReadmePrecondition:
+    """Contract caveat 1 is binding: the README must state the inert-endpoint
+    precondition — stock deployments answer delegation_denied until the
+    connector opt-in surface ships."""
+
+    def test_readme_states_the_seeded_connector_precondition(self):
+        readme = (REPO_ROOT / "examples" / "delegation" / "README.md").read_text()
+
+        assert "delegation_credential_mode" in readme
+        assert "delegation_denied" in readme
+        # The default that makes the exchange inert, and the two modes that arm it.
+        assert "owner" in readme
+        assert "originator" in readme

--- a/tests/integrations/langgraph/test_custom_tool_defs.py
+++ b/tests/integrations/langgraph/test_custom_tool_defs.py
@@ -48,20 +48,53 @@ async def test_converter_reports_bad_args_to_the_model() -> None:
     assert isinstance(result, str) and "text" in result
 
 
-def test_adapter_normalizes_custom_tool_defs_and_passes_native_through() -> None:
+def test_adapter_splits_custom_tool_defs_from_native_tools() -> None:
+    """Deliberately amended for INT-994: tuples are no longer converted once at
+    init — they are held raw on _custom_tool_defs and converted per turn, so
+    the conversion can bind that turn's ExecutionContext. Native LangChain
+    tools still pass through at init.
+    """
+
     @lc_tool
     def native(x: str) -> str:
         """A ready-made LangChain tool."""
         return x
 
-    # Advanced pattern (graph_factory) keeps additional_tools on the instance, so we
-    # can assert the normalization. A CustomToolDef tuple + a native tool go in.
     adapter = LangGraphAdapter(
         graph_factory=lambda tools: MagicMock(),
         additional_tools=[(EchoInput, echo), native],
     )
 
-    assert len(adapter.additional_tools) == 2
+    assert adapter._custom_tool_defs == [(EchoInput, echo)]
+    assert adapter.additional_tools == [native]
     assert not any(isinstance(t, tuple) for t in adapter.additional_tools)
-    names = {getattr(t, "name", None) for t in adapter.additional_tools}
-    assert names == {"echo", "native"}
+
+
+async def test_converter_threads_ctx_to_opt_in_handler() -> None:
+    """INT-994: the converter binds the given ctx into the tool closure, and a
+    two-param handler receives it."""
+    received = []
+
+    async def probe(args: EchoInput, ctx) -> str:
+        received.append(ctx)
+        return f"echo:{args.text}"
+
+    sentinel_ctx = object()
+    (converted,) = custom_tool_defs_to_langchain([(EchoInput, probe)], ctx=sentinel_ctx)
+
+    assert await converted.ainvoke({"text": "hi"}) == "echo:hi"
+    assert received == [sentinel_ctx]
+
+
+async def test_converter_defaults_to_no_ctx() -> None:
+    """Without a bound ctx the opt-in handler still runs, receiving None."""
+    received = []
+
+    async def probe(args: EchoInput, ctx) -> str:
+        received.append(ctx)
+        return "ok"
+
+    (converted,) = custom_tool_defs_to_langchain([(EchoInput, probe)])
+
+    assert await converted.ainvoke({"text": "hi"}) == "ok"
+    assert received == [None]

--- a/tests/integrations/test_crewai_tools.py
+++ b/tests/integrations/test_crewai_tools.py
@@ -643,3 +643,39 @@ class TestStoreMemoryInputDescription:
                     "scope": "organization",
                 }
             )
+
+
+class TestCustomToolCtxThreading:
+    """INT-994: custom tool handlers can receive the ExecutionContext."""
+
+    def test_custom_tool_receives_ctx_from_context_tools(self, builder_mod):
+        from pydantic import BaseModel
+
+        class CtxProbeInput(BaseModel):
+            """Report who is asking."""
+
+            text: str
+
+        received = []
+
+        async def probe(args: CtxProbeInput, ctx) -> str:
+            received.append(ctx)
+            return "probed"
+
+        tools_obj = MagicMock()
+        sentinel_ctx = object()
+        tools_obj._ctx = sentinel_ctx
+        context = builder_mod.CrewAIToolContext(room_id="room-1", tools=tools_obj)
+        tools = builder_mod.build_band_crewai_tools(
+            get_context=lambda: context,
+            reporter=builder_mod.NoopReporter(),
+            capabilities=frozenset(),
+            custom_tools=[(CtxProbeInput, probe)],
+        )
+        probe_tool = next(t for t in tools if t.name == "ctxprobe")
+
+        result = json.loads(probe_tool._run(text="hi"))
+
+        assert result["status"] == "success"
+        assert result["result"] == "probed"
+        assert received == [sentinel_ctx]

--- a/tests/platform/test_delegation_exchange.py
+++ b/tests/platform/test_delegation_exchange.py
@@ -1,0 +1,423 @@
+"""CredentialResolver: the SDK half of the delegated-credential exchange (INT-993).
+
+The wire contract under test is the frozen platform endpoint
+``POST /api/v1/agent/delegation/token`` (agent API key in ``X-API-Key``; errors
+shaped ``{"error": {"code", "message", "request_id"}}``). ``band_rest`` 0.0.26
+has no delegation client, so the resolver hand-rolls the httpx POST off
+``BandLink``'s ``rest_url``/``api_key`` — interception here is the same global
+``pytest-httpx`` ``httpx_mock`` fixture ``test_link_credentials.py`` uses, so
+the observed request is the real outbound call, not an injected seam.
+
+Reuse policy pinned here (RFC 6749 no-store; the platform replies
+``cache-control: no-store``): tokens live in resolver memory only, keyed by
+audience, fresh while ``expires_at`` clears a 30 s skew, and are NEVER reused
+when ``expires_at`` is null — null means unknown, not expired, and the SDK
+must not fabricate a TTL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from band.core.delegation import DelegationEnvelope
+from band.platform.delegation_exchange import (
+    AudienceNotAllowed,
+    ConsentMissing,
+    CredentialResolver,
+    CrossOrgBlocked,
+    DelegatedToken,
+    DelegationDenied,
+    DelegationError,
+    DelegationUnavailable,
+    ExchangeRateLimited,
+    NoDelegation,
+    ProviderNotConnected,
+    Revoked,
+    WindowExpired,
+)
+from band.platform.link import BandLink
+
+REST_URL = "https://platform.test"
+EXCHANGE_URL = f"{REST_URL}/api/v1/agent/delegation/token"
+MESSAGE_ID = "8f7f2f6a-3f6e-4a3e-9b1a-2c4d5e6f7a8b"
+AUDIENCE = "1f2e3d4c-5b6a-7980-a1b2-c3d4e5f6a7b8"
+
+
+def make_link() -> BandLink:
+    return BandLink(agent_id="agent-1", api_key="sk-agent-key", rest_url=REST_URL)
+
+
+def make_envelope(message_id: str | None = MESSAGE_ID) -> DelegationEnvelope:
+    return DelegationEnvelope.model_validate(
+        {
+            "version": 1,
+            "originator": {
+                "uuid": "0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9",
+                "handle": "alice",
+                "display_name": "Alice",
+            },
+            "message_id": message_id,
+            "minted_at": "2026-08-14T00:00:00Z",
+        }
+    )
+
+
+def make_resolver(
+    envelope: DelegationEnvelope | None = None,
+) -> CredentialResolver:
+    return CredentialResolver(make_link(), envelope)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def token_body(
+    *,
+    expires_at: str | None,
+    access_token: str = "provider-token-1",
+) -> dict[str, object]:
+    return {
+        "access_token": access_token,
+        "token_type": "bearer",
+        "expires_at": expires_at,
+        "obo": {
+            "originator_uuid": "0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9",
+            "originator_handle": "alice",
+            "agent_uuid": "agent-1",
+            "audience": AUDIENCE,
+        },
+    }
+
+
+def error_body(code: str, message: str = "nope") -> dict[str, object]:
+    return {"error": {"code": code, "message": message, "request_id": "req-123"}}
+
+
+class TestWireRequest:
+    """The outbound POST matches the frozen contract exactly."""
+
+    async def test_posts_message_id_and_audience_with_api_key_header(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        expires = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(json=token_body(expires_at=expires))
+
+        resolver = make_resolver(make_envelope())
+        await resolver.token_for(AUDIENCE)
+
+        request = httpx_mock.get_request()
+        assert request is not None
+        assert request.method == "POST"
+        assert str(request.url) == EXCHANGE_URL
+        assert request.headers["X-API-Key"] == "sk-agent-key"
+        # Missing Content-Type is a 422 on the platform side — pin it.
+        assert request.headers["Content-Type"] == "application/json"
+        import json
+
+        assert json.loads(request.content) == {
+            "message_id": MESSAGE_ID,
+            "audience": AUDIENCE,
+        }
+
+    async def test_parses_a_success_response(self, httpx_mock: HTTPXMock) -> None:
+        expires = datetime.now(timezone.utc).replace(microsecond=0) + timedelta(hours=1)
+        httpx_mock.add_response(json=token_body(expires_at=_iso(expires)))
+
+        resolver = make_resolver(make_envelope())
+        token = await resolver.token_for(AUDIENCE)
+
+        assert isinstance(token, DelegatedToken)
+        assert token.access_token == "provider-token-1"
+        assert token.token_type == "bearer"
+        assert token.expires_at == expires
+        assert token.obo is not None
+        assert token.obo.originator_uuid == "0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9"
+        assert token.obo.originator_handle == "alice"
+        assert token.obo.agent_uuid == "agent-1"
+        # The platform echoes the RESOLVED canonical connector id.
+        assert token.obo.audience == AUDIENCE
+
+    async def test_malformed_success_body_raises_typed_error(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(json={"unexpected": "shape"})
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(DelegationError):
+            await resolver.token_for(AUDIENCE)
+
+
+class TestReusePolicy:
+    """In-memory only, expiry-aware with 30 s skew, never on null expiry."""
+
+    async def test_fresh_token_is_reused_without_a_second_request(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        expires = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(json=token_body(expires_at=expires))
+
+        resolver = make_resolver(make_envelope())
+        first = await resolver.token_for(AUDIENCE)
+        second = await resolver.token_for(AUDIENCE)
+
+        assert first is second
+        assert len(httpx_mock.get_requests()) == 1
+
+    async def test_null_expiry_is_never_reused(self, httpx_mock: HTTPXMock) -> None:
+        # null = UNKNOWN, not expired: each call must fetch a fresh token
+        # rather than fabricate a TTL for reuse.
+        httpx_mock.add_response(json=token_body(expires_at=None, access_token="tok-a"))
+        httpx_mock.add_response(json=token_body(expires_at=None, access_token="tok-b"))
+
+        resolver = make_resolver(make_envelope())
+        first = await resolver.token_for(AUDIENCE)
+        second = await resolver.token_for(AUDIENCE)
+
+        assert first.access_token == "tok-a"
+        assert second.access_token == "tok-b"
+        assert len(httpx_mock.get_requests()) == 2
+
+    async def test_expired_token_is_refetched(self, httpx_mock: HTTPXMock) -> None:
+        expired = _iso(datetime.now(timezone.utc) - timedelta(minutes=5))
+        fresh = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(json=token_body(expires_at=expired))
+        httpx_mock.add_response(
+            json=token_body(expires_at=fresh, access_token="tok-fresh")
+        )
+
+        resolver = make_resolver(make_envelope())
+        await resolver.token_for(AUDIENCE)
+        second = await resolver.token_for(AUDIENCE)
+
+        assert second.access_token == "tok-fresh"
+        assert len(httpx_mock.get_requests()) == 2
+
+    async def test_token_inside_the_skew_window_is_refetched(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        # Still nominally live (+10 s) but inside the 30 s skew: treat as
+        # expired so a token cannot die mid-provider-call.
+        nearly = _iso(datetime.now(timezone.utc) + timedelta(seconds=10))
+        fresh = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(json=token_body(expires_at=nearly))
+        httpx_mock.add_response(
+            json=token_body(expires_at=fresh, access_token="tok-fresh")
+        )
+
+        resolver = make_resolver(make_envelope())
+        await resolver.token_for(AUDIENCE)
+        second = await resolver.token_for(AUDIENCE)
+
+        assert second.access_token == "tok-fresh"
+        assert len(httpx_mock.get_requests()) == 2
+
+    async def test_audiences_cache_independently(self, httpx_mock: HTTPXMock) -> None:
+        other_audience = "9e8d7c6b-5a49-3827-b1a0-f9e8d7c6b5a4"
+        expires = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(json=token_body(expires_at=expires, access_token="a"))
+        httpx_mock.add_response(json=token_body(expires_at=expires, access_token="b"))
+
+        resolver = make_resolver(make_envelope())
+        first = await resolver.token_for(AUDIENCE)
+        second = await resolver.token_for(other_audience)
+
+        assert first.access_token == "a"
+        assert second.access_token == "b"
+        assert len(httpx_mock.get_requests()) == 2
+
+    async def test_a_new_resolver_does_not_inherit_tokens(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        # No-store means memory-of-this-resolver only: nothing on disk, nothing
+        # shared between resolver instances.
+        expires = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(json=token_body(expires_at=expires))
+        httpx_mock.add_response(json=token_body(expires_at=expires))
+
+        await make_resolver(make_envelope()).token_for(AUDIENCE)
+        await make_resolver(make_envelope()).token_for(AUDIENCE)
+
+        assert len(httpx_mock.get_requests()) == 2
+
+
+class TestSingleFlight:
+    async def test_concurrent_calls_for_one_audience_make_one_request(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        # The per-message exchange cap (default 20) makes a tool fan-out
+        # stampede expensive: concurrent token_for calls must coalesce. The
+        # callback suspends on a real await so all five tasks genuinely
+        # overlap — a plain add_response resolves without yielding, which
+        # would serialize the tasks and mask a missing lock.
+        expires = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+
+        async def slow_token(request: object) -> object:
+            import httpx
+
+            await asyncio.sleep(0.01)
+            return httpx.Response(200, json=token_body(expires_at=expires))
+
+        httpx_mock.add_callback(slow_token)
+
+        resolver = make_resolver(make_envelope())
+        tokens = await asyncio.gather(*(resolver.token_for(AUDIENCE) for _ in range(5)))
+
+        assert len(httpx_mock.get_requests()) == 1
+        assert all(token is tokens[0] for token in tokens)
+
+
+class TestErrorTaxonomy:
+    """Every frozen error code maps to its typed exception."""
+
+    @pytest.mark.parametrize(
+        ("status", "code", "expected"),
+        [
+            (403, "window_expired", WindowExpired),
+            (403, "consent_missing", ConsentMissing),
+            (403, "provider_not_connected", ProviderNotConnected),
+            (403, "revoked", Revoked),
+            (403, "audience_not_allowed", AudienceNotAllowed),
+            (403, "cross_org_blocked", CrossOrgBlocked),
+            (403, "delegation_denied", DelegationDenied),
+            (429, "rate_limited", ExchangeRateLimited),
+            (404, "not_found", DelegationUnavailable),
+        ],
+    )
+    async def test_maps_code_to_typed_error(
+        self,
+        httpx_mock: HTTPXMock,
+        status: int,
+        code: str,
+        expected: type[DelegationError],
+    ) -> None:
+        httpx_mock.add_response(status_code=status, json=error_body(code))
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(expected) as excinfo:
+            await resolver.token_for(AUDIENCE)
+
+        assert excinfo.value.code == code
+        assert excinfo.value.status == status
+        assert excinfo.value.request_id == "req-123"
+        assert "nope" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            # Fern's auth plug rejects without the error envelope.
+            (401, DelegationError),
+            (404, DelegationUnavailable),
+            (429, ExchangeRateLimited),
+        ],
+    )
+    async def test_falls_back_by_http_status_without_a_known_code(
+        self,
+        httpx_mock: HTTPXMock,
+        status: int,
+        expected: type[DelegationError],
+    ) -> None:
+        httpx_mock.add_response(status_code=status, text="denied")
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(expected) as excinfo:
+            await resolver.token_for(AUDIENCE)
+
+        assert excinfo.value.status == status
+
+    async def test_unknown_code_stays_a_delegation_error(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        # forbidden (wrong credential type) and validation_error (422) have no
+        # dedicated class; they surface as the typed base with code intact.
+        httpx_mock.add_response(status_code=403, json=error_body("forbidden"))
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(DelegationError) as excinfo:
+            await resolver.token_for(AUDIENCE)
+
+        assert type(excinfo.value) is DelegationError
+        assert excinfo.value.code == "forbidden"
+
+    async def test_errors_are_not_cached(self, httpx_mock: HTTPXMock) -> None:
+        expires = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        httpx_mock.add_response(status_code=403, json=error_body("consent_missing"))
+        httpx_mock.add_response(json=token_body(expires_at=expires))
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(ConsentMissing):
+            await resolver.token_for(AUDIENCE)
+        token = await resolver.token_for(AUDIENCE)
+
+        assert token.access_token == "provider-token-1"
+        assert len(httpx_mock.get_requests()) == 2
+
+
+class TestFirstRunFunnel:
+    """The funnel pair carries the contract's remediation, ready to render."""
+
+    async def test_consent_missing_carries_the_grant_remediation(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            status_code=403,
+            json=error_body("consent_missing", "No consent for this agent"),
+        )
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(ConsentMissing) as excinfo:
+            await resolver.token_for(AUDIENCE)
+
+        error = excinfo.value
+        assert error.remediation == "Ask the user to grant consent, then retry."
+        # str(e) is what a tool-error path shows the model/human — the
+        # remediation must ride along with the platform's own message.
+        assert "No consent for this agent" in str(error)
+        assert error.remediation in str(error)
+
+    async def test_provider_not_connected_carries_the_connect_remediation(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            status_code=403,
+            json=error_body("provider_not_connected", "No usable connection"),
+        )
+
+        resolver = make_resolver(make_envelope())
+        with pytest.raises(ProviderNotConnected) as excinfo:
+            await resolver.token_for(AUDIENCE)
+
+        error = excinfo.value
+        assert error.remediation == "Ask the user to connect the provider, then retry."
+        assert "No usable connection" in str(error)
+        assert error.remediation in str(error)
+
+
+class TestNoDelegation:
+    """I3: the resolver never runs without an envelope."""
+
+    async def test_none_envelope_raises_before_any_request(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        resolver = make_resolver(None)
+
+        with pytest.raises(NoDelegation) as excinfo:
+            await resolver.token_for(AUDIENCE)
+
+        assert len(httpx_mock.get_requests()) == 0
+        # The absence-error explains itself instead of letting the exchange 404.
+        assert "delegation" in str(excinfo.value).lower()
+
+    async def test_envelope_without_message_id_raises_before_any_request(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        resolver = make_resolver(make_envelope(message_id=None))
+
+        with pytest.raises(NoDelegation):
+            await resolver.token_for(AUDIENCE)
+
+        assert len(httpx_mock.get_requests()) == 0

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -816,6 +816,111 @@ class TestGetStaleProcessingMessages:
         link.rest.agent_api_messages.list_agent_messages.assert_awaited_once()
 
 
+class TestRestMessagesCarryTheDelegationEnvelope:
+    """INT-992: the REST backlog wrappers build the runtime PlatformMessage,
+    the message handler-facing type — its ``delegation`` field is the typed
+    view of ``metadata["delegation"]``. Parsing is tolerant: a malformed
+    envelope yields ``None``, never an exception (the recovery sweep must not
+    die on a platform bug)."""
+
+    ENVELOPE = {
+        "version": 1,
+        "originator": {
+            "uuid": "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b",
+            "handle": "alice.asker",
+            "display_name": "Alice Asker",
+        },
+        "message_id": "7f3e9a1b-5c2d-4f6e-8a9b-1c3d5e7f9a2b",
+        "minted_at": "2026-08-13T09:30:00Z",
+        "hop": None,
+    }
+
+    @staticmethod
+    def _rest_item(metadata):
+        item = MagicMock()
+        item.id = "msg-1"
+        item.chat_room_id = "room-1"
+        item.content = "delegated ask"
+        item.sender_id = "user-1"
+        item.sender_type = "User"
+        item.sender_name = "Bob Broker"
+        item.message_type = "text"
+        item.metadata = metadata
+        item.inserted_at = None
+        return item
+
+    @pytest.mark.asyncio
+    async def test_get_next_message_parses_the_envelope(self):
+        from band.core.delegation import DelegationEnvelope
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        response = MagicMock()
+        response.data = self._rest_item({"delegation": dict(self.ENVELOPE)})
+        link.rest.agent_api_messages.get_agent_next_message = AsyncMock(
+            return_value=response
+        )
+
+        msg = await link.get_next_message("room-1")
+
+        assert msg is not None
+        assert isinstance(msg.delegation, DelegationEnvelope)
+        assert msg.delegation.originator is not None
+        assert msg.delegation.originator.handle == "alice.asker"
+        # The raw metadata still carries the envelope for the backlog re-wrap;
+        # only LLM-facing formatting strips it.
+        assert msg.metadata["delegation"] == self.ENVELOPE
+
+    @pytest.mark.asyncio
+    async def test_get_next_message_without_envelope_yields_none(self):
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        response = MagicMock()
+        response.data = self._rest_item({})
+        link.rest.agent_api_messages.get_agent_next_message = AsyncMock(
+            return_value=response
+        )
+
+        msg = await link.get_next_message("room-1")
+
+        assert msg is not None
+        assert msg.delegation is None
+
+    @pytest.mark.asyncio
+    async def test_get_next_message_tolerates_a_malformed_envelope(self):
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        response = MagicMock()
+        response.data = self._rest_item({"delegation": "junk-not-an-envelope"})
+        link.rest.agent_api_messages.get_agent_next_message = AsyncMock(
+            return_value=response
+        )
+
+        msg = await link.get_next_message("room-1")
+
+        assert msg is not None
+        assert msg.delegation is None
+
+    @pytest.mark.asyncio
+    async def test_stale_processing_messages_parse_the_envelope(self):
+        from band.core.delegation import DelegationEnvelope
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        response = MagicMock()
+        response.data = [self._rest_item({"delegation": dict(self.ENVELOPE)})]
+        response.metadata = MagicMock(total_pages=1)
+        link.rest.agent_api_messages.list_agent_messages = AsyncMock(
+            return_value=response
+        )
+
+        messages = await link.get_stale_processing_messages("room-1")
+
+        assert len(messages) == 1
+        assert isinstance(messages[0].delegation, DelegationEnvelope)
+        assert messages[0].delegation.message_id == self.ENVELOPE["message_id"]
+
+
 class TestReportActivity:
     """Tests for BandLink.report_activity (boolean working-state reporting)."""
 

--- a/tests/preprocessing/test_default.py
+++ b/tests/preprocessing/test_default.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 
 from band.client.streaming import MessageCreatedPayload, MessageMetadata
+from band.core.delegation import DelegationEnvelope
 from band.core.protocols import Preprocessor
 from band.core.types import AgentInput, HistoryProvider
 from band.platform.event import (
@@ -15,6 +16,9 @@ from band.preprocessing.default import DefaultPreprocessor
 from band.runtime.types import SessionConfig
 
 
+_DEFAULT_METADATA = object()  # sentinel: "caller didn't pass metadata"
+
+
 def make_message_payload(
     *,
     id: str = "msg-1",
@@ -23,13 +27,16 @@ def make_message_payload(
     sender_type: str = "User",
     room_id: str = "room-1",
     message_type: str = "text",
+    metadata: MessageMetadata | None | object = _DEFAULT_METADATA,
 ) -> MessageCreatedPayload:
     """Create test MessageCreatedPayload."""
+    if metadata is _DEFAULT_METADATA:
+        metadata = MessageMetadata(mentions=[], status="sent")
     return MessageCreatedPayload(
         id=id,
         content=content,
         message_type=message_type,
-        metadata=MessageMetadata(mentions=[], status="sent"),
+        metadata=metadata,  # type: ignore[arg-type]
         sender_id=sender_id,
         sender_type=sender_type,
         chat_room_id=room_id,
@@ -45,6 +52,7 @@ def make_message_event(
     content: str = "Hello",
     sender_id: str = "user-1",
     sender_type: str = "User",
+    metadata: MessageMetadata | None | object = _DEFAULT_METADATA,
 ) -> MessageEvent:
     """Create test MessageEvent."""
     return MessageEvent(
@@ -54,6 +62,7 @@ def make_message_event(
             sender_id=sender_id,
             sender_type=sender_type,
             room_id=room_id,
+            metadata=metadata,
         ),
     )
 
@@ -499,6 +508,121 @@ class TestHistoryLoadingErrors:
         # Should still return AgentInput with empty history
         assert result is not None
         assert len(result.history) == 0
+
+
+class TestDelegationLift:
+    """INT-992: the preprocessor is the single lift point for the platform's
+    identity envelope — parsed once off the inbound metadata and set on
+    ``ctx.delegation`` for handler/tool code. The LLM never sees it (the
+    formatter strips the key from history; format_for_llm renders name +
+    content only)."""
+
+    ENVELOPE = {
+        "version": 1,
+        "originator": {
+            "uuid": "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b",
+            "handle": "alice.asker",
+            "display_name": "Alice Asker",
+        },
+        "message_id": "7f3e9a1b-5c2d-4f6e-8a9b-1c3d5e7f9a2b",
+        "minted_at": "2026-08-13T09:30:00Z",
+        "hop": None,
+    }
+
+    async def _process(self, ctx, event):
+        preprocessor = DefaultPreprocessor()
+        with patch("band.preprocessing.default.AgentTools") as mock_tools:
+            mock_tools.from_context.return_value = MagicMock()
+            with patch(
+                "band.preprocessing.default.check_and_format_participants"
+            ) as mock_participants:
+                mock_participants.return_value = None
+                return await preprocessor.process(ctx, event, agent_id="agent-1")
+
+    async def test_lifts_the_envelope_onto_ctx(self):
+        ctx = make_mock_ctx()
+        metadata = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": dict(self.ENVELOPE)}
+        )
+        event = make_message_event(metadata=metadata)
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        assert isinstance(ctx.delegation, DelegationEnvelope)
+        assert ctx.delegation.originator is not None
+        assert ctx.delegation.originator.handle == "alice.asker"
+        assert ctx.delegation.message_id == self.ENVELOPE["message_id"]
+
+    async def test_clears_a_stale_envelope_when_the_next_message_is_not_delegated(
+        self,
+    ):
+        """ctx.delegation is per-message state: an undelegated message must
+        overwrite the previous turn's envelope with None."""
+        ctx = make_mock_ctx()
+        ctx.delegation = DelegationEnvelope.model_validate(self.ENVELOPE)  # stale
+        event = make_message_event()  # default metadata, no envelope
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        assert ctx.delegation is None
+
+    async def test_none_metadata_lifts_none(self):
+        ctx = make_mock_ctx()
+        ctx.delegation = "stale-sentinel"
+        event = make_message_event(metadata=None)
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        assert ctx.delegation is None
+
+    async def test_malformed_envelope_lifts_none_and_does_not_raise(self):
+        """I3 end to end: a malformed platform envelope arriving over the wire
+        must neither raise nor surface as anything but None."""
+        ctx = make_mock_ctx()
+        payload = MessageCreatedPayload.model_validate(
+            {
+                "id": "msg-1",
+                "content": "Hello",
+                "message_type": "text",
+                "metadata": {
+                    "mentions": [],
+                    "status": "sent",
+                    "delegation": "junk-not-an-envelope",
+                },
+                "sender_id": "user-1",
+                "sender_type": "User",
+                "chat_room_id": "room-1",
+                "inserted_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z",
+            }
+        )
+        event = MessageEvent(room_id="room-1", payload=payload)
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        assert ctx.delegation is None
+
+    async def test_the_envelope_does_not_leak_into_msg_content(self):
+        """The AgentInput message the adapters format for the model carries no
+        envelope content."""
+        ctx = make_mock_ctx()
+        metadata = MessageMetadata.model_validate(
+            {"mentions": [], "status": "sent", "delegation": dict(self.ENVELOPE)}
+        )
+        event = make_message_event(content="delegated ask", metadata=metadata)
+
+        result = await self._process(ctx, event)
+
+        assert result is not None
+        rendered = result.msg.format_for_llm()
+        assert "alice.asker" not in rendered
+        assert "Alice Asker" not in rendered
+        assert "delegation" not in rendered
+        assert rendered.endswith("delegated ask")
 
 
 class TestBootstrapHistoryTruncation:

--- a/tests/runtime/test_custom_tools.py
+++ b/tests/runtime/test_custom_tools.py
@@ -365,3 +365,162 @@ class TestExecuteCustomTool:
         await execute_custom_tool(tool, {"query": "test"})  # No max_results
 
         assert received_args[0].max_results == 10  # Default value
+
+
+class TestContextThreading:
+    """Optional second handler parameter receives the ExecutionContext (INT-994)."""
+
+    @pytest.mark.asyncio
+    async def test_two_param_async_handler_receives_ctx(self):
+        received = []
+
+        async def handler(args: WeatherInput, ctx) -> str:
+            received.append(ctx)
+            return f"{args.city} with ctx"
+
+        sentinel_ctx = object()
+        tool: CustomToolDef = (WeatherInput, handler)
+
+        result = await execute_custom_tool(tool, {"city": "NYC"}, ctx=sentinel_ctx)
+
+        assert result == "NYC with ctx"
+        assert received == [sentinel_ctx]
+
+    @pytest.mark.asyncio
+    async def test_two_param_sync_handler_receives_ctx(self):
+        received = []
+
+        def handler(args: WeatherInput, ctx) -> str:
+            received.append(ctx)
+            return "sync ok"
+
+        sentinel_ctx = object()
+        tool: CustomToolDef = (WeatherInput, handler)
+
+        result = await execute_custom_tool(tool, {"city": "NYC"}, ctx=sentinel_ctx)
+
+        assert result == "sync ok"
+        assert received == [sentinel_ctx]
+
+    @pytest.mark.asyncio
+    async def test_two_param_handler_gets_none_when_no_ctx_threads(self):
+        """An adapter that has not threaded ctx must still run the handler —
+        the second parameter is Optional by contract."""
+        received = []
+
+        async def handler(args: WeatherInput, ctx) -> str:
+            received.append(ctx)
+            return "ok"
+
+        tool: CustomToolDef = (WeatherInput, handler)
+
+        await execute_custom_tool(tool, {"city": "NYC"})
+
+        assert received == [None]
+
+    @pytest.mark.asyncio
+    async def test_one_param_handler_never_sees_ctx(self):
+        """Legacy one-arg handlers keep their exact call shape even when the
+        adapter passes a live ctx."""
+        tool: CustomToolDef = (WeatherInput, async_weather)
+
+        result = await execute_custom_tool(tool, {"city": "NYC"}, ctx=object())
+
+        assert result == "Weather in NYC: Sunny, 72F"
+
+    @pytest.mark.asyncio
+    async def test_zero_arg_handler_unchanged_with_ctx(self):
+        class EmptyInput(BaseModel):
+            """Takes nothing."""
+
+        async def handler() -> str:
+            return "no args at all"
+
+        tool: CustomToolDef = (EmptyInput, handler)
+
+        result = await execute_custom_tool(tool, {}, ctx=object())
+
+        assert result == "no args at all"
+
+    @pytest.mark.asyncio
+    async def test_var_positional_handler_stays_legacy(self):
+        """A (args, *rest) signature is NOT a ctx opt-in — only an explicit
+        second positional parameter is."""
+        received = []
+
+        async def handler(args: WeatherInput, *rest) -> str:
+            received.append(rest)
+            return "legacy"
+
+        tool: CustomToolDef = (WeatherInput, handler)
+
+        await execute_custom_tool(tool, {"city": "NYC"}, ctx=object())
+
+        assert received == [()]
+
+    @pytest.mark.asyncio
+    async def test_invoke_validated_threads_ctx(self):
+        from band.runtime.custom_tools import invoke_validated_custom_tool
+
+        received = []
+
+        async def handler(args: WeatherInput, ctx) -> str:
+            received.append(ctx)
+            return "validated ok"
+
+        sentinel_ctx = object()
+        tool: CustomToolDef = (WeatherInput, handler)
+
+        result = await invoke_validated_custom_tool(
+            tool, WeatherInput(city="LA"), ctx=sentinel_ctx
+        )
+
+        assert result == "validated ok"
+        assert received == [sentinel_ctx]
+
+    @pytest.mark.asyncio
+    async def test_two_param_unhashable_callable_receives_ctx(self):
+        """The arity cache must tolerate unhashable callables, same as the
+        accepts-input path."""
+        received = []
+
+        class UnhashableCtxTool:
+            def __eq__(self, other: object) -> bool:
+                return isinstance(other, UnhashableCtxTool)
+
+            async def __call__(self, args: WeatherInput, ctx) -> str:
+                received.append(ctx)
+                return "unhashable ctx ok"
+
+        sentinel_ctx = object()
+        tool: CustomToolDef = (WeatherInput, UnhashableCtxTool())
+
+        result = await execute_custom_tool(tool, {"city": "SF"}, ctx=sentinel_ctx)
+
+        assert result == "unhashable ctx ok"
+        assert received == [sentinel_ctx]
+
+
+class TestCtxFromTools:
+    """ctx_from_tools — the defensive per-call-site accessor."""
+
+    def test_reads_the_private_ctx_slot(self):
+        from band.runtime.custom_tools import ctx_from_tools
+
+        class ToolsWithCtx:
+            _ctx = "the-execution-context"
+
+        assert ctx_from_tools(ToolsWithCtx()) == "the-execution-context"
+
+    def test_fake_agent_tools_without_slot_yields_none(self):
+        """FakeAgentTools (band.testing) carries no _ctx; call sites must get
+        None, never an AttributeError."""
+        from band.runtime.custom_tools import ctx_from_tools
+        from band.testing import FakeAgentTools
+
+        assert ctx_from_tools(FakeAgentTools()) is None
+
+    def test_none_tools_yields_none(self):
+        from band.runtime.custom_tools import ctx_from_tools
+
+        assert ctx_from_tools(None) is None

--- a/tests/runtime/test_execution.py
+++ b/tests/runtime/test_execution.py
@@ -103,6 +103,13 @@ class TestExecutionContextConstruction:
 
         assert ctx.is_llm_initialized is False
 
+    def test_init_no_delegation(self, mock_link, mock_handler):
+        """The identity envelope (INT-992) starts absent; the preprocessor
+        sets it per message."""
+        ctx = ExecutionContext("room-123", mock_link, mock_handler)
+
+        assert ctx.delegation is None
+
 
 class TestExecutionContextProtocol:
     """Test that ExecutionContext implements Execution protocol."""

--- a/tests/runtime/test_execution.py
+++ b/tests/runtime/test_execution.py
@@ -111,6 +111,62 @@ class TestExecutionContextConstruction:
         assert ctx.delegation is None
 
 
+class TestCredentials:
+    """ctx.credentials — the per-turn delegated-credential resolver (INT-993)."""
+
+    def test_returns_a_resolver_bound_to_the_current_envelope(
+        self, mock_link, mock_handler
+    ):
+        from band.core.delegation import DelegationEnvelope
+        from band.platform.delegation_exchange import CredentialResolver
+
+        ctx = ExecutionContext("room-123", mock_link, mock_handler)
+        envelope = DelegationEnvelope(message_id="msg-1")
+        ctx.delegation = envelope
+
+        resolver = ctx.credentials
+
+        assert isinstance(resolver, CredentialResolver)
+        assert resolver.envelope is envelope
+
+    def test_is_stable_within_one_turn(self, mock_link, mock_handler):
+        """A tool fan-out must share one resolver, or its per-audience cache
+        and single-flight lock would be useless."""
+        from band.core.delegation import DelegationEnvelope
+
+        ctx = ExecutionContext("room-123", mock_link, mock_handler)
+        ctx.delegation = DelegationEnvelope(message_id="msg-1")
+
+        assert ctx.credentials is ctx.credentials
+
+    def test_rebuilds_when_the_envelope_changes(self, mock_link, mock_handler):
+        """A new message's envelope must never see the previous message's
+        token cache — the exchange is scoped to (message, audience)."""
+        from band.core.delegation import DelegationEnvelope
+
+        ctx = ExecutionContext("room-123", mock_link, mock_handler)
+        ctx.delegation = DelegationEnvelope(message_id="msg-1")
+        first = ctx.credentials
+
+        ctx.delegation = DelegationEnvelope(message_id="msg-2")
+        second = ctx.credentials
+
+        assert second is not first
+        assert second.envelope is ctx.delegation
+
+    async def test_without_envelope_token_for_raises_no_delegation(
+        self, mock_link, mock_handler
+    ):
+        """I3: owner-invoked messages have no envelope; the resolver's
+        absence-error explains that instead of an AttributeError or a 404."""
+        from band.platform.delegation_exchange import NoDelegation
+
+        ctx = ExecutionContext("room-123", mock_link, mock_handler)
+
+        with pytest.raises(NoDelegation):
+            await ctx.credentials.token_for("some-connector-id")
+
+
 class TestExecutionContextProtocol:
     """Test that ExecutionContext implements Execution protocol."""
 

--- a/tests/runtime/test_formatters.py
+++ b/tests/runtime/test_formatters.py
@@ -84,7 +84,12 @@ class TestFormatMessageForLlm:
         assert result["message_type"] == "text"
 
     def test_preserves_metadata(self):
-        """Should preserve metadata for adapters that need it (e.g., A2A)."""
+        """Should preserve metadata for adapters that need it (e.g., A2A).
+
+        The single exception is the platform's identity envelope
+        (``metadata["delegation"]``, INT-992): it is for handler/tool code,
+        never the model, so it is the ONLY key stripped at this seam.
+        """
         msg = {
             "sender_type": "Agent",
             "content": "A2A task completed",
@@ -93,6 +98,7 @@ class TestFormatMessageForLlm:
                 "a2a_context_id": "ctx-123",
                 "a2a_task_id": "task-456",
                 "a2a_task_state": "completed",
+                "delegation": _DELEGATION_ENVELOPE,
             },
         }
         result = format_message_for_llm(msg)
@@ -107,6 +113,114 @@ class TestFormatMessageForLlm:
         msg = {"sender_type": "Agent", "content": "Hello"}
         result = format_message_for_llm(msg)
         assert result["metadata"] == {}
+
+
+# The platform's frozen minted shape for the identity envelope (INT-992).
+_DELEGATION_ENVELOPE = {
+    "version": 1,
+    "originator": {
+        "uuid": "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b",
+        "handle": "alice.asker",
+        "display_name": "Alice Asker",
+    },
+    "message_id": "7f3e9a1b-5c2d-4f6e-8a9b-1c3d5e7f9a2b",
+    "minted_at": "2026-08-13T09:30:00Z",
+    "hop": None,
+}
+
+
+class TestDelegationNeverReachesTheLlm:
+    """I1 (INT-992): the identity envelope must never appear in anything
+    formatted for the model. format_message_for_llm is the single choke point
+    every history path goes through (bootstrap hydration and oneshot alike),
+    so the strip lives here and ONLY here — adapter-facing surfaces keep full
+    metadata."""
+
+    def test_strips_only_the_delegation_key(self):
+        msg = {
+            "sender_type": "User",
+            "content": "please check the forecast",
+            "sender_name": "Alice",
+            "metadata": {
+                "delegation": dict(_DELEGATION_ENVELOPE),
+                "a2a_context_id": "ctx-123",
+                "status": "sent",
+            },
+        }
+
+        result = format_message_for_llm(msg)
+
+        assert "delegation" not in result["metadata"]
+        # The adapter contract survives: every other key is untouched.
+        assert result["metadata"]["a2a_context_id"] == "ctx-123"
+        assert result["metadata"]["status"] == "sent"
+
+    def test_no_envelope_content_in_the_formatted_message(self):
+        msg = {
+            "sender_type": "User",
+            "content": "please check the forecast",
+            "sender_name": "Bob Broker",
+            "metadata": {"delegation": dict(_DELEGATION_ENVELOPE)},
+        }
+
+        result = format_message_for_llm(msg)
+
+        rendered = str(result)
+        assert "alice.asker" not in rendered
+        assert "Alice Asker" not in rendered
+        assert "0b7a3c2e-9d1f-4e8a-b6c5-2f4a8d9e1c3b" not in rendered
+        assert "delegation" not in rendered
+
+    def test_does_not_mutate_the_source_metadata(self):
+        """The source dict belongs to the hydrated context cache, which
+        adapter-facing paths keep reading — strip on a copy."""
+        metadata = {
+            "delegation": dict(_DELEGATION_ENVELOPE),
+            "a2a_context_id": "ctx-123",
+        }
+        msg = {"sender_type": "User", "content": "hi", "metadata": metadata}
+
+        format_message_for_llm(msg)
+
+        assert metadata["delegation"] == _DELEGATION_ENVELOPE
+        assert metadata["a2a_context_id"] == "ctx-123"
+
+    def test_metadata_without_envelope_passes_through_unchanged(self):
+        metadata = {"a2a_context_id": "ctx-123", "status": "sent"}
+        msg = {"sender_type": "User", "content": "hi", "metadata": metadata}
+
+        result = format_message_for_llm(msg)
+
+        assert result["metadata"] == {"a2a_context_id": "ctx-123", "status": "sent"}
+
+    def test_history_hydration_never_carries_the_envelope(self):
+        """End to end through format_history_for_llm: a delegated message in
+        hydrated history reaches the model without any envelope content."""
+        messages = [
+            {
+                "id": "m1",
+                "sender_type": "User",
+                "content": "earlier plain message",
+                "metadata": {"status": "sent"},
+            },
+            {
+                "id": "m2",
+                "sender_type": "User",
+                "content": "delegated ask",
+                "metadata": {
+                    "delegation": dict(_DELEGATION_ENVELOPE),
+                    "a2a_context_id": "ctx-123",
+                },
+            },
+        ]
+
+        result = format_history_for_llm(messages)
+
+        rendered = str(result)
+        assert "delegation" not in rendered
+        assert "alice.asker" not in rendered
+        assert result[1]["metadata"]["a2a_context_id"] == "ctx-123"
+        assert result[0]["metadata"] == {"status": "sent"}
 
 
 class TestFormatHistoryForLlm:

--- a/tests/runtime/test_mcp_server.py
+++ b/tests/runtime/test_mcp_server.py
@@ -274,3 +274,74 @@ class TestLocalMcpServer:
                     assert result.structuredContent == {"echo": "hello"}
         finally:
             await server.stop()
+
+
+class TestCustomToolCtxThreading:
+    """INT-994: both custom-registration builders thread the tools' ctx."""
+
+    @pytest.mark.asyncio
+    async def test_custom_registration_threads_agent_tools_ctx(self) -> None:
+        agent_tools = AgentTools("room-123", MagicMock(), [])
+        sentinel_ctx = object()
+        agent_tools._ctx = sentinel_ctx  # type: ignore[assignment]
+
+        received = []
+
+        async def probe(args: EchoInput, ctx) -> dict[str, str]:
+            received.append(ctx)
+            return {"echo": args.message}
+
+        registrations = build_band_mcp_tool_registrations(
+            agent_tools,
+            additional_tools=[(EchoInput, probe)],
+        )
+        registration = next(item for item in registrations if item.name == "echo")
+
+        result = await registration.execute({"message": "hi"})
+
+        assert result == {"echo": "hi"}
+        assert received == [sentinel_ctx]
+
+    @pytest.mark.asyncio
+    async def test_resolved_custom_registration_threads_room_tools_ctx(self) -> None:
+        room_tools = AgentTools("room-123", MagicMock(), [])
+        sentinel_ctx = object()
+        room_tools._ctx = sentinel_ctx  # type: ignore[assignment]
+
+        received = []
+
+        async def probe(args: EchoInput, ctx) -> dict[str, str]:
+            received.append(ctx)
+            return {"echo": args.message}
+
+        registrations = build_resolved_band_mcp_tool_registrations(
+            get_tools={"room-123": room_tools}.get,
+            additional_tools=[(EchoInput, probe)],
+        )
+        registration = next(item for item in registrations if item.name == "echo")
+
+        result = await registration.execute({"room_id": "room-123", "message": "hi"})
+
+        assert result == {"echo": "hi"}
+        assert received == [sentinel_ctx]
+
+    @pytest.mark.asyncio
+    async def test_resolved_custom_tool_still_runs_without_room_tools(self) -> None:
+        """A custom tool needs no AgentTools to execute — an unknown room
+        yields ctx=None, never an error (unlike builtin registrations)."""
+        received = []
+
+        async def probe(args: EchoInput, ctx) -> dict[str, str]:
+            received.append(ctx)
+            return {"echo": args.message}
+
+        registrations = build_resolved_band_mcp_tool_registrations(
+            get_tools=lambda _room_id: None,
+            additional_tools=[(EchoInput, probe)],
+        )
+        registration = next(item for item in registrations if item.name == "echo")
+
+        result = await registration.execute({"room_id": "ghost", "message": "hi"})
+
+        assert result == {"echo": "hi"}
+        assert received == [None]

--- a/tests/test_lazy_exports.py
+++ b/tests/test_lazy_exports.py
@@ -18,7 +18,7 @@ import pytest
 
 from tests.paths import SRC_ROOT
 
-_LAZY_PACKAGES = ("adapters", "converters", "testing")
+_LAZY_PACKAGES = ("adapters", "converters", "platform", "testing")
 
 
 def _package_source(package: str) -> ast.Module:
@@ -97,3 +97,18 @@ def test_unknown_attribute_raises_attribute_error() -> None:
 
     with pytest.raises(AttributeError, match="NoSuchAdapter"):
         band.adapters.NoSuchAdapter
+
+
+def test_platform_exports_the_delegation_exchange_surface() -> None:
+    """The INT-993 public names resolve through band.platform's lazy surface."""
+    from band.platform import (
+        ConsentMissing,
+        CredentialResolver,
+        DelegationError,
+        NoDelegation,
+    )
+    from band.platform import delegation_exchange
+
+    assert CredentialResolver is delegation_exchange.CredentialResolver
+    assert issubclass(ConsentMissing, DelegationError)
+    assert issubclass(NoDelegation, DelegationError)


### PR DESCRIPTION
M2 SDK 3/3. **Stacked on the INT-994 PR** — diff is cumulative until parents merge; the INT-995 increment is the last commit.

`examples/delegation/` — the M2 anchor demo: Bob owns the CRM-specialist agent, Alice @mentions it, and its custom tool acts with **Alice's** connection via `ctx.credentials.token_for(<connector-id>)`. The tool renders the first-run funnel as human guidance: `ConsentMissing` → "grant consent", `ProviderNotConnected` → "connect the provider", using the platform's own remediation strings from INT-993's typed errors.

**The README carries the binding precondition box**: on a stock deployment the exchange is inert — `delegation_credential_mode` defaults `:owner` and currently has no API/UI opt-in surface, so every exchange returns `delegation_denied` until that ships; the walkthrough states the seeded-connector prerequisite instead of overpromising. (Same disclosure the platform's Agent API 1.17.0 changelog makes.)

Offline tests pin the funnel rendering and the README precondition (so the caveat can't be silently dropped). Suite 4659 passed, red set byte-identical to base; ruff (853 files) + pyrefly clean.

Linear: INT-995

🤖 Generated with [Claude Code](https://claude.com/claude-code)