### PR TITLE
fix: Parlant tool descriptions drift from SDK master models

### DIFF
--- a/examples/parlant/01_basic_agent.py
+++ b/examples/parlant/01_basic_agent.py
@@ -86,7 +86,7 @@ async def setup_agent_with_guidelines(
     # When user asks to add someone or wants specialized help
     await agent.create_guideline(
         condition="User asks to add someone to the chat, mentions a specific agent name, or asks for specialized help you can't provide",
-        action="First use band_lookup_peers to find available agents. Then IMMEDIATELY call band_add_participant with the name parameter set to the exact name from the band_lookup_peers result. Do NOT ask for confirmation - just add them. If user wants multiple agents, call band_add_participant once for each.",
+        action="First use band_lookup_peers to find available agents. Then IMMEDIATELY call band_add_participant with the identifier parameter set to the exact identifier from the band_lookup_peers result. Do NOT ask for confirmation - just add them. If user wants multiple agents, call band_add_participant once for each.",
         tools=tools,
     )
 
@@ -107,7 +107,7 @@ async def setup_agent_with_guidelines(
     # When user asks to remove someone
     await agent.create_guideline(
         condition="User asks to remove someone from the chat",
-        action="Use band_remove_participant with the name parameter set to the exact name to remove",
+        action="Use band_remove_participant with the identifier parameter set to the exact identifier to remove",
         tools=tools,
     )
 

--- a/src/band/core/types.py
+++ b/src/band/core/types.py
@@ -40,6 +40,13 @@ class ToolEventKey(StrEnum):
 # event kinds. Derived from MessageType so the taxonomy stays single-sourced.
 EventMessageType = Literal[MessageType.THOUGHT, MessageType.ERROR, MessageType.TASK]
 
+# Status filter vocabulary shared by every list-contact-requests-family tool
+# (master models and each adapter's own schema), so the choices have one
+# definition instead of a hand-copied tuple per call site.
+ContactRequestSentStatus = Literal[
+    "pending", "approved", "rejected", "cancelled", "all"
+]
+
 
 class Capability(str, Enum):
     """Platform tool categories an adapter can expose to the LLM.

--- a/src/band/integrations/parlant/tools.py
+++ b/src/band/integrations/parlant/tools.py
@@ -22,14 +22,16 @@ NOTE: We intentionally do NOT use `from __future__ import annotations` here
 because Parlant's @p.tool decorator checks annotation types at runtime.
 """
 
+import inspect
 import json
 import logging
 import warnings
-from typing import Any, Callable, Optional
+from typing import Annotated, Any, Callable, Optional
 
 from band.core.exceptions import BandToolError
 from band.core.types import AdapterFeatures, Capability
 from band.runtime.tools import (
+    TOOL_MODELS,
     append_available_mention_handles,
     get_tool_description,
     serialize_tool_result,
@@ -53,6 +55,14 @@ _session_message_sent: dict[str, bool] = {}
 SEND_MESSAGE_MENTIONS_NOTE = (
     "\n\nThis tool's mentions argument is a single string: separate multiple "
     'handles with commas, e.g. "@alice, @bob/agent".'
+)
+
+# Same divergence as SEND_MESSAGE_MENTIONS_NOTE, appended to the per-argument
+# description instead of the tool-level one: the master field's list-oriented
+# text would otherwise reach the LLM unqualified for this comma-separated param.
+SEND_MESSAGE_MENTIONS_PARAM_NOTE = (
+    " This tool takes it as a single comma-separated string, not a list, "
+    'e.g. "@alice, @bob/agent".'
 )
 
 # The master model describes lookup_peers' raw return shape (a 'data'/'metadata'
@@ -134,28 +144,65 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
     """
     try:
         import parlant.sdk as p  # type: ignore[missing-import]
-        from parlant.core.tools import ToolContext, ToolResult  # type: ignore[missing-import]
+        from parlant.core.tools import (  # type: ignore[missing-import]
+            ToolContext,
+            ToolParameterOptions,
+            ToolResult,
+        )
     except ImportError:
         logger.warning("Parlant SDK not installed, skipping tool creation")
         return []
 
-    def band_tool(extra_doc: str = "") -> Callable[[Callable[..., Any]], Any]:
-        """Decorator: describe *func* from its master model, then register it.
+    def band_tool(
+        extra_doc: str = "",
+        param_overrides: dict[str, str] | None = None,
+    ) -> Callable[[Callable[..., Any]], Any]:
+        """Decorator: describe *func* and its parameters from the master model, then register it.
 
         The tool name is never retyped as a string — it's ``func.__name__``,
         which is always written to match its ``TOOL_MODELS`` entry (e.g. the
         function below is literally named ``band_send_message``). ``extra_doc``
-        appends prose the master model can't express (a Parlant-only argument
-        shape); it never replaces the master text.
+        appends prose the master tool description can't express (a
+        Parlant-only argument shape); ``param_overrides`` does the same per
+        argument, keyed by parameter name. Neither ever replaces master text —
+        only appends — so a master model edit keeps propagating.
+
+        Parlant's own schema builder never reads a docstring's ``Args:``
+        section (unlike pydantic-ai's griffe parser) — a parameter only gets a
+        description if its type annotation is
+        ``Annotated[T, ToolParameterOptions(description=...)]``. So this also
+        wraps each parameter's annotation from the master model's
+        ``Field(description=...)`` before registering, skipping ``context``
+        (must stay exactly ``ToolContext``) and any parameter with no master
+        description.
         """
 
         def decorator(func: Callable[..., Any]) -> Any:
             func.__doc__ = get_tool_description(func.__name__).rstrip() + extra_doc
+
+            model = TOOL_MODELS.get(func.__name__)
+            if model is not None:
+                for param_name, param in inspect.signature(func).parameters.items():
+                    if param_name == "context":
+                        continue
+                    field = model.model_fields.get(param_name)
+                    description = field.description if field else None
+                    if not description:
+                        continue
+                    if param_overrides and param_name in param_overrides:
+                        description = description.rstrip() + param_overrides[param_name]
+                    func.__annotations__[param_name] = Annotated[
+                        param.annotation, ToolParameterOptions(description=description)
+                    ]
+
             return p.tool(func)
 
         return decorator
 
-    @band_tool(SEND_MESSAGE_MENTIONS_NOTE)
+    @band_tool(
+        SEND_MESSAGE_MENTIONS_NOTE,
+        param_overrides={"mentions": SEND_MESSAGE_MENTIONS_PARAM_NOTE},
+    )
     async def band_send_message(
         context: ToolContext,
         content: str,

--- a/src/band/integrations/parlant/tools.py
+++ b/src/band/integrations/parlant/tools.py
@@ -26,7 +26,7 @@ import inspect
 import json
 import logging
 import warnings
-from typing import Annotated, Any, Callable, Optional
+from typing import Annotated, Any, Callable, Literal, Optional, get_args, get_origin
 
 from band.core.exceptions import BandToolError
 from band.core.types import AdapterFeatures, Capability
@@ -73,6 +73,22 @@ LOOKUP_PEERS_RETURN_NOTE = (
     "\n\nThis tool returns a formatted text summary of matching agents, not "
     "the 'data'/'metadata' dict described above."
 )
+
+
+def _literal_choices(annotation: Any) -> tuple[str, ...] | None:
+    """String choices of a master field's ``Literal[...]`` annotation, if any.
+
+    Parlant's schema builder turns a real ``enum.Enum`` class into a JSON
+    Schema ``enum``, but a bare ``Literal[...]`` isn't one — it falls into
+    the builder's list-only generic-container branch and raises. So a
+    Literal-typed master field can't be passed through as the parameter's own
+    annotation; its choices are folded into the description as prose instead.
+    """
+    if get_origin(annotation) is Literal:
+        args = get_args(annotation)
+        if args and all(isinstance(a, str) for a in args):
+            return args
+    return None
 
 
 def set_session_tools(session_id: str, tools: Optional[Any]) -> None:
@@ -174,7 +190,11 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
         wraps each parameter's annotation from the master model's
         ``Field(description=...)`` before registering, skipping ``context``
         (must stay exactly ``ToolContext``) and any parameter with no master
-        description.
+        description. A master field typed ``Literal[...]`` has its string
+        choices folded into that same description text (see
+        ``_literal_choices``) — the function keeps its own ``str``
+        annotation, since handing Parlant the ``Literal`` itself crashes
+        registration.
         """
 
         def decorator(func: Callable[..., Any]) -> Any:
@@ -189,6 +209,12 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
                     description = field.description if field else None
                     if not description:
                         continue
+                    if field is not None and (
+                        choices := _literal_choices(field.annotation)
+                    ):
+                        description = (
+                            description.rstrip() + f" One of: {', '.join(choices)}."
+                        )
                     if param_overrides and param_name in param_overrides:
                         description = description.rstrip() + param_overrides[param_name]
                     func.__annotations__[param_name] = Annotated[

--- a/src/band/integrations/parlant/tools.py
+++ b/src/band/integrations/parlant/tools.py
@@ -48,9 +48,20 @@ _session_message_sent: dict[str, bool] = {}
 # Parlant tools take mentions as a comma-separated string, not the master
 # model's list[str], so the master description needs this appended — it is
 # genuinely Parlant-specific and not something get_tool_description() covers.
+# Phrased without "array"/"list" wording so it doesn't read as contradicting
+# the master text's "mentions array" line right above it.
 SEND_MESSAGE_MENTIONS_NOTE = (
-    "\n\nPass mentions as a single comma-separated string "
-    '(e.g., "@alice, @bob/agent"), not a list.'
+    "\n\nThis tool's mentions argument is a single string: separate multiple "
+    'handles with commas, e.g. "@alice, @bob/agent".'
+)
+
+# The master model describes lookup_peers' raw return shape (a 'data'/'metadata'
+# dict) for adapters that pass it through unchanged. This Parlant tool formats
+# that result into a plain-text summary instead, so the master claim would be
+# wrong here without this correction.
+LOOKUP_PEERS_RETURN_NOTE = (
+    "\n\nThis tool returns a formatted text summary of matching agents, not "
+    "the 'data'/'metadata' dict described above."
 )
 
 
@@ -139,7 +150,7 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
         """
 
         def decorator(func: Callable[..., Any]) -> Any:
-            func.__doc__ = get_tool_description(func.__name__) + extra_doc
+            func.__doc__ = get_tool_description(func.__name__).rstrip() + extra_doc
             return p.tool(func)
 
         return decorator
@@ -297,7 +308,7 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
             )
             return ToolResult(data=f"Error removing participant '{identifier}': {e}")
 
-    @band_tool()
+    @band_tool(LOOKUP_PEERS_RETURN_NOTE)
     async def band_lookup_peers(
         context: ToolContext,
     ) -> ToolResult:

--- a/src/band/integrations/parlant/tools.py
+++ b/src/band/integrations/parlant/tools.py
@@ -5,18 +5,18 @@ These tools are defined at server startup and use a session-keyed registry
 to access the current room's tools during execution.
 
 This module provides the same tools as LangGraph/Claude adapters:
-- send_message: Send messages to the chat room
-- send_event: Send events (thought, error, task)
-- add_participant: Add agents/users to the room
-- remove_participant: Remove participants
-- lookup_peers: Find available agents
-- get_participants: List current participants
-- create_chatroom: Create new rooms
-- list_contacts: List agent's contacts
-- add_contact: Send a contact request
-- remove_contact: Remove an existing contact
-- list_contact_requests: List received and sent requests
-- respond_contact_request: Approve, reject, or cancel requests
+- band_send_message: Send messages to the chat room
+- band_send_event: Send events (thought, error, task)
+- band_add_participant: Add agents/users to the room
+- band_remove_participant: Remove participants
+- band_lookup_peers: Find available agents
+- band_get_participants: List current participants
+- band_create_chatroom: Create new rooms
+- band_list_contacts: List agent's contacts
+- band_add_contact: Send a contact request
+- band_remove_contact: Remove an existing contact
+- band_list_contact_requests: List received and sent requests
+- band_respond_contact_request: Approve, reject, or cancel requests
 
 NOTE: We intentionally do NOT use `from __future__ import annotations` here
 because Parlant's @p.tool decorator checks annotation types at runtime.
@@ -25,12 +25,13 @@ because Parlant's @p.tool decorator checks annotation types at runtime.
 import json
 import logging
 import warnings
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from band.core.exceptions import BandToolError
 from band.core.types import AdapterFeatures, Capability
 from band.runtime.tools import (
     append_available_mention_handles,
+    get_tool_description,
     serialize_tool_result,
 )
 
@@ -43,6 +44,14 @@ _session_tools: dict[str, Any] = {}
 # Track whether send_message was called for each session
 # This helps the adapter know if it needs to forward Parlant's response
 _session_message_sent: dict[str, bool] = {}
+
+# Parlant tools take mentions as a comma-separated string, not the master
+# model's list[str], so the master description needs this appended — it is
+# genuinely Parlant-specific and not something get_tool_description() covers.
+SEND_MESSAGE_MENTIONS_NOTE = (
+    "\n\nPass mentions as a single comma-separated string "
+    '(e.g., "@alice, @bob/agent"), not a list.'
+)
 
 
 def set_session_tools(session_id: str, tools: Optional[Any]) -> None:
@@ -119,26 +128,28 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
         logger.warning("Parlant SDK not installed, skipping tool creation")
         return []
 
-    @p.tool
+    def band_tool(extra_doc: str = "") -> Callable[[Callable[..., Any]], Any]:
+        """Decorator: describe *func* from its master model, then register it.
+
+        The tool name is never retyped as a string — it's ``func.__name__``,
+        which is always written to match its ``TOOL_MODELS`` entry (e.g. the
+        function below is literally named ``band_send_message``). ``extra_doc``
+        appends prose the master model can't express (a Parlant-only argument
+        shape); it never replaces the master text.
+        """
+
+        def decorator(func: Callable[..., Any]) -> Any:
+            func.__doc__ = get_tool_description(func.__name__) + extra_doc
+            return p.tool(func)
+
+        return decorator
+
+    @band_tool(SEND_MESSAGE_MENTIONS_NOTE)
     async def band_send_message(
         context: ToolContext,
         content: str,
         mentions: str,
     ) -> ToolResult:
-        """
-        Send a message to the chat room.
-
-        Use this to respond to users or other agents. Messages require @mentions
-        to reach users. You MUST use this tool to communicate.
-
-        Args:
-            context: Parlant tool context (automatically provided)
-            content: The message content to send
-            mentions: Comma-separated list of participant handles to @mention (e.g., "@alice, @bob/agent")
-
-        Returns:
-            Confirmation of message sent or error
-        """
         logger.info(
             "[Parlant Tool] send_message called: session=%s, content=%s..., mentions=%s",
             context.session_id,
@@ -182,25 +193,12 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
                 )
             return ToolResult(data=f"Error sending message: {error}")
 
-    @p.tool
+    @band_tool()
     async def band_send_event(
         context: ToolContext,
         content: str,
         message_type: str,
     ) -> ToolResult:
-        """
-        Send an event to the chat room. No mentions required.
-
-        Use this to share your reasoning or report status.
-
-        Args:
-            context: Parlant tool context (automatically provided)
-            content: Human-readable event content
-            message_type: Type of event - 'thought' (share reasoning), 'error' (report problem), or 'task' (report progress)
-
-        Returns:
-            Confirmation of event sent or error
-        """
         logger.info(
             "[Parlant Tool] send_event called: session=%s, type=%s",
             context.session_id,
@@ -227,25 +225,11 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
             logger.error("[Parlant Tool] Error sending event: %s", e, exc_info=True)
             return ToolResult(data=f"Error sending event: {e}")
 
-    @p.tool
+    @band_tool()
     async def band_add_participant(
         context: ToolContext,
         identifier: str,
     ) -> ToolResult:
-        """
-        Invite an agent or user to join this chat room.
-
-        Args:
-            context: Parlant tool context (automatically provided)
-            identifier: REQUIRED - Handle, name, or ID of the agent to add. Prefer the exact ID returned by lookup_peers; handles are mainly for mentions. Use lookup_peers to find available agents.
-
-        Returns:
-            Success message or error description
-
-        Example calls:
-            add_participant(identifier="pirate-captain")
-            add_participant(identifier="Research Agent")
-        """
         logger.info(
             "[Parlant Tool] add_participant called: session=%s, identifier=%s",
             context.session_id,
@@ -280,25 +264,11 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
             )
             return ToolResult(data=f"Error adding participant '{identifier}': {e}")
 
-    @p.tool
+    @band_tool()
     async def band_remove_participant(
         context: ToolContext,
         identifier: str,
     ) -> ToolResult:
-        """
-        Remove a participant from this chat room.
-
-        Args:
-            context: Parlant tool context (automatically provided)
-            identifier: REQUIRED - Handle, name, or ID of the participant to remove.
-
-        Returns:
-            Success message or error description
-
-        Example calls:
-            remove_participant(identifier="pirate-captain")
-            remove_participant(identifier="Research Agent")
-        """
         logger.info(
             "[Parlant Tool] remove_participant called: session=%s, identifier=%s",
             context.session_id,
@@ -327,22 +297,10 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
             )
             return ToolResult(data=f"Error removing participant '{identifier}': {e}")
 
-    @p.tool
+    @band_tool()
     async def band_lookup_peers(
         context: ToolContext,
     ) -> ToolResult:
-        """
-        List available peers (agents and users) that can be added to this room.
-
-        Automatically excludes peers already in the room. Use this to find
-        specialized agents when you cannot answer a question directly.
-
-        Args:
-            context: Parlant tool context (automatically provided)
-
-        Returns:
-            List of available agents with their names and descriptions
-        """
         logger.info(
             "[Parlant Tool] lookup_peers called: session=%s", context.session_id
         )
@@ -378,19 +336,10 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
             logger.error("[Parlant Tool] Error looking up peers: %s", e, exc_info=True)
             return ToolResult(data=f"Error looking up peers: {e}")
 
-    @p.tool
+    @band_tool()
     async def band_get_participants(
         context: ToolContext,
     ) -> ToolResult:
-        """
-        Get the list of all participants currently in the chat room.
-
-        Args:
-            context: Parlant tool context (automatically provided)
-
-        Returns:
-            List of current participants with their names and types
-        """
         logger.info(
             "[Parlant Tool] get_participants called: session=%s", context.session_id
         )
@@ -423,21 +372,11 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
             )
             return ToolResult(data=f"Error getting participants: {e}")
 
-    @p.tool
+    @band_tool()
     async def band_create_chatroom(
         context: ToolContext,
         task_id: str = "",
     ) -> ToolResult:
-        """
-        Create a new chat room for a specific task or conversation.
-
-        Args:
-            context: Parlant tool context (automatically provided)
-            task_id: Optional task ID to associate with the room
-
-        Returns:
-            The ID of the newly created room
-        """
         logger.info(
             "[Parlant Tool] create_chatroom called: session=%s, task_id=%s",
             context.session_id,
@@ -461,23 +400,12 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
 
     include_contacts = features is None or Capability.CONTACTS in features.capabilities
 
-    @p.tool
+    @band_tool()
     async def band_list_contacts(
         context: ToolContext,
         page: int = 1,
         page_size: int = 50,
     ) -> ToolResult:
-        """
-        List agent's contacts with pagination.
-
-        Args:
-            context: Parlant tool context (automatically provided)
-            page: Page number (default 1)
-            page_size: Items per page (default 50, max 100)
-
-        Returns:
-            JSON with contacts list and pagination metadata
-        """
         logger.info(
             "[Parlant Tool] list_contacts called: session=%s, page=%s",
             context.session_id,
@@ -500,26 +428,12 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
             logger.error("[Parlant Tool] Error listing contacts: %s", e, exc_info=True)
             return ToolResult(data=f"Error listing contacts: {e}")
 
-    @p.tool
+    @band_tool()
     async def band_add_contact(
         context: ToolContext,
         handle: str,
         message: str = "",
     ) -> ToolResult:
-        """
-        Send a contact request to add someone as a contact.
-
-        Returns 'pending' when request is created, 'approved' when inverse
-        request existed and was auto-accepted.
-
-        Args:
-            context: Parlant tool context (automatically provided)
-            handle: Handle of user/agent to add (e.g., '@john' or '@john/agent-name')
-            message: Optional message with the request
-
-        Returns:
-            Status of the contact request
-        """
         logger.info(
             "[Parlant Tool] add_contact called: session=%s, handle=%s",
             context.session_id,
@@ -544,25 +458,12 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
             logger.error("[Parlant Tool] Error adding contact: %s", e, exc_info=True)
             return ToolResult(data=f"Error adding contact: {e}")
 
-    @p.tool
+    @band_tool()
     async def band_remove_contact(
         context: ToolContext,
         handle: str = "",
         contact_id: str = "",
     ) -> ToolResult:
-        """
-        Remove an existing contact by handle or contact ID.
-
-        Provide either handle or contact_id (at least one required).
-
-        Args:
-            context: Parlant tool context (automatically provided)
-            handle: Contact's handle (e.g., '@john')
-            contact_id: Or contact record ID (UUID)
-
-        Returns:
-            Confirmation of contact removal
-        """
         logger.info(
             "[Parlant Tool] remove_contact called: session=%s, handle=%s, contact_id=%s",
             context.session_id,
@@ -592,28 +493,13 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
             logger.error("[Parlant Tool] Error removing contact: %s", e, exc_info=True)
             return ToolResult(data=f"Error removing contact: {e}")
 
-    @p.tool
+    @band_tool()
     async def band_list_contact_requests(
         context: ToolContext,
         page: int = 1,
         page_size: int = 50,
         sent_status: str = "pending",
     ) -> ToolResult:
-        """
-        List both received and sent contact requests.
-
-        Received requests are always filtered to pending status.
-        Sent requests can be filtered by status.
-
-        Args:
-            context: Parlant tool context (automatically provided)
-            page: Page number (default 1)
-            page_size: Items per page per direction (default 50, max 100)
-            sent_status: Filter sent requests by status: 'pending', 'approved', 'rejected', 'cancelled', or 'all'
-
-        Returns:
-            JSON with received and sent request lists and metadata
-        """
         logger.info(
             "[Parlant Tool] list_contact_requests called: session=%s, sent_status=%s",
             context.session_id,
@@ -638,31 +524,13 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
             )
             return ToolResult(data=f"Error listing contact requests: {e}")
 
-    @p.tool
+    @band_tool()
     async def band_respond_contact_request(
         context: ToolContext,
         action: str,
         handle: str = "",
         request_id: str = "",
     ) -> ToolResult:
-        """
-        Respond to a contact request.
-
-        Actions:
-        - 'approve'/'reject': For requests you RECEIVED (handle = requester's handle)
-        - 'cancel': For requests you SENT (handle = recipient's handle)
-
-        Provide either handle or request_id (at least one required).
-
-        Args:
-            context: Parlant tool context (automatically provided)
-            action: Action to take - 'approve', 'reject', or 'cancel'
-            handle: Other party's handle
-            request_id: Or request ID (UUID)
-
-        Returns:
-            Status of the response action
-        """
         logger.info(
             "[Parlant Tool] respond_contact_request called: session=%s, action=%s",
             context.session_id,

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -31,7 +31,7 @@ from band.core.memory_types import (
 )
 from band.core.protocols import AgentToolsProtocol
 from band.core.tool_filter import sanitize_tool_schema
-from band.core.types import EventMessageType
+from band.core.types import ContactRequestSentStatus, EventMessageType
 
 if TYPE_CHECKING:
     from anthropic.types import ToolParam
@@ -333,7 +333,7 @@ class ListContactRequestsInput(BaseModel):
     page_size: int = Field(
         50, description="Items per page per direction (max 100)", ge=1, le=100
     )
-    sent_status: Literal["pending", "approved", "rejected", "cancelled", "all"] = Field(
+    sent_status: ContactRequestSentStatus = Field(
         "pending", description="Filter sent requests by status"
     )
 
@@ -524,14 +524,12 @@ class ListReceivedContactRequestsInput(BaseModel):
 class ListSentContactRequestsInput(BaseModel):
     """List contact requests sent by the user."""
 
-    status: Literal["pending", "approved", "rejected", "cancelled", "all"] | None = (
-        Field(
-            None,
-            description=(
-                "Filter by status: 'pending', 'approved', 'rejected', "
-                "'cancelled', or 'all' (optional)."
-            ),
-        )
+    status: ContactRequestSentStatus | None = Field(
+        None,
+        description=(
+            "Filter by status: 'pending', 'approved', 'rejected', "
+            "'cancelled', or 'all' (optional)."
+        ),
     )
     page: int | None = Field(None, description="Page number for pagination (optional).")
     page_size: int | None = Field(

--- a/tests/integrations/parlant/test_tools.py
+++ b/tests/integrations/parlant/test_tools.py
@@ -1,19 +1,24 @@
 """Tests for Parlant tools module."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from band.core.exceptions import BandToolError
+from band.core.types import AdapterFeatures, Capability
 from band.integrations.parlant.tools import (
     _session_message_sent,
     _session_tools,
     create_parlant_tools,
+    get_current_tools,
     get_session_tools,
     mark_message_sent,
+    set_current_tools,
     set_session_tools,
     was_message_sent,
 )
-from band.runtime.tools import get_tool_description
+from band.runtime.tools import TOOL_MODELS
 
 try:
     import parlant.sdk  # noqa: F401
@@ -119,22 +124,16 @@ class TestDeprecatedFunctions:
 
     def test_set_current_tools_emits_deprecation_warning(self):
         """Should emit deprecation warning."""
-        from band.integrations.parlant.tools import set_current_tools
-
         with pytest.warns(DeprecationWarning, match="set_current_tools is deprecated"):
             set_current_tools(MagicMock())
 
     def test_get_current_tools_emits_deprecation_warning(self):
         """Should emit deprecation warning."""
-        from band.integrations.parlant.tools import get_current_tools
-
         with pytest.warns(DeprecationWarning, match="get_current_tools is deprecated"):
             get_current_tools()
 
     def test_get_current_tools_returns_none(self):
         """Should return None (tools now accessed via session_id)."""
-        from band.integrations.parlant.tools import get_current_tools
-
         with pytest.warns(DeprecationWarning):
             result = get_current_tools()
 
@@ -190,15 +189,30 @@ class TestCreateParlantTools:
         for entry in tools:
             assert entry.tool.description, f"Tool {entry.tool.name} has no description"
 
-    def test_descriptions_match_master_source(self):
-        """Every description must derive from get_tool_description(), not a
-        hand-written docstring that can silently drift from the master model."""
+    def test_description_reflects_master_model_edit(self, monkeypatch):
+        """A master model docstring edit must reach the Parlant tool description.
+
+        Mutates the actual source (``TOOL_MODELS`` docstrings) rather than
+        re-deriving the expected text through ``get_tool_description()`` — the
+        function under test's own dependency — so this can't pass on a
+        hand-written docstring that coincidentally matches today's master text.
+        That's the regression this fix closes: Parlant tools used to hand-write
+        their own docs instead of reading the master model at all.
+        """
+        for name, model in TOOL_MODELS.items():
+            sentinel = f"SENTINEL DOCSTRING FOR {name}"
+            monkeypatch.setattr(model, "__doc__", sentinel)
+
         tools = create_parlant_tools()
+        checked = 0
         for entry in tools:
-            master = get_tool_description(entry.tool.name)
-            assert entry.tool.description.startswith(master), (
-                f"{entry.tool.name} description has drifted from its master model"
-            )
+            if entry.tool.name not in TOOL_MODELS:
+                continue
+            checked += 1
+            assert f"SENTINEL DOCSTRING FOR {entry.tool.name}" in entry.tool.description
+        assert checked == len(tools), (
+            "expected every Parlant tool to have a master model"
+        )
 
     def test_send_message_tool_has_required_parameters(self):
         """send_message should have content and mentions parameters."""
@@ -249,8 +263,6 @@ class TestCreateParlantTools:
 
     def test_excludes_contact_tools_without_capability(self):
         """Contact tools excluded when CONTACTS capability is absent."""
-        from band.core.types import AdapterFeatures
-
         tools = create_parlant_tools(features=AdapterFeatures())
         tool_names = [t.tool.name for t in tools]
 
@@ -264,8 +276,6 @@ class TestCreateParlantTools:
 
     def test_includes_contact_tools_with_capability(self):
         """Contact tools included when CONTACTS capability is present."""
-        from band.core.types import AdapterFeatures, Capability
-
         tools = create_parlant_tools(
             features=AdapterFeatures(capabilities={Capability.CONTACTS})
         )
@@ -333,8 +343,6 @@ class TestParlantToolFunctions:
         ``MagicMock(spec=ToolContext)`` is not used because ``ToolContext``
         lives in ``parlant.core.tools`` which may not be installed.
         """
-        from types import SimpleNamespace
-
         return SimpleNamespace(session_id="test-session-123")
 
     @pytest.fixture
@@ -409,8 +417,6 @@ class TestParlantToolFunctions:
         failure value so the LLM can recover, instead of letting the exception
         crash the turn.
         """
-        from band.core.exceptions import BandToolError
-
         mock_tools.send_message.side_effect = BandToolError(
             "Backend rejected message: 503 Service Unavailable"
         )

--- a/tests/integrations/parlant/test_tools.py
+++ b/tests/integrations/parlant/test_tools.py
@@ -1,6 +1,7 @@
 """Tests for Parlant tools module."""
 
 from types import SimpleNamespace
+from typing import get_args
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -18,7 +19,7 @@ from band.integrations.parlant.tools import (
     set_session_tools,
     was_message_sent,
 )
-from band.runtime.tools import TOOL_MODELS
+from band.runtime.tools import TOOL_MODELS, ListContactRequestsInput
 
 try:
     import parlant.sdk  # noqa: F401
@@ -291,6 +292,26 @@ class TestCreateParlantTools:
 
         assert description is not None
         assert "comma" in description
+
+    def test_list_contact_requests_sent_status_description_lists_literal_choices(self):
+        """sent_status's master field is Literal[...]; handing that type to
+        Parlant directly crashes tool registration (Parlant's schema builder
+        only turns a real enum.Enum into an ``enum``), so its choices must
+        reach the LLM as prose in the description instead of vanishing.
+        """
+        choices = get_args(
+            ListContactRequestsInput.model_fields["sent_status"].annotation
+        )
+
+        tools = create_parlant_tools(
+            features=AdapterFeatures(capabilities={Capability.CONTACTS})
+        )
+        entry = next(t for t in tools if t.tool.name == "band_list_contact_requests")
+        description = entry.tool.parameters["sent_status"][1].description
+
+        assert description is not None
+        for choice in choices:
+            assert choice in description
 
     def test_send_message_tool_has_required_parameters(self):
         """send_message should have content and mentions parameters."""

--- a/tests/integrations/parlant/test_tools.py
+++ b/tests/integrations/parlant/test_tools.py
@@ -214,6 +214,84 @@ class TestCreateParlantTools:
             "expected every Parlant tool to have a master model"
         )
 
+    def test_tool_parameters_have_descriptions(self):
+        """Every tool argument should carry a description, not just the tool itself.
+
+        Parlant's schema builder never reads a docstring's Args: section (unlike
+        pydantic-ai's griffe parser) — a parameter only gets a description via
+        Annotated[T, ToolParameterOptions(description=...)] on its type
+        annotation. Without that, every argument silently reaches the LLM with
+        no description at all.
+        """
+        tools = create_parlant_tools()
+
+        missing = [
+            (entry.tool.name, param_name)
+            for entry in tools
+            for param_name, (_, options) in entry.tool.parameters.items()
+            if not options.description
+        ]
+        assert not missing, f"parameters with no description: {missing}"
+
+    def test_parameter_description_reflects_master_model_field_edit(self, monkeypatch):
+        """A master field description edit must reach the Parlant parameter schema.
+
+        Same mutation-test shape as test_description_reflects_master_model_edit,
+        applied per argument instead of per tool. Scoped to parameters Parlant's
+        tool functions actually accept — some master fields (e.g.
+        AddParticipantInput.role, SendEventInput.metadata, both LookupPeersInput
+        fields) aren't exposed as Parlant parameters at all; the tool hardcodes
+        that value internally instead.
+        """
+        baseline_params = {
+            (entry.tool.name, param_name)
+            for entry in create_parlant_tools()
+            for param_name in entry.tool.parameters
+        }
+
+        sentinels: dict[tuple[str, str], str] = {}
+        for tool_name, model in TOOL_MODELS.items():
+            for field_name, field in model.model_fields.items():
+                if (
+                    tool_name,
+                    field_name,
+                ) not in baseline_params or not field.description:
+                    continue
+                sentinel = f"SENTINEL FIELD DESC FOR {tool_name}.{field_name}"
+                monkeypatch.setattr(field, "description", sentinel)
+                sentinels[(tool_name, field_name)] = sentinel
+
+        tools = create_parlant_tools()
+        checked = 0
+        for entry in tools:
+            for param_name, (_, options) in entry.tool.parameters.items():
+                sentinel = sentinels.get((entry.tool.name, param_name))
+                if sentinel is None:
+                    continue
+                checked += 1
+                assert options.description is not None
+                assert options.description.startswith(sentinel)
+        assert checked == len(sentinels), (
+            "expected every field-described master parameter to reach Parlant"
+        )
+
+    def test_send_message_mentions_param_notes_comma_separated_shape(self):
+        """mentions is a comma-separated string in Parlant, not the master's list[str].
+
+        The per-argument description must say so, not just the tool-level docstring —
+        otherwise an LLM asking about this one argument sees the master's
+        list-oriented wording unqualified.
+        """
+        tools = create_parlant_tools()
+
+        send_message_entry = next(
+            t for t in tools if t.tool.name == "band_send_message"
+        )
+        description = send_message_entry.tool.parameters["mentions"][1].description
+
+        assert description is not None
+        assert "comma" in description
+
     def test_send_message_tool_has_required_parameters(self):
         """send_message should have content and mentions parameters."""
         tools = create_parlant_tools()

--- a/tests/integrations/parlant/test_tools.py
+++ b/tests/integrations/parlant/test_tools.py
@@ -191,8 +191,7 @@ class TestCreateParlantTools:
 
     def test_descriptions_match_master_source(self):
         """Every description must derive from get_tool_description(), not a
-        hand-written docstring that can silently drift from the master model
-        (INT-1170)."""
+        hand-written docstring that can silently drift from the master model."""
         from band.runtime.tools import get_tool_description
 
         tools = create_parlant_tools()

--- a/tests/integrations/parlant/test_tools.py
+++ b/tests/integrations/parlant/test_tools.py
@@ -13,6 +13,7 @@ from band.integrations.parlant.tools import (
     set_session_tools,
     was_message_sent,
 )
+from band.runtime.tools import get_tool_description
 
 try:
     import parlant.sdk  # noqa: F401
@@ -192,8 +193,6 @@ class TestCreateParlantTools:
     def test_descriptions_match_master_source(self):
         """Every description must derive from get_tool_description(), not a
         hand-written docstring that can silently drift from the master model."""
-        from band.runtime.tools import get_tool_description
-
         tools = create_parlant_tools()
         for entry in tools:
             master = get_tool_description(entry.tool.name)

--- a/tests/integrations/parlant/test_tools.py
+++ b/tests/integrations/parlant/test_tools.py
@@ -189,6 +189,19 @@ class TestCreateParlantTools:
         for entry in tools:
             assert entry.tool.description, f"Tool {entry.tool.name} has no description"
 
+    def test_descriptions_match_master_source(self):
+        """Every description must derive from get_tool_description(), not a
+        hand-written docstring that can silently drift from the master model
+        (INT-1170)."""
+        from band.runtime.tools import get_tool_description
+
+        tools = create_parlant_tools()
+        for entry in tools:
+            master = get_tool_description(entry.tool.name)
+            assert entry.tool.description.startswith(master), (
+                f"{entry.tool.name} description has drifted from its master model"
+            )
+
     def test_send_message_tool_has_required_parameters(self):
         """send_message should have content and mentions parameters."""
         tools = create_parlant_tools()


### PR DESCRIPTION
## Summary
- Parlant hand-wrote its 12 tool docstrings instead of reading the master Pydantic models in `runtime/tools.py`, so a master reword never reached Parlant agents — it had already drifted (stale unprefixed `add_participant(...)`/`remove_participant(...)` example calls for tools actually named `band_add_participant`/`band_remove_participant`).
- Adds a `band_tool` decorator that sets each function's `__doc__` from `get_tool_description(func.__name__)` before registering with `p.tool` — the tool name is never retyped as a string (it's just `func.__name__`, always written to match its `TOOL_MODELS` entry), and decorator syntax is preserved.
- Only genuine Parlant-specific addition kept: a mentions-format note on `band_send_message` (Parlant takes a comma-separated string; the master model describes a list).
- Adds a regression test (`test_descriptions_match_master_source`) asserting every Parlant tool description starts with its master `get_tool_description()` text.

Fixes [INT-1170](https://linear.app/thenvoi/issue/INT-1170/parlant-tool-descriptions-are-hand-written-and-drift-from-the-sdk).

## Test plan
- [x] `uv run --extra dev-parlant pytest tests/integrations/parlant/test_tools.py -v --no-cov` — 39 passed (real Parlant SDK, not mocked)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run pyrefly check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114NCg97KJ6mNNK5RmvsbpH