### PR TITLE
chore(docs): wire changelog-generator for cloud sessions

### DIFF
--- a/.band/changelog.yml
+++ b/.band/changelog.yml
@@ -1,0 +1,18 @@
+fern_repo: thenvoi/fern
+fern_changelog_path: fern/changelog/sdks
+product:
+  name: Band Python SDK
+  label: Python SDK
+  tag: python
+linear:
+  team_key: INT
+announce:
+  slack:
+    enabled: true
+    channel: integrations
+    mode: live
+  discord:
+    # channel is a label only — the webhook fixes the real target, which in
+    # draft mode is the private review channel a human forwards from.
+    enabled: true
+    mode: draft

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "extraKnownMarketplaces": {
+    "private-agent-skills": {
+      "source": { "source": "github", "repo": "band-ai/private-agent-skills" },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "changelog-generator@private-agent-skills": true
+  }
+}


### PR DESCRIPTION
## Summary
Makes `/changelog-generator:generate` actually runnable in this repo, including from Claude cloud sessions and routines.

Two gaps this closes:
- `.claude/settings.json` existed only as an **untracked local file** with `enabledPlugins`, and with no `extraKnownMarketplaces` entry. Cloud sessions install plugins from the repo's committed settings, so the plugin resolved to nothing there.
- `.band/changelog.yml` did not exist, and `generate` treats it as a required input.

## Config values, and where they come from
| Key | Value | Source |
| --- | --- | --- |
| `fern_repo` | `thenvoi/fern` | `band-ai/fern` no longer resolves; `thenvoi/fern` is the live docs source |
| `fern_changelog_path` | `fern/changelog/sdks` | surface dir holding this product's entries |
| `product.label` / `product.tag` | `Python SDK` / `python` | matches every existing entry in that surface |
| `linear.team_key` | `INT` | INT-#### identifiers throughout this repo's history |
| Slack | live → `integrations` | confirmed target channel |
| Discord | draft | webhook points at the private review channel; the config `channel` is a label only, so it is omitted |

## Still needed outside this PR
The cloud environment itself (network allowlist for `api.linear.app`, `LINEAR_API_KEY` and webhook vars, and a setup script installing `gh` + `fern-api`) is configured at claude.ai/code, not in the repo.