### PR TITLE
fix: suppress JSONDecodeError chain on empty HTTP 429

### DIFF
--- a/src/band/client/rest.py
+++ b/src/band/client/rest.py
@@ -81,8 +81,10 @@ def _without_json_decode_chain(
     return wrapper
 
 
-AsyncRawAgentApiIdentityClient.get_agent_me = _without_json_decode_chain(
-    AsyncRawAgentApiIdentityClient.get_agent_me
+setattr(
+    AsyncRawAgentApiIdentityClient,
+    "get_agent_me",
+    _without_json_decode_chain(AsyncRawAgentApiIdentityClient.get_agent_me),
 )
 
 __all__ = [

--- a/src/band/client/rest.py
+++ b/src/band/client/rest.py
@@ -13,6 +13,13 @@ Usage:
     )
 """
 
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from functools import wraps
+from json.decoder import JSONDecodeError
+from typing import Any
+
 from band_rest import (
     RestClient,
     AsyncRestClient,
@@ -39,7 +46,9 @@ from band_rest import (
     Peer,
     UnauthorizedError,
 )
+from band_rest.agent_api_identity.raw_client import AsyncRawAgentApiIdentityClient
 from band_rest.core import ParsingError
+from band_rest.core.api_error import ApiError
 from band_rest.core.request_options import RequestOptions
 from band_rest.types import ChatMessageRequestMentionsItem
 
@@ -47,6 +56,34 @@ from band_rest.types import ChatMessageRequestMentionsItem
 # The band_rest client defaults to max_retries=0, which disables retries.
 # We set max_retries=3 to handle transient rate limit errors gracefully.
 DEFAULT_REQUEST_OPTIONS: RequestOptions = {"max_retries": 3}
+
+
+def _without_json_decode_chain(
+    method: Callable[..., Awaitable[Any]],
+) -> Callable[..., Awaitable[Any]]:
+    """Re-raise Fern ``ApiError`` without a ``JSONDecodeError`` ``__context__``.
+
+    ``band-client-rest==0.0.26`` (still in 0.0.28) calls ``_response.json()``
+    for non-2xx statuses, then ``raise ApiError(...)`` on ``JSONDecodeError``
+    without ``from None``. Empty ALB 429 bodies therefore print both
+    tracebacks. Drop this wrap when the pin raises with ``from None``.
+    """
+
+    @wraps(method)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return await method(*args, **kwargs)
+        except ApiError as error:
+            if isinstance(error.__context__, JSONDecodeError):
+                raise error from None
+            raise
+
+    return wrapper
+
+
+AsyncRawAgentApiIdentityClient.get_agent_me = _without_json_decode_chain(
+    AsyncRawAgentApiIdentityClient.get_agent_me
+)
 
 __all__ = [
     "RestClient",

--- a/tests/platform/test_rest_empty_429.py
+++ b/tests/platform/test_rest_empty_429.py
@@ -1,0 +1,43 @@
+"""Empty HTTP 429 bodies must raise a clean ApiError (GitHub #108).
+
+AWS ALB rate-limit responses often have ``Content-Length: 0``. The Fern
+raw client still calls ``_response.json()`` for that status, then wraps
+the resulting ``JSONDecodeError`` in ``ApiError`` without ``from None``.
+Python therefore prints both tracebacks.
+
+Interception is the maintained ``pytest-httpx`` ``httpx_mock`` fixture on
+the real ``BandLink`` REST client, matching ``test_link_credentials.py``.
+``max_retries=0`` isolates the decode/chaining bug from Fern 429 retries.
+"""
+
+from __future__ import annotations
+
+import traceback
+from json.decoder import JSONDecodeError
+
+import pytest
+from band_rest.core.api_error import ApiError
+from pytest_httpx import HTTPXMock
+
+from band.platform.link import BandLink
+
+
+async def test_empty_429_raises_api_error_without_json_decode_chain(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(status_code=429, content=b"")
+
+    link = BandLink(agent_id="agent-1", api_key="test-key")
+    with pytest.raises(ApiError) as exc_info:
+        await link.rest.agent_api_identity.get_agent_me(
+            request_options={"max_retries": 0},
+        )
+
+    error = exc_info.value
+    formatted = "".join(traceback.format_exception(error))
+    assert error.status_code == 429
+    assert not isinstance(error.__cause__, JSONDecodeError)
+    assert error.__suppress_context__ or not isinstance(
+        error.__context__, JSONDecodeError
+    )
+    assert "JSONDecodeError" not in formatted

--- a/tests/platform/test_rest_empty_429.py
+++ b/tests/platform/test_rest_empty_429.py
@@ -39,5 +39,5 @@ async def test_empty_429_raises_api_error_without_json_decode_chain(
     assert not isinstance(error.__cause__, JSONDecodeError)
     assert error.__suppress_context__ or not isinstance(
         error.__context__, JSONDecodeError
-    )
+    ), formatted
     assert "JSONDecodeError" not in formatted


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**JSONDecodeError traceback shown on empty 429 response bodies** ([#108](https://github.com/band-ai/band-sdk-python/issues/108))

Turns QA PR #557's test green. Empty ALB-style HTTP 429 (`Content-Length: 0`) on `BandLink` → `agent_api_identity.get_agent_me` now raises a clean `ApiError` with no `JSONDecodeError` in `__cause__` / `__context__` and no intermediate traceback.

## Changes

- Confirmed `band-client-rest==0.0.26` (and 0.0.28) still `raise ApiError(...)` from `JSONDecodeError` without `from None` in generated `get_agent_me`. Bumping the pin does not fix this.
- SDK-side wrap on the generated raw `get_agent_me` re-raises that `ApiError` with `from None`. Does not change Fern 429 retry behavior.

## Related Issues

Fixes #108

## Testing

- [x] `uv run pytest tests/platform/test_rest_empty_429.py -v --no-cov` (QA #557 test; red-to-green)
- [x] `uv run pytest tests/test_platform_runtime.py::TestStart::test_retries_metadata_fetch_on_rate_limit -v --no-cov`
- [x] Unit tests pass (`uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/` — 4875 passed, 122 skipped)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Code follows project style guidelines
- [x] Tests added/updated as needed (test is from QA PR #557; not rewritten)
- [ ] Documentation updated as needed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4940b2ce-5b75-4694-9db7-8c979b885a94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4940b2ce-5b75-4694-9db7-8c979b885a94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

