### PR TITLE
fix: repair backends E2E baseline regressions from PR #520 (INT-1254)

### DIFF
--- a/tests/e2e/baseline/smoke/adapters/test_codex.py
+++ b/tests/e2e/baseline/smoke/adapters/test_codex.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import pytest
 
 from band.adapters.codex import CodexAdapter, CodexAdapterConfig
-from band.core.types import AdapterFeatures, Emit
+from band.core.types import Emit
 
 from tests.e2e.baseline.agents import Lane, lane
 from tests.e2e.baseline.flaky import flaky_infra
@@ -72,7 +72,7 @@ async def test_codex_thoughts_are_not_placeholders(
     config_kwargs["reasoning_summary"] = "auto"
     adapter = CodexAdapter(
         config=CodexAdapterConfig(**config_kwargs),
-        features=AdapterFeatures(emit={Emit.THOUGHTS}),
+        emit=Emit.THOUGHTS,
     )
 
     identity = await resource_manager.provision_agent("codex-thoughts")

--- a/tests/e2e/baseline/toolkit/builders.py
+++ b/tests/e2e/baseline/toolkit/builders.py
@@ -466,10 +466,20 @@ def _build_copilot_acp(
     if s.backends.copilot_command.strip():
         config_kwargs["command"] = tuple(s.backends.copilot_command.split())
 
+    built_features = feature_kwargs(features)
+    if "emit" in built_features:
+        # memory_features()/contacts_features() request Emit.TOOL_CALLS so tool
+        # calls surface as tool_call events for the rest of the matrix, but this
+        # adapter narrates every tool call unconditionally and declares no
+        # SUPPORTED_EMIT (see ACPClientAdapter) -- clamp to what it actually
+        # supports so the shared fixture's intent survives without tripping the
+        # construction-time unsupported-emit check.
+        built_features["emit"] &= CopilotACPAdapter.SUPPORTED_EMIT
+
     return CopilotACPAdapter(
         config=CopilotACPAdapterConfig(**config_kwargs),
         additional_tools=_custom_tool_defs(tools),
-        **feature_kwargs(features),
+        **built_features,
     )
 
 


### PR DESCRIPTION
## Summary
- `CopilotACPAdapter` declares `SUPPORTED_EMIT = frozenset()` by design (ACP tool narration is unconditional, never emit-gated), but the shared `memory_features()`/`contacts_features()` capability-matrix fixtures hardcode `emit={Emit.TOOL_CALLS}` for every adapter. PR #520 turned an unsupported-emit request from a lazy `on_started` warning into a construction-time `BandConfigError`, so every copilot_acp memory/contacts matrix cell now fails at fixture setup.
- `test_codex_thoughts_are_not_placeholders` still built its adapter via the retired `features=AdapterFeatures(emit={Emit.THOUGHTS})` pattern PR #520 removed, raising `TypeError: SimpleAdapter._resolve_features() got an unexpected keyword argument 'features'`.
- `_build_copilot_acp` now clamps the requested `emit` to `CopilotACPAdapter.SUPPORTED_EMIT` before construction, and the codex smoke uses the direct `emit=Emit.THOUGHTS` kwarg.

Fixes the 4 nightly baseline failures from [run 32443980372](https://github.com/band-ai/band-sdk-python/actions/runs/32443980372) (commit 1ca53baa): `test_store_memory_across_memory_adapters[copilot_acp]`, `test_recall_memory_across_memory_adapters[copilot_acp]`, `test_memory_survives_adapter_rehydration[copilot_acp]`, `test_list_contacts_across_contacts_adapters[copilot_acp]`; plus `test_codex.py::test_codex_thoughts_are_not_placeholders`.

Test-only change — `src/band` untouched; the stricter construction-time validation from PR #520 is correct and stays as-is.

Linear: INT-1254

## Test plan
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files
- [x] `uv run pyrefly check` — 0 errors
- [x] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/ -q` — 4874 passed, 122 skipped
- [x] Direct construction sanity checks confirming `CopilotACPAdapter`/`CodexAdapter` no longer raise `BandConfigError`/`TypeError` with the fixed builders
- [ ] Live backends-lane E2E run (`BAND_E2E_LANE=backends`) to confirm the 5 tests pass against the real platform + Copilot/Codex CLIs (needs live credentials, not run in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JieRNYtYxMPfLkMqHgbXvT