### PR TITLE
fix: bound e2e health-check curls with --max-time

### DIFF
--- a/.github/scripts/run-baseline-e2e.sh
+++ b/.github/scripts/run-baseline-e2e.sh
@@ -23,21 +23,31 @@ mkdir -p artifacts/attempts
 BAND_E2E_SCORECARD_JSON="$ATTEMPT1" uv run pytest tests/e2e/baseline/ -v -s --no-cov
 code=$?
 if [ "$code" -ne 0 ]; then
-  # --lfnf=none is load-bearing, not a tidy-up: pytest's default for "--last-failed
-  # but no lastfailed cache" is `all`, i.e. run the WHOLE suite. Attempt 1 can fail
-  # without ever recording a failed nodeid (a collection error, an import-time
-  # raise, an OOM/kill mid-session), and the plain flag would then silently promote
-  # the retry into a second full live lane -- double the provider spend and wall
-  # clock, against a leg that carries a wall-clock cap. Deselecting instead is the
-  # honest reading: a retry with nothing identifiable to retry has nothing to add.
-  BAND_E2E_SCORECARD_JSON="$ATTEMPT2" uv run pytest tests/e2e/baseline/ -v -s --no-cov \
-    --last-failed --lfnf=none
-  retry_code=$?
-  # Exit 5 is pytest's "no tests collected" -- here, --lfnf=none deselecting
-  # everything (the no-cache case above). That says nothing about the lane, so
-  # attempt 1's verdict stands rather than being relabeled by an empty retry.
-  if [ "$retry_code" -ne 5 ]; then
-    code=$retry_code
+  # A retry only helps for one-off flakiness (a rate-limit window, a cold start).
+  # If a large fraction of attempt 1 already failed, that reads as a systemic
+  # outage (a degraded provider) instead -- retrying would just re-run every
+  # failed nodeid into the same wall, multiplying the outage's cost (each nodeid
+  # already gets its own flaky_model/flaky_infra reruns) instead of absorbing a
+  # transient. Skip the whole-lane retry in that case; attempt 1's verdict stands.
+  if [ -f "$ATTEMPT1" ] && uv run python -m tests.e2e.baseline.scorecard mass-failure "$ATTEMPT1"; then
+    echo "Attempt 1's failure rate crossed the mass-failure threshold -- skipping the whole-lane retry (a systemic outage won't pass on a second try)." >&2
+  else
+    # --lfnf=none is load-bearing, not a tidy-up: pytest's default for "--last-failed
+    # but no lastfailed cache" is `all`, i.e. run the WHOLE suite. Attempt 1 can fail
+    # without ever recording a failed nodeid (a collection error, an import-time
+    # raise, an OOM/kill mid-session), and the plain flag would then silently promote
+    # the retry into a second full live lane -- double the provider spend and wall
+    # clock, against a leg that carries a wall-clock cap. Deselecting instead is the
+    # honest reading: a retry with nothing identifiable to retry has nothing to add.
+    BAND_E2E_SCORECARD_JSON="$ATTEMPT2" uv run pytest tests/e2e/baseline/ -v -s --no-cov \
+      --last-failed --lfnf=none
+    retry_code=$?
+    # Exit 5 is pytest's "no tests collected" -- here, --lfnf=none deselecting
+    # everything (the no-cache case above). That says nothing about the lane, so
+    # attempt 1's verdict stands rather than being relabeled by an empty retry.
+    if [ "$retry_code" -ne 5 ]; then
+      code=$retry_code
+    fi
   fi
 fi
 

--- a/.github/scripts/setup-letta.sh
+++ b/.github/scripts/setup-letta.sh
@@ -33,7 +33,11 @@ wait_healthy() {
   # dead server and the lane would fail opaquely at test time.
   local ready=false
   for _ in $(seq 1 45); do
-    if curl -fsS http://localhost:8283/v1/health/; then ready=true; break; fi
+    # --max-time bounds each attempt: without it, a server that accepts the
+    # connection but never finishes the response wedges this loop (and the
+    # whole job, up to its 240-minute timeout) on a single curl call instead
+    # of retrying and failing loudly within the intended ~90s budget.
+    if curl -fsS --max-time 5 http://localhost:8283/v1/health/; then ready=true; break; fi
     sleep 2
   done
   if [ "$ready" != true ]; then

--- a/.github/scripts/setup-opencode.sh
+++ b/.github/scripts/setup-opencode.sh
@@ -42,7 +42,11 @@ printf '%s\n' "$OPENCODE_CONFIG_JSON" > "$workdir/opencode.json"
     >/tmp/opencode-serve.log 2>&1 & )
 ready=false
 for _ in $(seq 1 30); do
-  if curl -fsS http://127.0.0.1:4096/global/health; then ready=true; break; fi
+  # --max-time bounds each attempt: without it, a server that accepts the
+  # connection but never finishes the response wedges this loop (and the
+  # whole job, up to its 240-minute timeout) on a single curl call instead
+  # of retrying and failing loudly within the intended ~60s budget.
+  if curl -fsS --max-time 5 http://127.0.0.1:4096/global/health; then ready=true; break; fi
   sleep 2
 done
 # Fail loudly if the server never came up (covers a server that died on launch —

--- a/tests/e2e/baseline/scorecard.py
+++ b/tests/e2e/baseline/scorecard.py
@@ -277,6 +277,28 @@ def gate(rows: list[ScorecardRow], expected_lanes: frozenset[str]) -> GateResult
     return GateResult(ok=not failing and not missing, failing=failing, missing=missing)
 
 
+# Fraction of attempted cells that must fail before a lane's whole-suite retry
+# (run-baseline-e2e.sh) is skipped as unlikely to help. This many failures in one
+# pass reads as a systemic outage (a degraded provider) rather than one-off
+# flakiness, and retrying a systemic outage only spends the same wall clock again
+# -- observed live 2026-08-23: a provider slowdown made the core lane's retry
+# multiply an already-doomed run instead of catching a transient.
+MASS_FAILURE_THRESHOLD = 0.25
+
+
+def failed_fraction(rows: list[ScorecardRow]) -> float:
+    """Fraction of *attempted* rows (``pass``/``fail``; ``skip``/``na`` excluded)
+    that failed.
+
+    Used to tell one-off flakiness from a systemic outage — see
+    ``MASS_FAILURE_THRESHOLD``. ``0.0`` when nothing was attempted.
+    """
+    attempted = [r for r in rows if r.status in ("pass", "fail")]
+    if not attempted:
+        return 0.0
+    return sum(1 for r in attempted if r.status == "fail") / len(attempted)
+
+
 def gate_summary(result: GateResult, rows: list[ScorecardRow]) -> str:
     """A one-line verdict + totals, meant to sit above the markdown grid."""
     counts = {status: sum(1 for r in rows if r.status == status) for status in _RANK}
@@ -405,9 +427,23 @@ def _overlay_cmd(args: argparse.Namespace) -> None:
     logger.info("scorecard: overlaid %d cell(s) -> %s", len(rows), args.out)
 
 
+def _mass_failure_cmd(args: argparse.Namespace) -> None:
+    rows = _load(args.scorecard)
+    fraction = failed_fraction(rows)
+    logger.info(
+        "scorecard: %.0f%% of attempted cells failed (mass-failure threshold %.0f%%)",
+        fraction * 100,
+        MASS_FAILURE_THRESHOLD * 100,
+    )
+    if fraction < MASS_FAILURE_THRESHOLD:
+        sys.exit(1)
+
+
 def main(argv: list[str] | None = None) -> None:
     """CLI: ``merge`` the per-lane scorecards CI uploads into one artifact and gate on
-    it, or ``overlay`` a same-lane retry attempt onto its original run."""
+    it, ``overlay`` a same-lane retry attempt onto its original run, or
+    ``mass-failure`` check whether an attempt's failure rate crossed
+    ``MASS_FAILURE_THRESHOLD`` (exit 0 if so)."""
     parser = argparse.ArgumentParser(prog="scorecard")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
@@ -439,11 +475,21 @@ def main(argv: list[str] | None = None) -> None:
         "--out", required=True, help="combined scorecard JSON path"
     )
 
+    mass_failure_cmd = sub.add_parser(
+        "mass-failure",
+        help="exit 0 if a scorecard's failure rate crosses MASS_FAILURE_THRESHOLD, "
+        "exit 1 otherwise -- used to skip a whole-lane retry that would only repeat "
+        "a systemic outage rather than catch a one-off",
+    )
+    mass_failure_cmd.add_argument("scorecard", help="the attempt's scorecard JSON")
+
     args = parser.parse_args(argv)
     if args.cmd == "merge":
         _merge_cmd(args, parser)
-    else:
+    elif args.cmd == "overlay":
         _overlay_cmd(args)
+    else:
+        _mass_failure_cmd(args)
 
 
 if __name__ == "__main__":

--- a/tests/framework_conformance/test_scorecard.py
+++ b/tests/framework_conformance/test_scorecard.py
@@ -30,9 +30,11 @@ from tests.e2e.baseline.agents import (
     per_adapter,
 )
 from tests.e2e.baseline.scorecard import (
+    MASS_FAILURE_THRESHOLD,
     ScorecardCollector,
     ScorecardRow,
     digest_body,
+    failed_fraction,
     gate,
     gate_summary,
     merge,
@@ -277,6 +279,35 @@ def test_gate_fails_a_skip_cell_whose_lane_was_expected_to_run() -> None:
     result = gate([row], frozenset({str(_LANE_A.id)}))
     assert result.ok is False
     assert result.missing == (row,)
+
+
+def test_failed_fraction_ignores_skip_and_na() -> None:
+    rows = [
+        ScorecardRow("t", _ADAPTER_A, "fail"),
+        ScorecardRow("t", _ADAPTER_B, "pass"),
+        ScorecardRow("t", _ADAPTER_A, "skip"),
+        ScorecardRow("t", _ADAPTER_B, "na", "no usage"),
+    ]
+    assert failed_fraction(rows) == pytest.approx(0.5)
+
+
+def test_failed_fraction_zero_when_nothing_attempted() -> None:
+    rows = [ScorecardRow("t", _ADAPTER_A, "skip")]
+    assert failed_fraction(rows) == 0.0
+
+
+def test_failed_fraction_below_threshold_for_one_off_flakiness() -> None:
+    rows = [ScorecardRow("t", _ADAPTER_A, "fail")] + [
+        ScorecardRow("t", _ADAPTER_B, "pass") for _ in range(9)
+    ]
+    assert failed_fraction(rows) < MASS_FAILURE_THRESHOLD
+
+
+def test_failed_fraction_crosses_threshold_for_systemic_outage() -> None:
+    rows = [ScorecardRow("t", _ADAPTER_A, "fail") for _ in range(3)] + [
+        ScorecardRow("t", _ADAPTER_B, "pass")
+    ]
+    assert failed_fraction(rows) >= MASS_FAILURE_THRESHOLD
 
 
 def test_gate_passes_pass_and_na_cells() -> None:


### PR DESCRIPTION
## Summary
- `setup-opencode.sh`/`setup-letta.sh`: health-check `curl` calls had no timeout. Root cause of a 3+ hour stuck `e2e (backends / ubuntu)` run (workflow run 32639750074): `opencode serve` accepted the TCP connection on `/global/health` but never finished the response, so the single `curl` call blocked forever (confirmed by `opencode`/`curl` subprocesses still alive at cancel time). Adds `--max-time 5` to both.
- `run-baseline-e2e.sh`: the lane's whole-suite retry (`--last-failed` on any attempt-1 failure) had no circuit breaker for a systemic outage. Same day, a provider slowdown made 3/6 core-lane adapters (strands, pydantic_ai, langgraph) time out on nearly every turn; each failing test was retried up to 6x total (2 in-pytest reruns x the lane's own attempt-2 retry), running the `core` lane to its full 240-minute job timeout with no scorecard ever written. Adds `failed_fraction()` / `MASS_FAILURE_THRESHOLD` (25%) to `scorecard.py` and a `mass-failure` CLI check the script consults before retrying: past that threshold, the failure reads as systemic rather than one-off, so the whole-lane retry is skipped and attempt 1's verdict stands.

## Test plan
- [x] Unit tests for `failed_fraction`/`mass-failure` (`tests/framework_conformance/test_scorecard.py`) — 32 passed.
- [x] `ruff check`, `ruff format --check`, `pyrefly check` clean on touched files.
- [ ] Scoped `workflow_dispatch` (`lane=backends`, `os=ubuntu`) on this branch completes without hanging on the OpenCode/Letta setup steps.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LZGfRzusXFKfqEHEPWY5Dv