### PR TITLE
fix: tool text drifts from the SDK master across adapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,37 @@ This is a Python SDK that connects AI agents to the Band collaborative platform.
 
 ## Platform Tools
 
+### Tool text is never written in an adapter
+
+`src/band/runtime/tools.py` owns every word an LLM reads about a platform tool:
+the input model's class docstring is the tool description, and each
+`Field(description=...)` is an argument description. An adapter must reach for
+whichever of these fits its framework instead of retyping the text:
+
+| Framework wants | Use | Result |
+|---|---|---|
+| A Pydantic `args_schema` class | `platform_args_schema(name)` | the master model itself |
+| The same, but its tool layer emits a value the master won't parse | `platform_args_schema(name, validators={...})` | a subclass with the master's text plus the extra validators |
+| Schema derived from a function docstring | `@platform_tool(name)` | docstring = master description + a rendered `Args:` section |
+| A raw JSON/dict schema | `iter_tool_definitions()`, `get_openai_tool_schemas()`, `get_anthropic_tool_schemas()` | built live from the master |
+
+None of these accept description text — an adapter that needs different wording
+has a modeling problem to fix on the master, not a local string to write. If a
+framework's leniency really is adapter-specific (CrewAI's `mentions` coercion),
+express it as a `validators=` entry, never as a re-declared field.
+
+```python
+from band.runtime.tools import SendMessageInput, platform_args_schema
+
+assert platform_args_schema("band_send_message") is SendMessageInput
+```
+
+Guardrail: `tests/framework_conformance/test_tool_text_drift.py` runs each
+`AdapterConfig.advertised_arg_text` probe and fails if what the adapter
+advertises differs from the master. Wire the probe up for a new adapter that
+builds its own schema objects; leave it `None` when the master schema is passed
+through untouched.
+
 ### Chat Tools
 - `band_send_message`: Send message to chat room (requires mentions)
 - `band_send_event`: Send non-message event (thought, error, task)
@@ -601,7 +632,7 @@ When adding a new framework adapter and converter, follow this TDD workflow. Use
 
 1. Add an output adapter in `tests/framework_configs/output_adapters.py` — choose base class matching output format (`BaseDictListOutputAdapter`, `StringOutputAdapter`, `SenderDictListAdapter`, or `LangChainOutputAdapter`).
 2. Register converter config in `tests/framework_configs/converters.py` — factory function, builder function returning `ConverterConfig` with behavioral flags, append to `_CONVERTER_CONFIG_BUILDERS`.
-3. Register adapter config in `tests/framework_configs/adapters.py` — factory function with mocked constructor args, builder function returning `AdapterConfig`, append to `_ADAPTER_CONFIG_BUILDERS`.
+3. Register adapter config in `tests/framework_configs/adapters.py` — factory function with mocked constructor args, builder function returning `AdapterConfig`, append to `_ADAPTER_CONFIG_BUILDERS`. If the adapter builds its own tool schema objects, also set `advertised_arg_text` (see [Tool text is never written in an adapter](#tool-text-is-never-written-in-an-adapter)).
 
 ### Phase 3: Run Conformance Tests (Expect Failures)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ whichever of these fits its framework instead of retyping the text:
 |---|---|---|
 | A Pydantic `args_schema` class | `platform_args_schema(name)` | the master model itself |
 | The same, but its tool layer emits a value the master won't parse | `platform_args_schema(name, validators={...})` | a subclass with the master's text plus the extra validators |
-| Schema derived from a function docstring | `@platform_tool(name)` | docstring = master description + a rendered `Args:` section |
+| Schema derived from a function docstring | `@platform_tool` (bare — reads `fn.__name__`, takes no name argument) | docstring = master description + a rendered `Args:` section |
 | A raw JSON/dict schema | `iter_tool_definitions()`, `get_openai_tool_schemas()`, `get_anthropic_tool_schemas()` | built live from the master |
 
 None of these accept description text — an adapter that needs different wording
@@ -32,9 +32,15 @@ framework's leniency really is adapter-specific (CrewAI's `mentions` coercion),
 express it as a `validators=` entry, never as a re-declared field.
 
 ```python
-from band.runtime.tools import SendMessageInput, platform_args_schema
+from band.runtime.tools import SendMessageInput, platform_args_schema, platform_tool
+
+
+@platform_tool
+async def band_send_message(content: str, mentions: list[str]) -> None: ...
+
 
 assert platform_args_schema("band_send_message") is SendMessageInput
+assert "Args:" in (band_send_message.__doc__ or "")
 ```
 
 Guardrail: `tests/framework_conformance/test_tool_text_drift.py` runs each

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -61,9 +61,9 @@ from band.runtime.custom_tools import (
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     band_tool_errored,
-    get_tool_description,
     is_terminal_success,
     missing_reply_error,
+    platform_tool,
     serialize_tool_result,
 )
 
@@ -384,6 +384,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # Register platform tools dynamically from centralized definitions
         # All tools catch exceptions and return error strings so LLM can see failures
 
+        @platform_tool("band_send_message")
         async def band_send_message(
             ctx: RunContext[AgentToolsProtocol],
             content: str,
@@ -394,9 +395,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             except Exception as e:
                 return f"Error sending message: {e}"
 
-        band_send_message.__doc__ = get_tool_description("band_send_message")
         agent.tool(band_send_message)
 
+        @platform_tool("band_send_event")
         async def band_send_event(
             ctx: RunContext[AgentToolsProtocol],
             content: str,
@@ -408,9 +409,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             except Exception as e:
                 return f"Error sending event: {e}"
 
-        band_send_event.__doc__ = get_tool_description("band_send_event")
         agent.tool(band_send_event)
 
+        @platform_tool("band_add_participant")
         async def band_add_participant(
             ctx: RunContext[AgentToolsProtocol],
             identifier: str,
@@ -421,9 +422,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             except Exception as e:
                 return f"Error adding participant '{identifier}': {e}"
 
-        band_add_participant.__doc__ = get_tool_description("band_add_participant")
         agent.tool(band_add_participant)
 
+        @platform_tool("band_remove_participant")
         async def band_remove_participant(
             ctx: RunContext[AgentToolsProtocol],
             identifier: str,
@@ -433,11 +434,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             except Exception as e:
                 return f"Error removing participant '{identifier}': {e}"
 
-        band_remove_participant.__doc__ = get_tool_description(
-            "band_remove_participant"
-        )
         agent.tool(band_remove_participant)
 
+        @platform_tool("band_lookup_peers")
         async def band_lookup_peers(
             ctx: RunContext[AgentToolsProtocol],
             page: int = 1,
@@ -450,9 +449,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             except Exception as e:
                 return f"Error looking up peers: {e}"
 
-        band_lookup_peers.__doc__ = get_tool_description("band_lookup_peers")
         agent.tool(band_lookup_peers)
 
+        @platform_tool("band_get_participants")
         async def band_get_participants(
             ctx: RunContext[AgentToolsProtocol],
         ) -> list[dict[str, Any]] | str:
@@ -461,9 +460,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             except Exception as e:
                 return f"Error getting participants: {e}"
 
-        band_get_participants.__doc__ = get_tool_description("band_get_participants")
         agent.tool(band_get_participants)
 
+        @platform_tool("band_create_chatroom")
         async def band_create_chatroom(
             ctx: RunContext[AgentToolsProtocol],
             task_id: str | None = None,
@@ -473,12 +472,12 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             except Exception as e:
                 return f"Error creating chatroom (task_id={task_id}): {e}"
 
-        band_create_chatroom.__doc__ = get_tool_description("band_create_chatroom")
         agent.tool(band_create_chatroom)
 
         # Contact management tools (opt-in via Capability.CONTACTS)
         if Capability.CONTACTS in self.features.capabilities:
 
+            @platform_tool("band_list_contacts")
             async def band_list_contacts(
                 ctx: RunContext[AgentToolsProtocol],
                 page: int = 1,
@@ -491,9 +490,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                 except Exception as e:
                     return f"Error listing contacts: {e}"
 
-            band_list_contacts.__doc__ = get_tool_description("band_list_contacts")
             agent.tool(band_list_contacts)
 
+            @platform_tool("band_add_contact")
             async def band_add_contact(
                 ctx: RunContext[AgentToolsProtocol],
                 handle: str,
@@ -504,9 +503,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                 except Exception as e:
                     return f"Error adding contact '{handle}': {e}"
 
-            band_add_contact.__doc__ = get_tool_description("band_add_contact")
             agent.tool(band_add_contact)
 
+            @platform_tool("band_remove_contact")
             async def band_remove_contact(
                 ctx: RunContext[AgentToolsProtocol],
                 handle: str | None = None,
@@ -517,9 +516,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                 except Exception as e:
                     return f"Error removing contact: {e}"
 
-            band_remove_contact.__doc__ = get_tool_description("band_remove_contact")
             agent.tool(band_remove_contact)
 
+            @platform_tool("band_list_contact_requests")
             async def band_list_contact_requests(
                 ctx: RunContext[AgentToolsProtocol],
                 page: int = 1,
@@ -535,11 +534,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                 except Exception as e:
                     return f"Error listing contact requests: {e}"
 
-            band_list_contact_requests.__doc__ = get_tool_description(
-                "band_list_contact_requests"
-            )
             agent.tool(band_list_contact_requests)
 
+            @platform_tool("band_respond_contact_request")
             async def band_respond_contact_request(
                 ctx: RunContext[AgentToolsProtocol],
                 action: str,
@@ -568,14 +565,12 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                         pass  # Don't fail if error reporting fails
                     return error_msg
 
-            band_respond_contact_request.__doc__ = get_tool_description(
-                "band_respond_contact_request"
-            )
             agent.tool(band_respond_contact_request)
 
         # Memory management tools (enterprise only - opt-in)
         if Capability.MEMORY in self.features.capabilities:
 
+            @platform_tool("band_list_memories")
             async def band_list_memories(
                 ctx: RunContext[AgentToolsProtocol],
                 subject_id: str | None = None,
@@ -602,9 +597,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                 except Exception as e:
                     return f"Error listing memories: {e}"
 
-            band_list_memories.__doc__ = get_tool_description("band_list_memories")
             agent.tool(band_list_memories)
 
+            @platform_tool("band_store_memory")
             async def band_store_memory(
                 ctx: RunContext[AgentToolsProtocol],
                 content: str,
@@ -632,9 +627,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                 except Exception as e:
                     return f"Error storing memory: {e}"
 
-            band_store_memory.__doc__ = get_tool_description("band_store_memory")
             agent.tool(band_store_memory)
 
+            @platform_tool("band_get_memory")
             async def band_get_memory(
                 ctx: RunContext[AgentToolsProtocol],
                 memory_id: str,
@@ -644,9 +639,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                 except Exception as e:
                     return f"Error getting memory: {e}"
 
-            band_get_memory.__doc__ = get_tool_description("band_get_memory")
             agent.tool(band_get_memory)
 
+            @platform_tool("band_supersede_memory")
             async def band_supersede_memory(
                 ctx: RunContext[AgentToolsProtocol],
                 memory_id: str,
@@ -658,11 +653,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                 except Exception as e:
                     return f"Error superseding memory: {e}"
 
-            band_supersede_memory.__doc__ = get_tool_description(
-                "band_supersede_memory"
-            )
             agent.tool(band_supersede_memory)
 
+            @platform_tool("band_archive_memory")
             async def band_archive_memory(
                 ctx: RunContext[AgentToolsProtocol],
                 memory_id: str,
@@ -674,7 +667,6 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                 except Exception as e:
                     return f"Error archiving memory: {e}"
 
-            band_archive_memory.__doc__ = get_tool_description("band_archive_memory")
             agent.tool(band_archive_memory)
 
         # Register custom tools (user-provided PydanticAI-compatible functions) on

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -384,7 +384,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # Register platform tools dynamically from centralized definitions
         # All tools catch exceptions and return error strings so LLM can see failures
 
-        @platform_tool("band_send_message")
+        @platform_tool
         async def band_send_message(
             ctx: RunContext[AgentToolsProtocol],
             content: str,
@@ -397,7 +397,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
         agent.tool(band_send_message)
 
-        @platform_tool("band_send_event")
+        @platform_tool
         async def band_send_event(
             ctx: RunContext[AgentToolsProtocol],
             content: str,
@@ -411,7 +411,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
         agent.tool(band_send_event)
 
-        @platform_tool("band_add_participant")
+        @platform_tool
         async def band_add_participant(
             ctx: RunContext[AgentToolsProtocol],
             identifier: str,
@@ -424,7 +424,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
         agent.tool(band_add_participant)
 
-        @platform_tool("band_remove_participant")
+        @platform_tool
         async def band_remove_participant(
             ctx: RunContext[AgentToolsProtocol],
             identifier: str,
@@ -436,7 +436,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
         agent.tool(band_remove_participant)
 
-        @platform_tool("band_lookup_peers")
+        @platform_tool
         async def band_lookup_peers(
             ctx: RunContext[AgentToolsProtocol],
             page: int = 1,
@@ -451,7 +451,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
         agent.tool(band_lookup_peers)
 
-        @platform_tool("band_get_participants")
+        @platform_tool
         async def band_get_participants(
             ctx: RunContext[AgentToolsProtocol],
         ) -> list[dict[str, Any]] | str:
@@ -462,7 +462,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
         agent.tool(band_get_participants)
 
-        @platform_tool("band_create_chatroom")
+        @platform_tool
         async def band_create_chatroom(
             ctx: RunContext[AgentToolsProtocol],
             task_id: str | None = None,
@@ -477,7 +477,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # Contact management tools (opt-in via Capability.CONTACTS)
         if Capability.CONTACTS in self.features.capabilities:
 
-            @platform_tool("band_list_contacts")
+            @platform_tool
             async def band_list_contacts(
                 ctx: RunContext[AgentToolsProtocol],
                 page: int = 1,
@@ -492,7 +492,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
             agent.tool(band_list_contacts)
 
-            @platform_tool("band_add_contact")
+            @platform_tool
             async def band_add_contact(
                 ctx: RunContext[AgentToolsProtocol],
                 handle: str,
@@ -505,7 +505,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
             agent.tool(band_add_contact)
 
-            @platform_tool("band_remove_contact")
+            @platform_tool
             async def band_remove_contact(
                 ctx: RunContext[AgentToolsProtocol],
                 handle: str | None = None,
@@ -518,7 +518,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
             agent.tool(band_remove_contact)
 
-            @platform_tool("band_list_contact_requests")
+            @platform_tool
             async def band_list_contact_requests(
                 ctx: RunContext[AgentToolsProtocol],
                 page: int = 1,
@@ -536,7 +536,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
             agent.tool(band_list_contact_requests)
 
-            @platform_tool("band_respond_contact_request")
+            @platform_tool
             async def band_respond_contact_request(
                 ctx: RunContext[AgentToolsProtocol],
                 action: str,
@@ -570,7 +570,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # Memory management tools (enterprise only - opt-in)
         if Capability.MEMORY in self.features.capabilities:
 
-            @platform_tool("band_list_memories")
+            @platform_tool
             async def band_list_memories(
                 ctx: RunContext[AgentToolsProtocol],
                 subject_id: str | None = None,
@@ -599,7 +599,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
             agent.tool(band_list_memories)
 
-            @platform_tool("band_store_memory")
+            @platform_tool
             async def band_store_memory(
                 ctx: RunContext[AgentToolsProtocol],
                 content: str,
@@ -629,7 +629,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
             agent.tool(band_store_memory)
 
-            @platform_tool("band_get_memory")
+            @platform_tool
             async def band_get_memory(
                 ctx: RunContext[AgentToolsProtocol],
                 memory_id: str,
@@ -641,7 +641,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
             agent.tool(band_get_memory)
 
-            @platform_tool("band_supersede_memory")
+            @platform_tool
             async def band_supersede_memory(
                 ctx: RunContext[AgentToolsProtocol],
                 memory_id: str,
@@ -655,7 +655,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
             agent.tool(band_supersede_memory)
 
-            @platform_tool("band_archive_memory")
+            @platform_tool
             async def band_archive_memory(
                 ctx: RunContext[AgentToolsProtocol],
                 memory_id: str,

--- a/src/band/integrations/crewai/tools.py
+++ b/src/band/integrations/crewai/tools.py
@@ -58,6 +58,7 @@ from band.runtime.tools import (
     is_terminal_success,
     platform_args_schema,
     serialize_tool_result,
+    validate_tool_arguments,
 )
 
 logger = logging.getLogger(__name__)
@@ -415,18 +416,16 @@ def _make_platform_tools(
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            content: str = kwargs.get("content", "")
-            metadata: dict[str, Any] | None = kwargs.get("metadata")
-
             async def execute(tools: AgentToolsProtocol) -> str:
-                if "message_type" not in kwargs:
-                    raise ValueError(
-                        "Invalid arguments for band_send_event: "
-                        "message_type: Field required"
-                    )
+                # Validated here, not in _run: _run is also called directly,
+                # bypassing args_schema validation, and _exec turns the
+                # ValueError into the error result the caller expects.
+                args = validate_tool_arguments(
+                    "band_send_event", self.args_schema, kwargs
+                )
                 # No execution reporting for send_event to avoid meta-events.
                 await tools.send_event(
-                    content, kwargs["message_type"], metadata=metadata
+                    args["content"], args["message_type"], metadata=args.get("metadata")
                 )
                 return json.dumps({"status": "success", "message": "Event sent"})
 

--- a/src/band/integrations/crewai/tools.py
+++ b/src/band/integrations/crewai/tools.py
@@ -26,29 +26,16 @@ from typing import (
     Any,
     Awaitable,
     Callable,
-    Literal,
     Protocol,
-    Type,
     cast,
     runtime_checkable,
 )
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, field_validator
 
 if TYPE_CHECKING:
     from crewai.tools import BaseTool
 
-from band.core.memory_types import (
-    MemoryListScope,
-    MemorySegment,
-    MemoryStatus,
-    MemoryStoreScope,
-    MemorySystem,
-    MemoryType,
-    memory_type_field_description,
-    validate_memory_type_for_system,
-    validate_subject_scope,
-)
 from band.core.exceptions import BandToolError
 from band.core.protocols import AgentToolsProtocol
 from band.core.tool_filter import filter_tool_schemas
@@ -56,8 +43,6 @@ from band.core.types import (
     AdapterFeatures,
     Capability,
     Emit,
-    EventMessageType,
-    MessageType,
     ToolEventKey,
 )
 from band.integrations.crewai.runtime import run_async
@@ -71,6 +56,7 @@ from band.runtime.tools import (
     append_available_mention_handles,
     get_tool_description,
     is_terminal_success,
+    platform_args_schema,
     serialize_tool_result,
 )
 
@@ -320,177 +306,45 @@ def _execute_tool(
     return result
 
 
-# --- Input models ---
+# --- CrewAI-specific parsing leniency ---
 
 
-class _SendMessageInput(BaseModel):
-    content: str = Field(..., description="The message content to send")
-    mentions: str = Field(
-        ...,
-        description='JSON array of participant handles to @mention (e.g., \'["@john", "@john/weather-agent"]\')',
-    )
+def normalize_mentions_lenient(value: Any) -> list[str]:
+    """Coerce whatever CrewAI's tool layer produced into a list of handles.
 
-    @field_validator("mentions", mode="before")
-    @classmethod
-    def normalize_mentions(cls, v: Any) -> str:
-        if v is None:
-            return "[]"
-        if isinstance(v, list):
-            return json.dumps(v)
-        return v
+    Smaller models driving CrewAI emit ``mentions`` as a JSON-encoded string or
+    a bracketed list of bare handles (``"[@john/agent]"``) rather than a real
+    list. Without this the platform rejects the call for having no mentions and
+    the agent retries in a loop, so the leniency lives here rather than on the
+    master model, which every other adapter satisfies as-is.
+    """
+    if value is None or value == "":
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            pass
+        else:
+            if isinstance(decoded, list):
+                return [str(item) for item in decoded]
+        stripped = value.strip().strip("[]")
+        return [
+            token.strip().strip("'\"") for token in stripped.split(",") if token.strip()
+        ]
+    return [str(value)]
 
 
-class _SendEventInput(BaseModel):
-    content: str = Field(..., description="Human-readable event content")
-    message_type: EventMessageType = Field(
-        default=MessageType.THOUGHT,
-        description="Type of event: 'thought', 'error', or 'task'",
-    )
-    metadata: dict[str, Any] | None = Field(
-        default=None, description="Optional structured metadata"
-    )
-
-
-class _AddParticipantInput(BaseModel):
-    identifier: str = Field(
-        ...,
-        description=(
-            "Identifier of participant to add — can be a handle, name, "
-            "or ID (from band_lookup_peers). Prefer the exact ID "
-            "returned by band_lookup_peers; handles are mainly for mentions."
+SEND_MESSAGE_ARGS_SCHEMA: type[BaseModel] = platform_args_schema(
+    "band_send_message",
+    validators={
+        "normalize_mentions": field_validator("mentions", mode="before")(
+            staticmethod(normalize_mentions_lenient)
         ),
-    )
-    role: Literal["owner", "admin", "member"] = Field(
-        default="member", description="Role: 'owner', 'admin', or 'member'"
-    )
-
-
-class _RemoveParticipantInput(BaseModel):
-    identifier: str = Field(
-        ...,
-        description=(
-            "Identifier of the participant to remove — can be a handle, name, or ID"
-        ),
-    )
-
-
-class _GetParticipantsInput(BaseModel):
-    pass
-
-
-class _LookupPeersInput(BaseModel):
-    page: int = Field(default=1, description="Page number", ge=1)
-    page_size: int = Field(
-        default=50, description="Items per page (max 100)", ge=1, le=100
-    )
-
-
-class _CreateChatroomInput(BaseModel):
-    task_id: str | None = Field(
-        default=None, description="Associated task ID (optional)"
-    )
-
-
-class _ListContactsInput(BaseModel):
-    page: int = Field(default=1, description="Page number", ge=1)
-    page_size: int = Field(
-        default=50, description="Items per page (max 100)", ge=1, le=100
-    )
-
-
-class _AddContactInput(BaseModel):
-    handle: str = Field(
-        ...,
-        description="Handle of user/agent to add (e.g., '@john' or '@john/agent-name')",
-    )
-    message: str | None = Field(
-        default=None, description="Optional message with the request"
-    )
-
-
-class _RemoveContactInput(BaseModel):
-    handle: str | None = Field(default=None, description="Contact's handle")
-    contact_id: str | None = Field(
-        default=None, description="Or contact record ID (UUID)"
-    )
-
-
-class _ListContactRequestsInput(BaseModel):
-    page: int = Field(default=1, description="Page number", ge=1)
-    page_size: int = Field(
-        default=50, description="Items per page (max 100)", ge=1, le=100
-    )
-    sent_status: Literal["pending", "approved", "rejected", "cancelled", "all"] = Field(
-        default="pending", description="Filter sent requests by status"
-    )
-
-
-class _RespondContactRequestInput(BaseModel):
-    action: Literal["approve", "reject", "cancel"] = Field(
-        ..., description="Action to take ('approve', 'reject', 'cancel')"
-    )
-    handle: str | None = Field(default=None, description="Other party's handle")
-    request_id: str | None = Field(default=None, description="Or request ID (UUID)")
-
-
-class _ListMemoriesInput(BaseModel):
-    subject_id: str | None = Field(default=None, description="Filter by subject UUID")
-    scope: MemoryListScope | None = Field(
-        default=None, description="Filter by scope (subject, organization, all)"
-    )
-    system: MemorySystem | None = Field(
-        default=None,
-        description="Filter by memory system (sensory, working, long_term)",
-    )
-    memory_type: MemoryType | None = Field(
-        default=None, description="Filter by memory type"
-    )
-    segment: MemorySegment | None = Field(
-        default=None, description="Filter by segment (user, agent, tool, guideline)"
-    )
-    content_query: str | None = Field(
-        default=None, description="Full-text search query"
-    )
-    page_size: int = Field(
-        default=50, description="Number of results per page", ge=1, le=50
-    )
-    status: MemoryStatus | None = Field(
-        default=None,
-        description="Filter by status (active, superseded, archived, all)",
-    )
-
-
-class _StoreMemoryInput(BaseModel):
-    content: str = Field(..., description="The memory content")
-    system: MemorySystem = Field(..., description="Memory system tier")
-    memory_type: MemoryType = Field(..., description=memory_type_field_description())
-    segment: MemorySegment = Field(..., description="Logical segment")
-    thought: str = Field(..., description="Agent's reasoning for storing this memory")
-    scope: MemoryStoreScope = Field(..., description="Visibility scope")
-    subject_id: str | None = Field(
-        default=None, description="UUID of the subject (required for subject scope)"
-    )
-    metadata: dict[str, Any] | None = Field(
-        default=None, description="Additional metadata"
-    )
-
-    @model_validator(mode="after")
-    def validate_memory_fields(self) -> "_StoreMemoryInput":
-        validate_memory_type_for_system(self.system, self.memory_type)
-        validate_subject_scope(self.scope, self.subject_id)
-        return self
-
-
-class _GetMemoryInput(BaseModel):
-    memory_id: str = Field(..., description="Memory ID (UUID)")
-
-
-class _SupersedeMemoryInput(BaseModel):
-    memory_id: str = Field(..., description="Memory ID (UUID)")
-
-
-class _ArchiveMemoryInput(BaseModel):
-    memory_id: str = Field(..., description="Memory ID (UUID)")
+    },
+)
 
 
 # --- Tool factory ---
@@ -524,16 +378,14 @@ def _make_platform_tools(
     class SendMessageTool(BaseTool):
         name: str = "band_send_message"
         description: str = get_tool_description("band_send_message")
-        args_schema: Type[BaseModel] = _SendMessageInput
+        args_schema: type[BaseModel] = SEND_MESSAGE_ARGS_SCHEMA
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
             content: str = kwargs.get("content", "")
-            mentions: str = kwargs.get("mentions", "[]")
-            try:
-                mention_list = json.loads(mentions) if mentions else []
-            except json.JSONDecodeError:
-                mention_list = []
+            # Normalized here too, not just in the schema: _run is also called
+            # directly, bypassing args_schema validation.
+            mention_list = normalize_mentions_lenient(kwargs.get("mentions"))
 
             async def execute(tools: AgentToolsProtocol) -> str:
                 execute_send_message = getattr(reporter, "execute_send_message", None)
@@ -559,7 +411,7 @@ def _make_platform_tools(
     class SendEventTool(BaseTool):
         name: str = "band_send_event"
         description: str = get_tool_description("band_send_event")
-        args_schema: Type[BaseModel] = _SendEventInput
+        args_schema: type[BaseModel] = platform_args_schema("band_send_event")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -577,7 +429,7 @@ def _make_platform_tools(
     class AddParticipantTool(BaseTool):
         name: str = "band_add_participant"
         description: str = get_tool_description("band_add_participant")
-        args_schema: Type[BaseModel] = _AddParticipantInput
+        args_schema: type[BaseModel] = platform_args_schema("band_add_participant")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -599,7 +451,7 @@ def _make_platform_tools(
     class RemoveParticipantTool(BaseTool):
         name: str = "band_remove_participant"
         description: str = get_tool_description("band_remove_participant")
-        args_schema: Type[BaseModel] = _RemoveParticipantInput
+        args_schema: type[BaseModel] = platform_args_schema("band_remove_participant")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -618,7 +470,7 @@ def _make_platform_tools(
     class GetParticipantsTool(BaseTool):
         name: str = "band_get_participants"
         description: str = get_tool_description("band_get_participants")
-        args_schema: Type[BaseModel] = _GetParticipantsInput
+        args_schema: type[BaseModel] = platform_args_schema("band_get_participants")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **_kwargs: Any) -> Any:
@@ -646,7 +498,7 @@ def _make_platform_tools(
     class LookupPeersTool(BaseTool):
         name: str = "band_lookup_peers"
         description: str = get_tool_description("band_lookup_peers")
-        args_schema: Type[BaseModel] = _LookupPeersInput
+        args_schema: type[BaseModel] = platform_args_schema("band_lookup_peers")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -668,7 +520,7 @@ def _make_platform_tools(
     class CreateChatroomTool(BaseTool):
         name: str = "band_create_chatroom"
         description: str = get_tool_description("band_create_chatroom")
-        args_schema: Type[BaseModel] = _CreateChatroomInput
+        args_schema: type[BaseModel] = platform_args_schema("band_create_chatroom")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -692,7 +544,7 @@ def _make_platform_tools(
     class ListContactsTool(BaseTool):
         name: str = "band_list_contacts"
         description: str = get_tool_description("band_list_contacts")
-        args_schema: Type[BaseModel] = _ListContactsInput
+        args_schema: type[BaseModel] = platform_args_schema("band_list_contacts")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -714,7 +566,7 @@ def _make_platform_tools(
     class AddContactTool(BaseTool):
         name: str = "band_add_contact"
         description: str = get_tool_description("band_add_contact")
-        args_schema: Type[BaseModel] = _AddContactInput
+        args_schema: type[BaseModel] = platform_args_schema("band_add_contact")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -736,7 +588,7 @@ def _make_platform_tools(
     class RemoveContactTool(BaseTool):
         name: str = "band_remove_contact"
         description: str = get_tool_description("band_remove_contact")
-        args_schema: Type[BaseModel] = _RemoveContactInput
+        args_schema: type[BaseModel] = platform_args_schema("band_remove_contact")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -758,7 +610,9 @@ def _make_platform_tools(
     class ListContactRequestsTool(BaseTool):
         name: str = "band_list_contact_requests"
         description: str = get_tool_description("band_list_contact_requests")
-        args_schema: Type[BaseModel] = _ListContactRequestsInput
+        args_schema: type[BaseModel] = platform_args_schema(
+            "band_list_contact_requests"
+        )
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -787,7 +641,9 @@ def _make_platform_tools(
     class RespondContactRequestTool(BaseTool):
         name: str = "band_respond_contact_request"
         description: str = get_tool_description("band_respond_contact_request")
-        args_schema: Type[BaseModel] = _RespondContactRequestInput
+        args_schema: type[BaseModel] = platform_args_schema(
+            "band_respond_contact_request"
+        )
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -812,14 +668,14 @@ def _make_platform_tools(
     class ListMemoriesTool(BaseTool):
         name: str = "band_list_memories"
         description: str = get_tool_description("band_list_memories")
-        args_schema: Type[BaseModel] = _ListMemoriesInput
+        args_schema: type[BaseModel] = platform_args_schema("band_list_memories")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
             subject_id = kwargs.get("subject_id")
             scope = kwargs.get("scope")
             system = kwargs.get("system")
-            memory_type = kwargs.get("memory_type")
+            memory_type = kwargs.get("type")
             segment = kwargs.get("segment")
             content_query = kwargs.get("content_query")
             page_size = kwargs.get("page_size", 50)
@@ -866,13 +722,13 @@ def _make_platform_tools(
     class StoreMemoryTool(BaseTool):
         name: str = "band_store_memory"
         description: str = get_tool_description("band_store_memory")
-        args_schema: Type[BaseModel] = _StoreMemoryInput
+        args_schema: type[BaseModel] = platform_args_schema("band_store_memory")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
             content = kwargs.get("content", "")
             system = kwargs.get("system", "")
-            memory_type = kwargs.get("memory_type", "")
+            memory_type = kwargs.get("type", "")
             segment = kwargs.get("segment", "")
             thought = kwargs.get("thought", "")
             scope = kwargs.get("scope", "")
@@ -915,7 +771,7 @@ def _make_platform_tools(
     class GetMemoryTool(BaseTool):
         name: str = "band_get_memory"
         description: str = get_tool_description("band_get_memory")
-        args_schema: Type[BaseModel] = _GetMemoryInput
+        args_schema: type[BaseModel] = platform_args_schema("band_get_memory")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -934,7 +790,7 @@ def _make_platform_tools(
     class SupersedeMemoryTool(BaseTool):
         name: str = "band_supersede_memory"
         description: str = get_tool_description("band_supersede_memory")
-        args_schema: Type[BaseModel] = _SupersedeMemoryInput
+        args_schema: type[BaseModel] = platform_args_schema("band_supersede_memory")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -953,7 +809,7 @@ def _make_platform_tools(
     class ArchiveMemoryTool(BaseTool):
         name: str = "band_archive_memory"
         description: str = get_tool_description("band_archive_memory")
-        args_schema: Type[BaseModel] = _ArchiveMemoryInput
+        args_schema: type[BaseModel] = platform_args_schema("band_archive_memory")
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -1042,7 +898,7 @@ def _make_custom_tools(
             class CustomCrewAITool(BaseTool):
                 name: str = _tool_name  # type: ignore[misc]
                 description: str = _tool_desc  # type: ignore[misc]
-                args_schema: Type[BaseModel] = model
+                args_schema: type[BaseModel] = model
                 cache_function: Any = staticmethod(lambda *_a, **_kw: False)
 
                 def _run(self, *_args: Any, **kwargs: Any) -> Any:

--- a/src/band/integrations/crewai/tools.py
+++ b/src/band/integrations/crewai/tools.py
@@ -416,12 +416,18 @@ def _make_platform_tools(
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
             content: str = kwargs.get("content", "")
-            message_type: str = kwargs.get("message_type", "thought")
             metadata: dict[str, Any] | None = kwargs.get("metadata")
 
             async def execute(tools: AgentToolsProtocol) -> str:
+                if "message_type" not in kwargs:
+                    raise ValueError(
+                        "Invalid arguments for band_send_event: "
+                        "message_type: Field required"
+                    )
                 # No execution reporting for send_event to avoid meta-events.
-                await tools.send_event(content, message_type, metadata=metadata)
+                await tools.send_event(
+                    content, kwargs["message_type"], metadata=metadata
+                )
                 return json.dumps({"status": "success", "message": "Event sent"})
 
             return _exec("band_send_event", execute)

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -1356,19 +1356,17 @@ def get_tool_docstring_with_args(name: str) -> str:
 ToolFunc = TypeVar("ToolFunc", bound=Callable[..., Any])
 
 
-def platform_tool(name: str) -> Callable[[ToolFunc], ToolFunc]:
+def platform_tool(fn: ToolFunc) -> ToolFunc:
     """Give a tool function the master description and ``Args:`` section.
 
-    For frameworks that derive their schema from the function docstring. The
-    decorator takes only a tool name on purpose — there is nowhere to type
-    prose, so the docstring cannot drift from the master model.
+    For frameworks that derive their schema from the function docstring. Reads
+    ``fn.__name__`` rather than taking a tool name argument — the function is
+    always named after the tool it registers (frameworks that key a tool by
+    its function name, like pydantic-ai, require this already), so there is
+    nowhere left to retype that name, let alone the description.
     """
-
-    def wrap(fn: ToolFunc) -> ToolFunc:
-        fn.__doc__ = get_tool_docstring_with_args(name)
-        return fn
-
-    return wrap
+    fn.__doc__ = get_tool_docstring_with_args(fn.__name__)
+    return fn
 
 
 def platform_args_schema(

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -1346,7 +1346,7 @@ def get_tool_docstring_with_args(name: str) -> str:
     arg_lines = [
         format_arg_doc(field_name, field.description)
         for field_name, field in model.model_fields.items()
-        if field.description
+        if field.description and field.description.strip()
     ]
     if not arg_lines:
         return description

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -11,9 +11,16 @@ import warnings
 from dataclasses import dataclass
 from datetime import datetime
 from collections.abc import AsyncIterator, Awaitable, Callable, Collection
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
-from pydantic import AliasChoices, BaseModel, Field, ValidationError, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field,
+    ValidationError,
+    create_model,
+    model_validator,
+)
 
 from band.client.rest import ChatRoomRequest, DEFAULT_REQUEST_OPTIONS
 from band.runtime.participants import participant_snapshot
@@ -276,8 +283,8 @@ class LookupPeersInput(BaseModel):
     a question directly.
     """
 
-    page: int = Field(1, description="Page number")
-    page_size: int = Field(50, le=100, description="Items per page (max 100)")
+    page: int = Field(1, ge=1, description="Page number")
+    page_size: int = Field(50, ge=1, le=100, description="Items per page (max 100)")
 
 
 class GetParticipantsInput(BaseModel):
@@ -1272,6 +1279,16 @@ def mcp_tool_names(names: frozenset[str]) -> list[str]:
     return [f"{MCP_TOOL_PREFIX}{name}" for name in sorted(names)]
 
 
+def resolve_tool_model(name: str) -> type[BaseModel] | None:
+    """Resolve a tool name to its master input model.
+
+    Accepts the deprecated unprefixed spelling too, so every consumer sees one
+    resolution rule. Warning about the deprecated form is the caller's job —
+    this stays quiet so it can be used for lookups that aren't user-facing.
+    """
+    return TOOL_MODELS.get(name) or TOOL_MODELS.get(f"band_{name}")
+
+
 def get_tool_description(name: str) -> str:
     """
     Get the LLM-optimized description for a tool.
@@ -1286,24 +1303,98 @@ def get_tool_description(name: str) -> str:
     Returns:
         Tool description string
     """
-    # Try exact match first
-    model = TOOL_MODELS.get(name)
-    if model and model.__doc__:
-        return model.__doc__
+    model = resolve_tool_model(name)
+    if model is None or not model.__doc__:
+        return f"Execute {name}"
 
-    # Try with prefix for backwards compatibility (deprecated)
-    if not name.startswith("band_"):
-        prefixed_name = f"band_{name}"
-        model = TOOL_MODELS.get(prefixed_name)
-        if model and model.__doc__:
-            warnings.warn(
-                f"Tool name '{name}' is deprecated. Use '{prefixed_name}' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return model.__doc__
+    if name not in TOOL_MODELS:
+        warnings.warn(
+            f"Tool name '{name}' is deprecated. Use 'band_{name}' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    return model.__doc__
 
-    return f"Execute {name}"
+
+def format_arg_doc(name: str, description: str) -> str:
+    """Render one Google-style ``Args:`` entry.
+
+    Continuation lines are indented past the argument name so a multi-line
+    ``Field(description=...)`` stays part of that argument — flush-left
+    continuations end the entry as far as a docstring parser is concerned.
+    """
+    head, *rest = description.strip().splitlines()
+    return "\n".join(
+        [f"    {name}: {head}", *(f"        {line.strip()}" for line in rest)]
+    )
+
+
+def get_tool_docstring_with_args(name: str) -> str:
+    """Return the tool description plus a Google-style ``Args:`` section.
+
+    Both halves come from the master model: the class docstring and each
+    field's ``Field(description=...)``. Frameworks that build their schema by
+    parsing a Python function's docstring (pydantic-ai via griffe) only see
+    per-argument text if it appears under ``Args:``, so this renders it there
+    rather than having each adapter retype it.
+    """
+    description = get_tool_description(name)
+    model = resolve_tool_model(name)
+    if model is None:
+        return description
+
+    arg_lines = [
+        format_arg_doc(field_name, field.description)
+        for field_name, field in model.model_fields.items()
+        if field.description
+    ]
+    if not arg_lines:
+        return description
+    return f"{description.rstrip()}\n\nArgs:\n" + "\n".join(arg_lines)
+
+
+ToolFunc = TypeVar("ToolFunc", bound=Callable[..., Any])
+
+
+def platform_tool(name: str) -> Callable[[ToolFunc], ToolFunc]:
+    """Give a tool function the master description and ``Args:`` section.
+
+    For frameworks that derive their schema from the function docstring. The
+    decorator takes only a tool name on purpose — there is nowhere to type
+    prose, so the docstring cannot drift from the master model.
+    """
+
+    def wrap(fn: ToolFunc) -> ToolFunc:
+        fn.__doc__ = get_tool_docstring_with_args(name)
+        return fn
+
+    return wrap
+
+
+def platform_args_schema(
+    name: str,
+    *,
+    validators: dict[str, Any] | None = None,
+) -> type[BaseModel]:
+    """Return the master input model for ``name`` as a framework args schema.
+
+    ``validators`` layers extra pydantic validators onto a subclass for
+    frameworks whose tool-calling layer emits a value the master model is too
+    strict to parse. There is deliberately no field or description override:
+    an adapter needing different *text* has a modeling problem to fix on the
+    master, not a formatting one to patch locally.
+    """
+    model = TOOL_MODELS[name]
+    if not validators:
+        return model
+    return create_model(
+        f"{model.__name__}Adapted",
+        __base__=model,
+        # create_model does not inherit the base docstring, and that docstring
+        # is the tool description every adapter reads.
+        __doc__=model.__doc__,
+        __validators__=validators,
+    )
 
 
 def iter_tool_definitions(

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -1382,7 +1382,9 @@ def platform_args_schema(
     an adapter needing different *text* has a modeling problem to fix on the
     master, not a formatting one to patch locally.
     """
-    model = TOOL_MODELS[name]
+    model = resolve_tool_model(name)
+    if model is None:
+        raise KeyError(name)
     if not validators:
         return model
     return create_model(

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -1107,7 +1107,7 @@ class TestMemoryToolExecution:
                 subject_id="subject-1",
                 scope="subject",
                 system="working",
-                memory_type="fact",
+                type="fact",
                 segment="user",
                 content_query="remember",
                 page_size=5,
@@ -1143,7 +1143,7 @@ class TestMemoryToolExecution:
             result = store_memory_tool._run(
                 content="remember this",
                 system="working",
-                memory_type="fact",
+                type="fact",
                 segment="user",
                 thought="important for follow-up",
                 scope="subject",
@@ -1241,7 +1241,7 @@ class TestToolExecution:
         send_message_tool = next(t for t in tools if t.name == "band_send_message")
 
         # Call tool without setting context variable (simulates call outside message handling)
-        result = send_message_tool._run(content="Hello!", mentions="[]")
+        result = send_message_tool._run(content="Hello!", mentions=[])
 
         result_data = json.loads(result)
         assert result_data["status"] == "error"
@@ -1296,8 +1296,9 @@ class TestToolExecution:
         schema_fields = send_event.args_schema.model_fields
 
         assert "message_type" in schema_fields
-        message_type_field = schema_fields["message_type"]
-        assert message_type_field.default == "thought"
+        # Required, not defaulted to "thought" — the master model is authoritative
+        # and every other adapter already makes the agent state the event type.
+        assert schema_fields["message_type"].is_required()
 
     def test_successful_tool_execution_with_room_context(
         self, CrewAIAdapter, crewai_mocks, mock_tools, room_context
@@ -1410,7 +1411,7 @@ class TestExecutionReporting:
         send_message_tool = next(t for t in tools if t.name == "band_send_message")
 
         with room_context("room-123"):
-            send_message_tool._run(content="Hello!", mentions="[]")
+            send_message_tool._run(content="Hello!", mentions=[])
 
         assert mock_tools.send_event.call_count >= 2
 
@@ -1552,68 +1553,34 @@ class TestRunAsync:
 
 
 class TestMentionsValidator:
-    @pytest.mark.asyncio
-    async def test_mentions_list_converted_to_json(self, CrewAIAdapter, crewai_mocks):
+    """Models driving CrewAI emit mentions in several shapes; all reach list[str]."""
+
+    @pytest.fixture
+    async def send_message_schema(self, CrewAIAdapter, crewai_mocks):
         crewai_mocks.Agent.reset_mock()
 
         adapter = CrewAIAdapter()
         await adapter.on_started("TestBot", "Test bot")
 
-        call_kwargs = crewai_mocks.Agent.call_args[1]
-        tools = call_kwargs["tools"]
-        send_message_tool = next(t for t in tools if t.name == "band_send_message")
+        tools = crewai_mocks.Agent.call_args[1]["tools"]
+        return next(t for t in tools if t.name == "band_send_message").args_schema
 
-        input_model = send_message_tool.args_schema
-
-        instance = input_model(
-            content="Hello!",
-            mentions=["Alice", "Bob"],
-        )
-
-        assert instance.mentions == '["Alice", "Bob"]'
-
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (["Alice", "Bob"], ["Alice", "Bob"]),
+            ('["Alice"]', ["Alice"]),
+            # Neither JSON nor a list — what gpt-4o-mini actually emitted.
+            ("[@yael.avioz/test2]", ["@yael.avioz/test2"]),
+            (None, []),
+            ("", []),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_mentions_string_kept_as_is(self, CrewAIAdapter, crewai_mocks):
-        crewai_mocks.Agent.reset_mock()
+    async def test_mentions_normalize_to_list(self, send_message_schema, raw, expected):
+        instance = send_message_schema(content="Hello!", mentions=raw)
 
-        adapter = CrewAIAdapter()
-        await adapter.on_started("TestBot", "Test bot")
-
-        call_kwargs = crewai_mocks.Agent.call_args[1]
-        tools = call_kwargs["tools"]
-        send_message_tool = next(t for t in tools if t.name == "band_send_message")
-
-        input_model = send_message_tool.args_schema
-
-        instance = input_model(
-            content="Hello!",
-            mentions='["Alice"]',
-        )
-
-        assert instance.mentions == '["Alice"]'
-
-    @pytest.mark.asyncio
-    async def test_mentions_none_converted_to_empty_array(
-        self, CrewAIAdapter, crewai_mocks
-    ):
-        """None mentions should be normalized to empty JSON array string."""
-        crewai_mocks.Agent.reset_mock()
-
-        adapter = CrewAIAdapter()
-        await adapter.on_started("TestBot", "Test bot")
-
-        call_kwargs = crewai_mocks.Agent.call_args[1]
-        tools = call_kwargs["tools"]
-        send_message_tool = next(t for t in tools if t.name == "band_send_message")
-
-        input_model = send_message_tool.args_schema
-
-        instance = input_model(
-            content="Hello!",
-            mentions=None,
-        )
-
-        assert instance.mentions == "[]"
+        assert instance.mentions == expected
 
 
 class TestPromptRendering:

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -1300,6 +1300,31 @@ class TestToolExecution:
         # and every other adapter already makes the agent state the event type.
         assert schema_fields["message_type"].is_required()
 
+    def test_send_event_run_rejects_missing_message_type(
+        self, CrewAIAdapter, crewai_mocks, mock_tools, room_context
+    ):
+        """A direct `_run` call bypasses args_schema validation (crewai Flows do
+
+        this), so the requiredness enforced by the schema must be enforced here
+        too, or an omitted message_type silently posts as "thought" again.
+        """
+        crewai_mocks.Agent.reset_mock()
+
+        adapter = CrewAIAdapter()
+        asyncio.run(adapter.on_started("TestBot", "Test bot"))
+
+        call_kwargs = crewai_mocks.Agent.call_args[1]
+        tools = call_kwargs["tools"]
+        send_event = next(t for t in tools if t.name == "band_send_event")
+
+        with room_context("room-123"):
+            result = send_event._run(content="no type given")
+
+        result_data = json.loads(result)
+        assert result_data["status"] == "error"
+        assert "message_type" in result_data["message"]
+        mock_tools.send_event.assert_not_called()
+
     def test_successful_tool_execution_with_room_context(
         self, CrewAIAdapter, crewai_mocks, mock_tools, room_context
     ):

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -1303,10 +1303,11 @@ class TestToolExecution:
     def test_send_event_run_rejects_missing_message_type(
         self, CrewAIAdapter, crewai_mocks, mock_tools, room_context
     ):
-        """A direct `_run` call bypasses args_schema validation (crewai Flows do
+        """A direct `_run` call must enforce the requiredness the schema enforces.
 
-        this), so the requiredness enforced by the schema must be enforced here
-        too, or an omitted message_type silently posts as "thought" again.
+        crewai Flows call `_run` directly, bypassing args_schema validation, so
+        without this an omitted message_type would silently post as "thought"
+        again.
         """
         crewai_mocks.Agent.reset_mock()
 

--- a/tests/adapters/test_crewai_flow_phase3.py
+++ b/tests/adapters/test_crewai_flow_phase3.py
@@ -788,7 +788,7 @@ class TestRuntimeTools:
                         for t in rt.create_crewai_tools()
                         if t.name == "band_send_message"
                     )
-                    send_tool._run(content="subcrew visible", mentions="[]")
+                    send_tool._run(content="subcrew visible", mentions=[])
                     return {
                         "decision": "direct_response",
                         "content": "should not finalize",
@@ -848,7 +848,7 @@ class TestRuntimeTools:
                         for t in rt.create_crewai_tools()
                         if t.name == "band_send_message"
                     )
-                    result = send_tool._run(content="subcrew visible", mentions="[]")
+                    result = send_tool._run(content="subcrew visible", mentions=[])
                     assert '"status": "success"' in result
                     return {"decision": "waiting", "reason": "done"}
 

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -55,6 +55,8 @@ from band.adapters.pydantic_ai import (
 from band.core.protocols import AgentToolsProtocol
 from band.core.types import AdapterFeatures, Capability, PlatformMessage
 from band.runtime.custom_tools import get_custom_tool_name
+from band.runtime.tools import get_tool_description
+from tests.framework_configs.adapters import pydantic_ai_probe_tools
 
 
 def make_stream_events(
@@ -667,6 +669,25 @@ class TestOnStarted:
 
         for tool in expected_tools:
             assert tool in tool_names, f"Tool {tool} not found"
+
+
+class TestAdvertisedToolSchemas:
+    """Per-argument text fidelity is asserted in test_tool_text_drift.
+
+    What is pydantic-ai-specific, and checked here, is the split: griffe
+    consumes the rendered ``Args:`` section into the argument schema, so the
+    tool's own blurb must come back as the plain master docstring.
+    """
+
+    @pytest.mark.asyncio
+    async def test_tool_blurb_is_the_master_docstring(self):
+        blurbs = {
+            name: schema.description
+            for name, schema in (await pydantic_ai_probe_tools()).items()
+        }
+
+        assert blurbs, "no tools registered, so nothing was actually checked"
+        assert blurbs == {name: get_tool_description(name).strip() for name in blurbs}
 
 
 class TestOnMessage:

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -10,14 +10,22 @@ from __future__ import annotations
 import functools
 import inspect
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any, Awaitable, Callable
 from unittest.mock import MagicMock
 
 from tests.framework_configs.sentinel import MISSING, STRICT_CI, MissingSentinel
 from band.adapters.claude_sdk import _CLAUDE_SDK_AVAILABLE as _HAS_CLAUDE_SDK
 from band.adapters.copilot_sdk import _COPILOT_SDK_AVAILABLE as _HAS_COPILOT_SDK
 
-__all__ = ["AdapterConfig", "ADAPTER_CONFIGS", "ADAPTER_EXCLUDED_MODULES"]
+__all__ = [
+    "AdapterConfig",
+    "ADAPTER_CONFIGS",
+    "ADAPTER_EXCLUDED_MODULES",
+    "AdvertisedArgTextProbe",
+]
+
+# {tool_name: {arg_name: description | None}} as advertised to the LLM.
+AdvertisedArgTextProbe = Callable[[], Awaitable[dict[str, dict[str, str | None]]]]
 
 # Populated lazily via __getattr__ to avoid top-level adapter imports.
 ADAPTER_CONFIGS: list[AdapterConfig]
@@ -80,6 +88,81 @@ class AdapterConfig:
 
     # Skip on_started conformance test when adapter needs live client (e.g. PydanticAI)
     skip_on_started_conformance: bool = False
+
+    # Optional probe returning the per-argument text this adapter actually
+    # advertises, as {tool_name: {arg_name: description | None}}, verified
+    # against the master models by test_tool_text_drift. Leave None when the
+    # adapter hands the master schema to its framework untouched — there is
+    # nothing that can drift, and a probe would only assert the obvious.
+    advertised_arg_text: AdvertisedArgTextProbe | None = None
+
+
+# ---------------------------------------------------------------------------
+# Advertised argument-text probes
+# ---------------------------------------------------------------------------
+
+
+def _all_capabilities() -> Any:
+    """Every capability, so a probe sees the whole platform tool surface."""
+    from band.core.types import AdapterFeatures, Capability
+
+    return AdapterFeatures(
+        capabilities={Capability.CONTACTS, Capability.MEMORY},
+    )
+
+
+async def pydantic_ai_probe_tools() -> dict[str, Any]:
+    """The pydantic-ai function schemas a started adapter advertises.
+
+    Kept here rather than inline in a test so the walk through pydantic-ai's
+    internals lives in exactly one place.
+    """
+    from band.adapters.pydantic_ai import PydanticAIAdapter
+
+    adapter = PydanticAIAdapter(model="test", features=_all_capabilities())
+    await adapter.on_started(agent_name="Probe", agent_description="probe")
+    return {
+        name: tool.function_schema
+        for name, tool in adapter._agent._function_toolset.tools.items()
+    }
+
+
+async def _pydantic_ai_advertised_arg_text() -> dict[str, dict[str, str | None]]:
+    """pydantic-ai derives argument text by parsing the function docstring.
+
+    Bare type hints therefore advertise no argument text at all, silently — the
+    failure mode this probe exists to catch.
+    """
+    return {
+        name: {
+            arg: spec.get("description")
+            for arg, spec in schema.json_schema.get("properties", {}).items()
+        }
+        for name, schema in (await pydantic_ai_probe_tools()).items()
+    }
+
+
+async def _crewai_advertised_arg_text() -> dict[str, dict[str, str | None]]:
+    """CrewAI is the one adapter that still mints a schema class of its own.
+
+    ``band_send_message`` is a ``create_model`` subclass carrying the master's
+    text plus CrewAI-specific mentions leniency, so a field re-declared on that
+    subclass would drift silently — this is the probe that catches it.
+    """
+    from band.integrations.crewai.tools import NoopReporter, build_band_crewai_tools
+
+    tools = build_band_crewai_tools(
+        get_context=lambda: None,
+        reporter=NoopReporter(),
+        features=_all_capabilities(),
+    )
+    return {
+        tool.name: {
+            arg: field.description
+            for arg, field in tool.args_schema.model_fields.items()
+        }
+        for tool in tools
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -329,6 +412,9 @@ def _build_crewai_config() -> AdapterConfig:
         # on_started does a runtime `from crewai import Agent, LLM` which fails
         # when crewai is not installed (conflict group with parlant/pydantic-ai).
         skip_on_started_conformance=not _crewai_available,
+        # Same gate: building the tools needs crewai.tools.BaseTool, so this
+        # probe only runs in the crewai lane.
+        advertised_arg_text=_crewai_advertised_arg_text if _crewai_available else None,
     )
 
 
@@ -483,6 +569,7 @@ def _build_pydantic_ai_config() -> AdapterConfig:
             "instrument": True,
         },
         skip_on_started_conformance=True,  # on_started creates real OpenAI client; tested in test_pydantic_ai_adapter
+        advertised_arg_text=_pydantic_ai_advertised_arg_text,
     )
 
 

--- a/tests/framework_conformance/test_tool_text_drift.py
+++ b/tests/framework_conformance/test_tool_text_drift.py
@@ -1,0 +1,62 @@
+"""Conformance test that the text adapters advertise came from the master models.
+
+``runtime/tools.py`` is the single source of truth for what an LLM reads about
+a platform tool: the input model's docstring is the tool description and each
+``Field(description=...)`` is an argument description. An adapter can lose that
+in two ways, and both have shipped: retyping the text locally (where it drifts)
+or handing the framework a schema shape that carries no argument text at all.
+
+An adapter opts in by setting ``AdapterConfig.advertised_arg_text`` to a probe
+returning what it really advertises. Adapters that pass the master schema
+through untouched leave it unset — see the field's docstring.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pytest
+
+from band.runtime.tools import TOOL_MODELS
+from tests.framework_configs.adapters import ADAPTER_CONFIGS, AdapterConfig
+
+# Probes are wired per lane (CrewAI only builds tools where crewai is
+# installed), so an empty set means "no probeable adapter in this lane", not a
+# silent hole — configs_with_probe is asserted non-empty per parametrized case.
+PROBED_CONFIGS = [cfg for cfg in ADAPTER_CONFIGS if cfg.advertised_arg_text is not None]
+
+
+def master_arg_text(tool_names: Iterable[str]) -> dict[str, dict[str, str | None]]:
+    """The argument text the master models define for *tool_names*."""
+    return {
+        name: {
+            arg: field.description
+            for arg, field in TOOL_MODELS[name].model_fields.items()
+        }
+        for name in tool_names
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("config", PROBED_CONFIGS, ids=lambda cfg: cfg.framework_id)
+async def test_advertised_arg_text_matches_master(config: AdapterConfig) -> None:
+    advertised = await config.advertised_arg_text()
+
+    unknown = set(advertised) - set(TOOL_MODELS)
+    assert not unknown, (
+        f"{config.display_name} advertises tools with no master model: {unknown}. "
+        "A probe must report platform tools only."
+    )
+    assert advertised, f"{config.display_name} probe advertised no tools"
+    # Expected keys come from the master, so a dropped or renamed argument
+    # fails here too — not just changed wording.
+    assert advertised == master_arg_text(advertised)
+
+
+def test_some_adapter_is_probed() -> None:
+    """A lane where every probe silently vanished would pass vacuously."""
+    assert PROBED_CONFIGS, (
+        "No adapter in this lane wired advertised_arg_text. Either a probe was "
+        "dropped, or a config failed to build and was swallowed — check that "
+        "the adapters this lane installs are registered in ADAPTER_CONFIGS."
+    )

--- a/tests/integrations/test_crewai_tools.py
+++ b/tests/integrations/test_crewai_tools.py
@@ -60,6 +60,19 @@ def runtime_mod(crewai_mocks):
     return importlib.import_module("band.integrations.crewai.runtime")
 
 
+@pytest.fixture
+def platform_args_schemas(builder_mod):
+    """Tool name -> the args schema CrewAI actually advertises to the LLM."""
+    from band.core.types import Capability
+
+    tools = builder_mod.build_band_crewai_tools(
+        get_context=lambda: None,
+        reporter=builder_mod.NoopReporter(),
+        capabilities=frozenset({Capability.CONTACTS, Capability.MEMORY}),
+    )
+    return {tool.name: tool.args_schema for tool in tools}
+
+
 # --- Tool-set composition ---
 
 
@@ -206,13 +219,13 @@ class TestToolSetComposition:
             ("band_list_contacts", {"page": 0}),
             ("band_list_contact_requests", {"sent_status": "done"}),
             ("band_respond_contact_request", {"action": "maybe"}),
-            ("band_list_memories", {"memory_type": "fact"}),
+            ("band_list_memories", {"type": "fact"}),
             (
                 "band_store_memory",
                 {
                     "content": "remember this",
                     "system": "working",
-                    "memory_type": "fact",
+                    "type": "fact",
                     "segment": "user",
                     "thought": "useful later",
                     "scope": "organization",
@@ -221,45 +234,26 @@ class TestToolSetComposition:
         ],
     )
     def test_platform_tool_schemas_reject_invalid_values(
-        self, builder_mod, tool_name, payload
+        self, platform_args_schemas, tool_name, payload
     ):
         from pydantic import ValidationError
 
-        from band.core.types import Capability
-
-        tools = builder_mod.build_band_crewai_tools(
-            get_context=lambda: None,
-            reporter=builder_mod.NoopReporter(),
-            capabilities=frozenset({Capability.CONTACTS, Capability.MEMORY}),
-        )
-        tool = next(t for t in tools if t.name == tool_name)
-
         with pytest.raises(ValidationError):
-            tool.args_schema.model_validate(payload)
+            platform_args_schemas[tool_name].model_validate(payload)
 
-    def test_platform_tool_schemas_accept_metadata_fields(self, builder_mod):
-        from band.core.types import Capability
-
-        tools = builder_mod.build_band_crewai_tools(
-            get_context=lambda: None,
-            reporter=builder_mod.NoopReporter(),
-            capabilities=frozenset({Capability.MEMORY}),
-        )
-        send_event = next(t for t in tools if t.name == "band_send_event")
-        store_memory = next(t for t in tools if t.name == "band_store_memory")
-
-        assert send_event.args_schema.model_validate(
+    def test_platform_tool_schemas_accept_metadata_fields(self, platform_args_schemas):
+        assert platform_args_schemas["band_send_event"].model_validate(
             {
                 "content": "state update",
                 "message_type": "task",
                 "metadata": {"run_id": "run-1"},
             }
         ).metadata == {"run_id": "run-1"}
-        assert store_memory.args_schema.model_validate(
+        assert platform_args_schemas["band_store_memory"].model_validate(
             {
                 "content": "remember this",
                 "system": "working",
-                "memory_type": "semantic",
+                "type": "semantic",
                 "segment": "user",
                 "thought": "useful later",
                 "scope": "organization",
@@ -301,7 +295,7 @@ class TestToolSetComposition:
         )
         send_message = next(t for t in tools if t.name == "band_send_message")
 
-        result = json.loads(send_message._run(content="hello", mentions="[]"))
+        result = json.loads(send_message._run(content="hello", mentions=[]))
 
         assert result["status"] == "success"
         tools_obj.send_message.assert_awaited_once()
@@ -371,7 +365,7 @@ class TestToolSetComposition:
         )
         send_message = next(t for t in tools if t.name == "band_send_message")
 
-        result = json.loads(send_message._run(content="hello", mentions="[]"))
+        result = json.loads(send_message._run(content="hello", mentions=[]))
 
         assert result["status"] == "error"
         assert tracker.replied is False
@@ -406,7 +400,7 @@ class TestToolSetComposition:
         )
         send_message = next(t for t in tools if t.name == "band_send_message")
 
-        result = json.loads(send_message._run(content="hello", mentions="[]"))
+        result = json.loads(send_message._run(content="hello", mentions=[]))
 
         assert result["status"] == "error"
         assert "@john" in result["message"]
@@ -440,7 +434,7 @@ class TestToolSetComposition:
         )
         send_message = next(t for t in tools if t.name == "band_send_message")
 
-        result = json.loads(send_message._run(content="hello", mentions="[]"))
+        result = json.loads(send_message._run(content="hello", mentions=[]))
 
         assert result["status"] == "error"
         assert "@john" in result["message"]
@@ -571,7 +565,7 @@ class TestMissingContext:
             capabilities=frozenset(),
         )
         send_message_tool = next(t for t in tools if t.name == "band_send_message")
-        result_str = send_message_tool._run(content="hi", mentions="[]")
+        result_str = send_message_tool._run(content="hi", mentions=[])
         result = json.loads(result_str)
         assert result["status"] == "error"
         assert "No room context available" in result["message"]
@@ -597,47 +591,43 @@ class TestRunAsyncLazyPatch:
         assert crewai_mocks.apply.call_count == 1
 
 
-class TestStoreMemoryInputDescription:
-    def test_crewai_store_memory_type_description_is_generated(self, builder_mod):
-        """CrewAI store_memory args schema should use memory_type_field_description()."""
+class TestStoreMemoryArgsSchema:
+    """CrewAI advertises the master model, so master text and validators apply."""
+
+    def test_type_description_comes_from_master(self, platform_args_schemas) -> None:
         from band.core.memory_types import memory_type_field_description
 
-        expected = memory_type_field_description()
+        schema = platform_args_schemas["band_store_memory"]
         assert (
-            builder_mod._StoreMemoryInput.model_fields["memory_type"].description
-            == expected
+            schema.model_fields["type"].description == memory_type_field_description()
         )
 
-    def test_crewai_store_memory_rejects_subject_scope_without_subject_id(
-        self, builder_mod
+    def test_rejects_subject_scope_without_subject_id(
+        self, platform_args_schemas
     ) -> None:
-        """CrewAI input validation rejects missing subject IDs."""
         from pydantic import ValidationError
 
         with pytest.raises(ValidationError, match="requires a subject_id"):
-            builder_mod._StoreMemoryInput.model_validate(
+            platform_args_schemas["band_store_memory"].model_validate(
                 {
                     "content": "remember this",
                     "system": "working",
-                    "memory_type": "semantic",
+                    "type": "semantic",
                     "segment": "user",
                     "thought": "useful later",
                     "scope": "subject",
                 }
             )
 
-    def test_crewai_store_memory_rejects_type_for_wrong_system(
-        self, builder_mod
-    ) -> None:
-        """CrewAI input validation rejects system/type mismatches."""
+    def test_rejects_type_for_wrong_system(self, platform_args_schemas) -> None:
         from pydantic import ValidationError
 
         with pytest.raises(ValidationError, match='type="semantic" is not valid'):
-            builder_mod._StoreMemoryInput.model_validate(
+            platform_args_schemas["band_store_memory"].model_validate(
                 {
                     "content": "remember this",
                     "system": "sensory",
-                    "memory_type": "semantic",
+                    "type": "semantic",
                     "segment": "user",
                     "thought": "useful later",
                     "scope": "organization",

--- a/tests/runtime/test_tool_definitions.py
+++ b/tests/runtime/test_tool_definitions.py
@@ -239,6 +239,27 @@ class TestGetToolDocstringWithArgs:
             "mentions": "first line second line"
         }
 
+    def test_whitespace_only_description_is_omitted(self, monkeypatch):
+        """A whitespace-only Field(description=...) is truthy, so it must be
+
+        filtered before reaching format_arg_doc's splitlines unpack — that
+        unpack has no floor and raises ValueError on an empty result, which
+        would crash any adapter importing this tool's schema.
+        """
+        from pydantic import BaseModel, Field
+
+        class ProbeInput(BaseModel):
+            """Probe tool for a whitespace-only field description."""
+
+            blank: str = Field(..., description="   ")
+            real: str = Field(..., description="Has text")
+
+        monkeypatch.setitem(TOOL_MODELS, "band_probe_whitespace", ProbeInput)
+
+        docstring = get_tool_docstring_with_args("band_probe_whitespace")
+
+        assert args_section(docstring) == {"real": "Has text"}
+
 
 class TestPlatformTool:
     def test_decorator_applies_master_docstring(self):

--- a/tests/runtime/test_tool_definitions.py
+++ b/tests/runtime/test_tool_definitions.py
@@ -240,11 +240,12 @@ class TestGetToolDocstringWithArgs:
         }
 
     def test_whitespace_only_description_is_omitted(self, monkeypatch):
-        """A whitespace-only Field(description=...) is truthy, so it must be
+        """A whitespace-only Field(description=...) must be filtered out.
 
-        filtered before reaching format_arg_doc's splitlines unpack — that
-        unpack has no floor and raises ValueError on an empty result, which
-        would crash any adapter importing this tool's schema.
+        It's truthy, so without filtering it reaches format_arg_doc's
+        splitlines unpack — that unpack has no floor and raises ValueError on
+        an empty result, which would crash any adapter importing this tool's
+        schema.
         """
         from pydantic import BaseModel, Field
 

--- a/tests/runtime/test_tool_definitions.py
+++ b/tests/runtime/test_tool_definitions.py
@@ -17,7 +17,11 @@ from band.runtime.tools import (
     SendEventInput,
     AddParticipantInput,
     LookupPeersInput,
+    format_arg_doc,
     get_tool_description,
+    get_tool_docstring_with_args,
+    platform_args_schema,
+    platform_tool,
 )
 
 
@@ -177,3 +181,93 @@ class TestGetToolDescription:
         """Should return fallback for unknown tool name."""
         desc = get_tool_description("unknown_tool")
         assert desc == "Execute unknown_tool"
+
+
+def args_section(docstring: str) -> dict[str, str]:
+    """Parse the rendered ``Args:`` block back into {arg_name: description}.
+
+    Mirrors how a Google-style docstring parser reads it: a line indented past
+    the argument name continues the previous entry.
+    """
+    _, _, args_block = docstring.partition("\nArgs:\n")
+    entries: dict[str, str] = {}
+    current = ""
+    for line in args_block.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith("        "):
+            entries[current] += " " + line.strip()
+            continue
+        current, _, description = line.strip().partition(": ")
+        entries[current] = description
+    return entries
+
+
+class TestGetToolDocstringWithArgs:
+    """The Args: section is rendered from the master fields, never hand-written."""
+
+    @pytest.mark.parametrize(
+        "name", ["band_send_message", "band_add_participant", "band_store_memory"]
+    )
+    def test_args_section_mirrors_master_field_descriptions(self, name):
+        model = TOOL_MODELS[name]
+        expected = {
+            field_name: field.description
+            for field_name, field in model.model_fields.items()
+            if field.description
+        }
+
+        assert args_section(get_tool_docstring_with_args(name)) == expected
+
+    def test_description_comes_first_verbatim(self):
+        docstring = get_tool_docstring_with_args("band_send_message")
+
+        assert docstring.startswith(get_tool_description("band_send_message").rstrip())
+
+    def test_fieldless_model_gets_no_args_section(self):
+        """GetParticipantsInput has no fields, so there is nothing to document."""
+        assert get_tool_docstring_with_args("band_get_participants") == (
+            get_tool_description("band_get_participants")
+        )
+
+    def test_multiline_description_stays_one_entry(self):
+        """A flush-left continuation would end the entry for a docstring parser."""
+        rendered = format_arg_doc("mentions", "first line\nsecond line")
+
+        assert rendered == "    mentions: first line\n        second line"
+        assert args_section(f"x\n\nArgs:\n{rendered}") == {
+            "mentions": "first line second line"
+        }
+
+
+class TestPlatformTool:
+    def test_decorator_applies_master_docstring(self):
+        @platform_tool("band_add_participant")
+        def whatever(identifier: str, role: str) -> None: ...
+
+        assert whatever.__doc__ == get_tool_docstring_with_args("band_add_participant")
+
+
+class TestPlatformArgsSchema:
+    def test_returns_master_model_unchanged_without_validators(self):
+        assert platform_args_schema("band_send_message") is SendMessageInput
+
+    def test_subclass_keeps_master_description_and_field_text(self):
+        from pydantic import field_validator
+
+        schema = platform_args_schema(
+            "band_send_message",
+            validators={
+                "coerce": field_validator("mentions", mode="before")(
+                    staticmethod(lambda v: [v] if isinstance(v, str) else v)
+                )
+            },
+        )
+
+        assert issubclass(schema, SendMessageInput)
+        assert schema.__doc__ == SendMessageInput.__doc__
+        assert (
+            schema.model_fields["mentions"].description
+            == SendMessageInput.model_fields["mentions"].description
+        )
+        assert schema(content="hi", mentions="@alice").mentions == ["@alice"]

--- a/tests/runtime/test_tool_definitions.py
+++ b/tests/runtime/test_tool_definitions.py
@@ -242,10 +242,12 @@ class TestGetToolDocstringWithArgs:
 
 class TestPlatformTool:
     def test_decorator_applies_master_docstring(self):
-        @platform_tool("band_add_participant")
-        def whatever(identifier: str, role: str) -> None: ...
+        @platform_tool
+        def band_add_participant(identifier: str, role: str) -> None: ...
 
-        assert whatever.__doc__ == get_tool_docstring_with_args("band_add_participant")
+        assert band_add_participant.__doc__ == get_tool_docstring_with_args(
+            "band_add_participant"
+        )
 
 
 class TestPlatformArgsSchema:


### PR DESCRIPTION
## Summary

- `runtime/tools.py` is meant to be the single source of truth for platform tool text (docstring = tool description, `Field(description=...)` = arg description). CrewAI hand-duplicated all 17 input models with independently written descriptions — measured drift on 14 of 42 fields, not the single instance INT-1171 named. pydantic_ai duplicated nothing but silently dropped every per-argument description, since pydantic-ai's griffe parser only reads `Args:` sections and the adapter supplied bare type hints.
- Adds two factories in `runtime/tools.py` that make the mistake structurally hard to make: `platform_args_schema(name, validators=...)` returns the master input model (optionally with adapter-only parsing leniency layered on via `create_model`), and `platform_tool(name)` decorates a function with the master docstring plus a rendered `Args:` section. Neither accepts description text.
- CrewAI's 17 duplicated model classes are deleted; both adapters rewired onto the factories.
- Restores INT-336's lenient `mentions` normalizer (`list[str]` + JSON-string/bracketed-handle coercion), silently reverted to a JSON-string field by a later refactor.
- Adds a registry-driven guardrail (`test_tool_text_drift.py`) that fails if an adapter's advertised schema diverges from the master — wired for pydantic_ai and CrewAI, the two adapters that build their own schema objects.
- Fixes a real gap found in review: `band_lookup_peers.page`/`page_size` lost their `ge=1` lower bound when CrewAI's locally-bounded copy was deleted in favor of the (unbounded) master — fixed on the master model, closing it for every adapter.
- Parlant already had this bug and is already fixed by #545 (INT-1170, separate PR, currently open) — not touched here.

## Behavior change

`band_send_event.message_type` is now **required** for CrewAI instead of defaulting to `"thought"`, matching every other adapter and the master model. A CrewAI agent that omits it now gets a validation error instead of a silently mislabeled event.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/` — 4559 passed
- [x] `uv run pytest tests/integrations/test_crewai_real_tools.py ...` against the real `crewai` package (`--extra dev-crewai`) — 145 passed
- [x] `uv run ruff check . && uv run ruff format --check . && uv run pyrefly check` — clean
- [x] `uv run pytest --markdown-docs $(git ls-files '*.md' ':!:examples/*')` — 61 passed
- [x] Verified all 17 pydantic_ai tool schemas now match the master exactly (0/42 mismatches; was 42/42 before the fix)
- [x] Verified the new CrewAI probe catches injected drift (re-declaring a field description on the local subclass fails the guardrail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mZ9meinC1E4WPLzNjY2LE