### PR TITLE
fix: require band-sdk>=2.1.0 in band-mcp

### DIFF
--- a/packages/band-mcp/pyproject.toml
+++ b/packages/band-mcp/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     # bump-mcp-sdk-floor job, so this always tracks the most recently
     # published band-sdk version -- band-mcp is developed in lockstep in
     # this monorepo and can depend on any already-released SDK feature.
-    "band-sdk>=1.6.0",
+    "band-sdk>=2.1.0",
     "uvicorn>=0.30.0",  # Required for SSE transport mode
 ]
 


### PR DESCRIPTION
band_mcp imports `band.integrations.mcp.engine`, which first shipped in band-sdk 2.1.0 (#552 → released as [band-sdk-v2.1.0](https://github.com/band-ai/band-sdk-python/releases/tag/band-sdk-v2.1.0)); the declared floor still said `>=1.6.0`, so a resolver could pair band-mcp with an SDK that lacks the engine and fail at import.

Supersedes #563, which aimed the floor at 3.0.0 — a version that never shipped (the band-sdk-v3.0.0 tag was a release-please misattribution of #552's band-mcp-only breaking change; the real release is 2.1.0, now on PyPI).

Merging this lets release-please cut band-mcp 2.0.1 with correct metadata. band-mcp 2.0.0 (tag `band-mcp-v2.0.0`) was never published to PyPI and stays unpublished — its floor lies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBcyR6pVrussVWoR6dWaR5