### PR TITLE
fix: flush the ACP collecting client at turn end in codex-acp e2e tests

### DIFF
--- a/src/band/integrations/acp/client_runtime.py
+++ b/src/band/integrations/acp/client_runtime.py
@@ -855,6 +855,11 @@ class ACPRuntime:
             return []
         return self._client.get_collected_chunks(session_id)
 
+    def get_collected_text(self, session_id: str) -> str:
+        if self._client is None:
+            return ""
+        return self._client.get_collected_text(session_id)
+
     async def stop(self) -> None:
         ctx: AbstractAsyncContextManager[tuple[ACPConnectionProtocol, object]] | None
         async with self._stop_lock:

--- a/src/band/integrations/acp/client_runtime.py
+++ b/src/band/integrations/acp/client_runtime.py
@@ -855,10 +855,17 @@ class ACPRuntime:
             return []
         return self._client.get_collected_chunks(session_id)
 
-    def get_collected_text(self, session_id: str) -> str:
-        if self._client is None:
-            return ""
-        return self._client.get_collected_text(session_id)
+    @property
+    def client(self) -> ACPCollectingClient | None:
+        """The active collecting client, once started.
+
+        ``ACPRuntime`` only forwards the handful of client methods a real turn
+        needs (``get_collected_chunks``, ``reset_session``, ...); this is the
+        read-only escape hatch for callers that need something else off the
+        buffer directly (e.g. ``get_collected_text``) rather than growing
+        ``ACPRuntime`` a passthrough per client method.
+        """
+        return self._client
 
     async def stop(self) -> None:
         ctx: AbstractAsyncContextManager[tuple[ACPConnectionProtocol, object]] | None

--- a/tests/integrations/acp/test_e2e_codex_acp.py
+++ b/tests/integrations/acp/test_e2e_codex_acp.py
@@ -189,6 +189,7 @@ async def test_codex_acp_new_session(acp_client: BandACPClient) -> None:
 @pytest.mark.asyncio(loop_scope="session")
 async def test_codex_acp_prompt_and_collect(acp_runtime: ACPRuntime) -> None:
     """Should send a prompt and collect response chunks from codex-acp."""
+    assert acp_runtime.client is not None
     session_id = await asyncio.wait_for(
         acp_runtime.create_session(cwd="/tmp", mcp_servers=[]),
         timeout=_INIT_TIMEOUT,
@@ -202,7 +203,7 @@ async def test_codex_acp_prompt_and_collect(acp_runtime: ACPRuntime) -> None:
         ),
         timeout=_PROMPT_TIMEOUT,
     )
-    text = acp_runtime.get_collected_text(session_id)
+    text = acp_runtime.client.get_collected_text(session_id)
     logger.info("Collected %d chunks, text: %s", len(chunks), text[:200])
 
     assert len(chunks) > 0, "Expected at least one response chunk"
@@ -220,6 +221,8 @@ async def test_codex_acp_http_mcp_server_tool_call(
 ) -> None:
     """Should connect to a local HTTP MCP server and execute a tool."""
     from acp.schema import HttpMcpServer
+
+    assert acp_runtime.client is not None
 
     # execute() must return a wire-serialized string: the dynamic handler
     # build_engine() creates always declares -> str, so FastMCP's
@@ -271,7 +274,7 @@ async def test_codex_acp_http_mcp_server_tool_call(
             ),
             timeout=_PROMPT_TIMEOUT,
         )
-        text = acp_runtime.get_collected_text(session_id)
+        text = acp_runtime.client.get_collected_text(session_id)
 
         assert any(chunk.chunk_type == "tool_call" for chunk in chunks)
         assert any(chunk.chunk_type == "tool_result" for chunk in chunks)
@@ -288,6 +291,8 @@ async def test_codex_acp_band_mcp_tool_call(
     from acp.schema import HttpMcpServer
 
     from tests.runtime.conftest import make_participant
+
+    assert acp_runtime.client is not None
 
     rest = SimpleNamespace(
         agent_api_participants=SimpleNamespace(
@@ -355,7 +360,7 @@ async def test_codex_acp_band_mcp_tool_call(
             ),
             timeout=_PROMPT_TIMEOUT,
         )
-        text = acp_runtime.get_collected_text(session_id)
+        text = acp_runtime.client.get_collected_text(session_id)
 
         tool_calls = [chunk for chunk in chunks if chunk.chunk_type == "tool_call"]
         if not tool_calls:
@@ -373,6 +378,7 @@ async def test_codex_acp_band_mcp_tool_call(
 @pytest.mark.asyncio(loop_scope="session")
 async def test_codex_acp_multiple_sessions(acp_runtime: ACPRuntime) -> None:
     """Should handle multiple concurrent sessions with separate buffers."""
+    assert acp_runtime.client is not None
     s1_id = await asyncio.wait_for(
         acp_runtime.create_session(cwd="/tmp", mcp_servers=[]), timeout=_INIT_TIMEOUT
     )
@@ -402,8 +408,8 @@ async def test_codex_acp_multiple_sessions(acp_runtime: ACPRuntime) -> None:
     assert len(chunks_1) > 0, "Session 1 should have response chunks"
     assert len(chunks_2) > 0, "Session 2 should have response chunks"
 
-    text_1 = acp_runtime.get_collected_text(s1_id)
-    text_2 = acp_runtime.get_collected_text(s2_id)
+    text_1 = acp_runtime.client.get_collected_text(s1_id)
+    text_2 = acp_runtime.client.get_collected_text(s2_id)
     logger.info("Session 1: %s", text_1[:100])
     logger.info("Session 2: %s", text_2[:100])
 

--- a/tests/integrations/acp/test_e2e_codex_acp.py
+++ b/tests/integrations/acp/test_e2e_codex_acp.py
@@ -1,12 +1,12 @@
 """End-to-end test: spawn codex-acp via ACP SDK and validate protocol flow.
 
-This test spawns `codex-acp` as a real ACP agent
-subprocess and validates the full protocol lifecycle:
-  1. Initialize connection
-  2. Create a new session with cwd/mcp_servers
-  3. Send a prompt
-  4. Receive session_update chunks
-  5. Verify collected chunks contain a response
+This test spawns `codex-acp` as a real ACP agent subprocess and validates the full
+protocol lifecycle. Protocol-level tests (initialize, new_session, list_sessions,
+spawn failure) drive the raw ACP connection directly via `_spawn_codex_acp`.
+Turn-level tests (prompt/collect, MCP tool calls, multiple sessions) drive
+`ACPRuntime` instead — the same start/create_session/prompt/stop lifecycle
+production code (`ACPClientAdapter`) uses, so a turn's `flush()` is never
+something a test has to remember to call by hand.
 
 Requires: codex-acp
 """
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import shutil
+from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -27,6 +28,7 @@ from pydantic import BaseModel
 from band.integrations.acp.client_profiles import NoopACPClientProfile
 from band.integrations.acp.client_runtime import (
     ACP_STDIO_LIMIT_BYTES,
+    ACPRuntime,
     allow_permission,
     cancel_permission,
     select_allow_option_id,
@@ -106,6 +108,29 @@ def acp_client() -> BandACPClient:
     return BandACPClient(profile=NoopACPClientProfile())
 
 
+@pytest.fixture
+async def acp_runtime() -> AsyncIterator[ACPRuntime]:
+    """A started ACPRuntime against the installed codex-acp, stopped on teardown.
+
+    Drives full turns through the same start/create_session/prompt/stop lifecycle
+    production code uses (``ACPClientAdapter``), rather than re-driving the raw ACP
+    connection by hand — so a turn's ``flush()`` is never something a test has to
+    remember to call itself.
+    """
+    if _CODEX_ACP_COMMAND is None:
+        pytest.skip("codex-acp not available")
+
+    runtime = ACPRuntime(
+        command=[_CODEX_ACP_COMMAND],
+        client_factory=lambda: BandACPClient(profile=NoopACPClientProfile()),
+    )
+    await asyncio.wait_for(runtime.start(), timeout=_INIT_TIMEOUT)
+    try:
+        yield runtime
+    finally:
+        await runtime.stop()
+
+
 async def _allow_all_permissions(
     options: object = None, **kwargs: object
 ) -> dict[str, object]:
@@ -161,59 +186,39 @@ async def test_codex_acp_new_session(acp_client: BandACPClient) -> None:
         await ctx.__aexit__(None, None, None)
 
 
-@pytest.mark.asyncio
-async def test_codex_acp_prompt_and_collect(acp_client: BandACPClient) -> None:
+@pytest.mark.asyncio(loop_scope="session")
+async def test_codex_acp_prompt_and_collect(acp_runtime: ACPRuntime) -> None:
     """Should send a prompt and collect response chunks from codex-acp."""
-    from acp import text_block
+    session_id = await asyncio.wait_for(
+        acp_runtime.create_session(cwd="/tmp", mcp_servers=[]),
+        timeout=_INIT_TIMEOUT,
+    )
+    acp_runtime.reset_session(session_id)
 
-    ctx = _spawn_codex_acp(acp_client)
-    conn, _proc = await ctx.__aenter__()
-    try:
-        await asyncio.wait_for(
-            conn.initialize(protocol_version=1),
-            timeout=_INIT_TIMEOUT,
-        )
-        session = await asyncio.wait_for(
-            conn.new_session(cwd="/tmp"),
-            timeout=_INIT_TIMEOUT,
-        )
-        session_id = session.session_id
+    chunks = await asyncio.wait_for(
+        acp_runtime.prompt(
+            session_id=session_id,
+            prompt_text="What is 2 + 2? Reply with just the number.",
+        ),
+        timeout=_PROMPT_TIMEOUT,
+    )
+    text = acp_runtime.get_collected_text(session_id)
+    logger.info("Collected %d chunks, text: %s", len(chunks), text[:200])
 
-        # Reset buffer for this session
-        acp_client.reset_session(session_id)
+    assert len(chunks) > 0, "Expected at least one response chunk"
+    assert len(text) > 0, "Expected non-empty response text"
 
-        # Send a simple prompt
-        result = await asyncio.wait_for(
-            conn.prompt(
-                session_id=session_id,
-                prompt=[text_block("What is 2 + 2? Reply with just the number.")],
-            ),
-            timeout=_PROMPT_TIMEOUT,
-        )
-        logger.info("Prompt result: %s", result)
-
-        # Check collected chunks
-        chunks = acp_client.get_collected_chunks(session_id)
-        text = acp_client.get_collected_text(session_id)
-        logger.info("Collected %d chunks, text: %s", len(chunks), text[:200])
-
-        assert len(chunks) > 0, "Expected at least one response chunk"
-        assert len(text) > 0, "Expected non-empty response text"
-
-        # Verify chunk types are valid
-        valid_types = {"text", "thought", "tool_call", "tool_result", "plan"}
-        seen_types = {chunk.chunk_type for chunk in chunks}
-        assert seen_types <= valid_types, f"Unexpected chunk types: {seen_types}"
-    finally:
-        await ctx.__aexit__(None, None, None)
+    # Verify chunk types are valid
+    valid_types = {"text", "thought", "tool_call", "tool_result", "plan"}
+    seen_types = {chunk.chunk_type for chunk in chunks}
+    assert seen_types <= valid_types, f"Unexpected chunk types: {seen_types}"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(loop_scope="session")
 async def test_codex_acp_http_mcp_server_tool_call(
-    acp_client: BandACPClient,
+    acp_runtime: ACPRuntime,
 ) -> None:
     """Should connect to a local HTTP MCP server and execute a tool."""
-    from acp import text_block
     from acp.schema import HttpMcpServer
 
     # execute() must return a wire-serialized string: the dynamic handler
@@ -238,89 +243,72 @@ async def test_codex_acp_http_mcp_server_tool_call(
 
     await local_server.start()
     try:
-        ctx = _spawn_codex_acp(acp_client)
-        conn, _proc = await ctx.__aenter__()
-        try:
-            init_result = await asyncio.wait_for(
-                conn.initialize(protocol_version=1),
-                timeout=_INIT_TIMEOUT,
-            )
-            mcp_capabilities = getattr(
-                getattr(init_result, "agent_capabilities", None),
-                "mcp_capabilities",
-                None,
-            )
-            assert getattr(mcp_capabilities, "http", False)
+        session_id = await asyncio.wait_for(
+            acp_runtime.create_session(
+                cwd="/tmp",
+                mcp_servers=[
+                    HttpMcpServer(
+                        type="http",
+                        name="smoke",
+                        url=local_server.http_url,
+                        headers=[],
+                    )
+                ],
+            ),
+            timeout=_INIT_TIMEOUT,
+        )
 
-            session = await asyncio.wait_for(
-                conn.new_session(
-                    cwd="/tmp",
-                    mcp_servers=[
-                        HttpMcpServer(
-                            type="http",
-                            name="smoke",
-                            url=local_server.http_url,
-                            headers=[],
-                        )
-                    ],
+        acp_runtime.reset_session(session_id)
+        acp_runtime.set_permission_handler(session_id, _allow_all_permissions)
+
+        chunks = await asyncio.wait_for(
+            acp_runtime.prompt(
+                session_id=session_id,
+                prompt_text=(
+                    "Use the smoke echo tool exactly once with message "
+                    "'mcp smoke ok'. Then reply with only the tool result."
                 ),
-                timeout=_INIT_TIMEOUT,
-            )
+            ),
+            timeout=_PROMPT_TIMEOUT,
+        )
+        text = acp_runtime.get_collected_text(session_id)
 
-            acp_client.reset_session(session.session_id)
-            acp_client.set_permission_handler(
-                session.session_id, _allow_all_permissions
-            )
-
-            await asyncio.wait_for(
-                conn.prompt(
-                    session_id=session.session_id,
-                    prompt=[
-                        text_block(
-                            "Use the smoke echo tool exactly once with message "
-                            "'mcp smoke ok'. Then reply with only the tool result."
-                        )
-                    ],
-                ),
-                timeout=_PROMPT_TIMEOUT,
-            )
-
-            chunks = acp_client.get_collected_chunks(session.session_id)
-            text = acp_client.get_collected_text(session.session_id)
-
-            assert any(chunk.chunk_type == "tool_call" for chunk in chunks)
-            assert any(chunk.chunk_type == "tool_result" for chunk in chunks)
-            assert "mcp smoke ok" in text
-        finally:
-            await ctx.__aexit__(None, None, None)
+        assert any(chunk.chunk_type == "tool_call" for chunk in chunks)
+        assert any(chunk.chunk_type == "tool_result" for chunk in chunks)
+        assert "mcp smoke ok" in text
     finally:
         await local_server.stop()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(loop_scope="session")
 async def test_codex_acp_band_mcp_tool_call(
-    acp_client: BandACPClient,
+    acp_runtime: ACPRuntime,
 ) -> None:
     """Should discover and call a real Band MCP tool."""
-    from acp import text_block
     from acp.schema import HttpMcpServer
+
+    from tests.runtime.conftest import make_participant
 
     rest = SimpleNamespace(
         agent_api_participants=SimpleNamespace(
             list_agent_chat_participants=AsyncMock(
                 return_value=SimpleNamespace(
                     data=[
-                        SimpleNamespace(
-                            id="u1",
-                            name="Pat",
-                            type="user",
-                            handle="@pat",
+                        make_participant(
+                            {
+                                "id": "u1",
+                                "name": "Pat",
+                                "type": "user",
+                                "handle": "@pat",
+                            }
                         ),
-                        SimpleNamespace(
-                            id="a1",
-                            name="ACP Bridge",
-                            type="agent",
-                            handle="@pat/acp-bridge",
+                        make_participant(
+                            {
+                                "id": "a1",
+                                "name": "ACP Bridge",
+                                "type": "agent",
+                                "handle": "@pat/acp-bridge",
+                            }
                         ),
                     ]
                 )
@@ -337,124 +325,87 @@ async def test_codex_acp_band_mcp_tool_call(
 
     await local_server.start()
     try:
-        ctx = _spawn_codex_acp(acp_client)
-        conn, _proc = await ctx.__aenter__()
-        try:
-            init_result = await asyncio.wait_for(
-                conn.initialize(protocol_version=1),
-                timeout=_INIT_TIMEOUT,
-            )
-            mcp_capabilities = getattr(
-                getattr(init_result, "agent_capabilities", None),
-                "mcp_capabilities",
-                None,
-            )
-            assert getattr(mcp_capabilities, "http", False)
+        session_id = await asyncio.wait_for(
+            acp_runtime.create_session(
+                cwd="/tmp",
+                mcp_servers=[
+                    HttpMcpServer(
+                        type="http",
+                        name="band",
+                        url=local_server.http_url,
+                        headers=[],
+                    )
+                ],
+            ),
+            timeout=_INIT_TIMEOUT,
+        )
 
-            session = await asyncio.wait_for(
-                conn.new_session(
-                    cwd="/tmp",
-                    mcp_servers=[
-                        HttpMcpServer(
-                            type="http",
-                            name="band",
-                            url=local_server.http_url,
-                            headers=[],
-                        )
-                    ],
+        acp_runtime.reset_session(session_id)
+        acp_runtime.set_permission_handler(session_id, _allow_all_permissions)
+
+        chunks = await asyncio.wait_for(
+            acp_runtime.prompt(
+                session_id=session_id,
+                prompt_text=(
+                    "You must call the Band get participants tool "
+                    "exactly once. Do not answer from prior context. "
+                    "After the tool call, reply with only the "
+                    "participant names."
                 ),
-                timeout=_INIT_TIMEOUT,
+            ),
+            timeout=_PROMPT_TIMEOUT,
+        )
+        text = acp_runtime.get_collected_text(session_id)
+
+        tool_calls = [chunk for chunk in chunks if chunk.chunk_type == "tool_call"]
+        if not tool_calls:
+            pytest.skip("codex-acp did not invoke the Band MCP tool in this run")
+        if not called_tool(tool_calls, "band_get_participants"):
+            pytest.skip(
+                "codex-acp invoked MCP in this run, but not the expected Band tool"
             )
-
-            acp_client.reset_session(session.session_id)
-            acp_client.set_permission_handler(
-                session.session_id, _allow_all_permissions
-            )
-
-            await asyncio.wait_for(
-                conn.prompt(
-                    session_id=session.session_id,
-                    prompt=[
-                        text_block(
-                            "You must call the Band get participants tool "
-                            "exactly once. Do not answer from prior context. "
-                            "After the tool call, reply with only the "
-                            "participant names."
-                        )
-                    ],
-                ),
-                timeout=_PROMPT_TIMEOUT,
-            )
-
-            chunks = acp_client.get_collected_chunks(session.session_id)
-            text = acp_client.get_collected_text(session.session_id)
-
-            tool_calls = [chunk for chunk in chunks if chunk.chunk_type == "tool_call"]
-            if not tool_calls:
-                pytest.skip("codex-acp did not invoke the Band MCP tool in this run")
-            if not called_tool(tool_calls, "band_get_participants"):
-                pytest.skip(
-                    "codex-acp invoked MCP in this run, but not the expected Band tool"
-                )
-            assert "Pat" in text
-            assert "ACP Bridge" in text
-        finally:
-            await ctx.__aexit__(None, None, None)
+        assert "Pat" in text
+        assert "ACP Bridge" in text
     finally:
         await local_server.stop()
 
 
-@pytest.mark.asyncio
-async def test_codex_acp_multiple_sessions(acp_client: BandACPClient) -> None:
+@pytest.mark.asyncio(loop_scope="session")
+async def test_codex_acp_multiple_sessions(acp_runtime: ACPRuntime) -> None:
     """Should handle multiple concurrent sessions with separate buffers."""
-    from acp import text_block
+    s1_id = await asyncio.wait_for(
+        acp_runtime.create_session(cwd="/tmp", mcp_servers=[]), timeout=_INIT_TIMEOUT
+    )
+    s2_id = await asyncio.wait_for(
+        acp_runtime.create_session(cwd="/tmp", mcp_servers=[]), timeout=_INIT_TIMEOUT
+    )
+    assert s1_id != s2_id
 
-    ctx = _spawn_codex_acp(acp_client)
-    conn, _proc = await ctx.__aenter__()
-    try:
-        await asyncio.wait_for(
-            conn.initialize(protocol_version=1),
-            timeout=_INIT_TIMEOUT,
-        )
+    acp_runtime.reset_session(s1_id)
+    acp_runtime.reset_session(s2_id)
 
-        # Create two sessions
-        s1 = await asyncio.wait_for(conn.new_session(cwd="/tmp"), timeout=_INIT_TIMEOUT)
-        s2 = await asyncio.wait_for(conn.new_session(cwd="/tmp"), timeout=_INIT_TIMEOUT)
-        assert s1.session_id != s2.session_id
+    # Send prompts to both (sequentially)
+    chunks_1 = await asyncio.wait_for(
+        acp_runtime.prompt(
+            session_id=s1_id, prompt_text="Say 'hello' and nothing else."
+        ),
+        timeout=_PROMPT_TIMEOUT,
+    )
+    chunks_2 = await asyncio.wait_for(
+        acp_runtime.prompt(
+            session_id=s2_id, prompt_text="Say 'world' and nothing else."
+        ),
+        timeout=_PROMPT_TIMEOUT,
+    )
 
-        # Reset buffers
-        acp_client.reset_session(s1.session_id)
-        acp_client.reset_session(s2.session_id)
+    # Both sessions should have responses in separate buffers
+    assert len(chunks_1) > 0, "Session 1 should have response chunks"
+    assert len(chunks_2) > 0, "Session 2 should have response chunks"
 
-        # Send prompts to both (sequentially)
-        await asyncio.wait_for(
-            conn.prompt(
-                session_id=s1.session_id,
-                prompt=[text_block("Say 'hello' and nothing else.")],
-            ),
-            timeout=_PROMPT_TIMEOUT,
-        )
-        await asyncio.wait_for(
-            conn.prompt(
-                session_id=s2.session_id,
-                prompt=[text_block("Say 'world' and nothing else.")],
-            ),
-            timeout=_PROMPT_TIMEOUT,
-        )
-
-        # Both sessions should have responses in separate buffers
-        chunks_1 = acp_client.get_collected_chunks(s1.session_id)
-        chunks_2 = acp_client.get_collected_chunks(s2.session_id)
-
-        assert len(chunks_1) > 0, "Session 1 should have response chunks"
-        assert len(chunks_2) > 0, "Session 2 should have response chunks"
-
-        text_1 = acp_client.get_collected_text(s1.session_id)
-        text_2 = acp_client.get_collected_text(s2.session_id)
-        logger.info("Session 1: %s", text_1[:100])
-        logger.info("Session 2: %s", text_2[:100])
-    finally:
-        await ctx.__aexit__(None, None, None)
+    text_1 = acp_runtime.get_collected_text(s1_id)
+    text_2 = acp_runtime.get_collected_text(s2_id)
+    logger.info("Session 1: %s", text_1[:100])
+    logger.info("Session 2: %s", text_2[:100])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `tests/integrations/acp/test_e2e_codex_acp.py` drove `BandACPClient`/`ACPCollectingClient` directly via a raw ACP connection (`spawn_agent_process` + `conn.prompt()`), bypassing `ACPRuntime` entirely. A plain-text reply is a coalesced chunk type — only finalized into the buffer `get_collected_chunks()`/`get_collected_text()` read at a boundary (a different chunk type) or an explicit `flush()`. codex-acp's only post-answer notifications (`UsageUpdate`/`SessionInfoUpdate`) carry no text, so no boundary ever arrived and every turn's real reply was silently dropped — deterministic, reproduces locally and in CI, not flaky/funds/network related.
- Proved live against real codex-acp 1.1.7: raw protocol capture confirmed codex-acp sends the correct `AgentMessageChunk(content=TextContentBlock(text='4'))` notification (codex-acp is not at fault) and that a manual `flush()` recovers the chunk immediately.
- Fix: rewrites the turn-level tests (`test_codex_acp_prompt_and_collect`, `test_codex_acp_http_mcp_server_tool_call`, `test_codex_acp_band_mcp_tool_call`, `test_codex_acp_multiple_sessions`) to drive `ACPRuntime` instead of the raw connection — the same `start`/`create_session`/`prompt`/`stop` lifecycle production code (`ACPClientAdapter`) already uses, where `flush()` happens automatically at turn end. So the test can no longer forget it, and it now exercises the same code path real callers do instead of a hand-rolled duplicate. Protocol-only tests (`initialize`, `new_session`, `list_sessions`, spawn failure) are unchanged — they don't read collected text/chunks.
- Adds a small `get_collected_text` passthrough on `ACPRuntime` (mirrors the existing `get_collected_chunks`) since the rewritten tests need it.
- `test_codex_acp_multiple_sessions` and the two MCP-tool tests needed `@pytest.mark.asyncio(loop_scope="session")` — `asyncio_default_fixture_loop_scope=session` puts the new async `acp_runtime` fixture on the session loop, while a plain `@pytest.mark.asyncio` test defaults to a function-scoped loop; same pattern already documented/used in `tests/e2e/baseline/conftest.py`.
- Along the way, fixing the flush bug unblocked `test_codex_acp_band_mcp_tool_call`'s real assertions and surfaced a second, previously-masked bug: its mocked REST response used `SimpleNamespace` participants, but `band_get_participants` (`runtime/tools.py`) calls `.model_dump()` on each one — real REST client rows are Pydantic models. Fixed by reusing the existing `make_participant`/`ChatParticipant` helper from `tests/runtime/conftest.py` instead of a stale ad-hoc mock shape.

Production is unaffected by the original bug — `ACPRuntime.prompt()` always flushed at turn end for every real caller; this was a test-only gap.

Fixes INT-1268.

## Test plan
- [x] `E2E_TESTS_ENABLED=true uv run pytest tests/integrations/acp/test_e2e_codex_acp.py -v --no-cov` — 7 passed, 1 skipped (session/list unsupported by this codex-acp build), run twice for stability.
- [x] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/ -q` — 5017 passed, 122 skipped.
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run pyrefly check` — clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01WWeKZushwwwqBv8M4jaCCr