### PR TITLE
ci: probe the band-sdk floor against a scratch venv in band-mcp-publish

### DIFF
--- a/.github/workflows/band-mcp-publish.yml
+++ b/.github/workflows/band-mcp-publish.yml
@@ -80,9 +80,14 @@ jobs:
           print(re.search(r'>=([0-9]+\.[0-9]+\.[0-9]+)', band_sdk).group(1))
           PYEOF
           )
+          # Dry-run into a scratch venv: the runner's bare python3 is
+          # Ubuntu's externally-managed interpreter, which uv refuses to
+          # target, so probing it fails on every attempt regardless of
+          # whether the version is indexed.
+          uv venv /tmp/floor-check
           echo "Waiting for band-sdk==${FLOOR} to be indexed on PyPI..."
           for _ in $(seq 1 60); do
-            if uv pip install "band-sdk==${FLOOR}" --dry-run --python "$(which python3)" >/dev/null 2>&1; then
+            if uv pip install "band-sdk==${FLOOR}" --dry-run --python /tmp/floor-check/bin/python; then
               echo "band-sdk==${FLOOR} is available."
               exit 0
             fi


### PR DESCRIPTION
The band-mcp-publish floor-wait step dry-ran the install against `$(which python3)` — the runner's externally-managed system interpreter, which uv refuses to target — so every probe failed and the loop timed out even when the version was already indexed ([failed run](https://github.com/band-ai/band-sdk-python/actions/runs/32630865121): waited 10 minutes for band-sdk==1.6.0, on PyPI since Aug 3). The `>/dev/null 2>&1` swallow hid the real error.

Fix: probe a scratch `uv venv` instead (the same pattern the install-check step below it and CI's packaging job already use), and stop swallowing the probe's output.

`ci:` type on purpose — no release bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBcyR6pVrussVWoR6dWaR5