### PR TITLE
test: fail on JSONDecodeError chain from empty 429 (#108)

### DIFF
--- a/tests/platform/test_rest_empty_429.py
+++ b/tests/platform/test_rest_empty_429.py
@@ -1,0 +1,43 @@
+"""Empty HTTP 429 bodies must raise a clean ApiError (GitHub #108).
+
+AWS ALB rate-limit responses often have ``Content-Length: 0``. The Fern
+raw client still calls ``_response.json()`` for that status, then wraps
+the resulting ``JSONDecodeError`` in ``ApiError`` without ``from None``.
+Python therefore prints both tracebacks.
+
+Interception is the maintained ``pytest-httpx`` ``httpx_mock`` fixture on
+the real ``BandLink`` REST client, matching ``test_link_credentials.py``.
+``max_retries=0`` isolates the decode/chaining bug from Fern 429 retries.
+"""
+
+from __future__ import annotations
+
+import traceback
+from json.decoder import JSONDecodeError
+
+import pytest
+from band_rest.core.api_error import ApiError
+from pytest_httpx import HTTPXMock
+
+from band.platform.link import BandLink
+
+
+async def test_empty_429_raises_api_error_without_json_decode_chain(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(status_code=429, content=b"")
+
+    link = BandLink(agent_id="agent-1", api_key="test-key")
+    with pytest.raises(ApiError) as exc_info:
+        await link.rest.agent_api_identity.get_agent_me(
+            request_options={"max_retries": 0},
+        )
+
+    error = exc_info.value
+    formatted = "".join(traceback.format_exception(error))
+    assert error.status_code == 429
+    assert not isinstance(error.__cause__, JSONDecodeError)
+    assert error.__suppress_context__ or not isinstance(
+        error.__context__, JSONDecodeError
+    )
+    assert "JSONDecodeError" not in formatted

--- a/tests/platform/test_rest_empty_429.py
+++ b/tests/platform/test_rest_empty_429.py
@@ -39,5 +39,5 @@ async def test_empty_429_raises_api_error_without_json_decode_chain(
     assert not isinstance(error.__cause__, JSONDecodeError)
     assert error.__suppress_context__ or not isinstance(
         error.__context__, JSONDecodeError
-    )
+    ), formatted
     assert "JSONDecodeError" not in formatted


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**JSONDecodeError traceback shown on empty 429 response bodies** ([#108](https://github.com/band-ai/band-sdk-python/issues/108))

This PR is **test-only and red on purpose**. It does not implement a production fix. It pins the #108 failure so a later change can turn it green.

## Expected vs actual

- **Expected:** an empty ALB-style HTTP 429 (`Content-Length: 0`) raises a clean `ApiError` with no `JSONDecodeError` in `__cause__` / `__context__` and no intermediate `JSONDecodeError` traceback.
- **Actual (current `main`, `band-client-rest==0.0.26`):** `get_agent_me` still calls `_response.json()` for 429, catches `JSONDecodeError`, and re-raises `ApiError` without `from None`. Python exception chaining prints both tracebacks.

Confirmed locally and in CI: `ApiError.status_code == 429`, `__cause__` is `None`, `__suppress_context__` is `False`, `__context__` is `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`.

## Test

- **File:** `tests/platform/test_rest_empty_429.py`
- **Command:**

```bash
uv run pytest tests/platform/test_rest_empty_429.py -v --no-cov
```

The test mocks an empty 429 on the real `BandLink` → `agent_api_identity.get_agent_me` path (`pytest-httpx`, `max_retries=0` to isolate decode/chaining from #107 retry behavior).

## CI (expected red)

Required `CI / test` jobs (Ubuntu/Windows × 3.11/3.12) failed on **only** this new test:

```
FAILED tests/platform/test_rest_empty_429.py::test_empty_429_raises_api_error_without_json_decode_chain
==== 1 failed, 4874 passed, 535 skipped ... =====
```

Lint, packaging, crewai, and parlant jobs passed. The assertion fails because `ApiError.__context__` is `JSONDecodeError` (formatted traceback includes "During handling of the above exception, another exception occurred").

## Related Issues

Relates to #108

## Testing

- [ ] Unit tests pass (`uv run pytest tests/ --ignore=tests/integration/`) — **this PR is expected to fail the new test**
- [x] Lint passed in CI
- [ ] Integration tests pass (if applicable)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Code follows project style guidelines
- [x] Tests added/updated as needed
- [ ] Documentation updated as needed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d449a47-260f-4f47-a93f-4994d7ce2650?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d449a47-260f-4f47-a93f-4994d7ce2650&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

