### PR TITLE
feat: add agent-scoped memory support

### DIFF
--- a/examples/band_mcp/02_claude_agent_sdk_external.py
+++ b/examples/band_mcp/02_claude_agent_sdk_external.py
@@ -96,7 +96,7 @@ async def main() -> None:
     store_reply = await run_turn(
         options,
         "Store this fact as a durable memory using band_store_memory with "
-        f'system="long_term", type="semantic", segment="agent", scope="organization": '
+        f'system="long_term", type="semantic", segment="agent", scope="agent": '
         f'"{fact}" Then tell me the memory id you got back.',
     )
     logger.info("Claude (session 1): %s", store_reply)
@@ -106,7 +106,7 @@ async def main() -> None:
     )
     recall_reply = await run_turn(
         options,
-        "Use band_list_memories to search your organization-scoped semantic memories "
+        "Use band_list_memories to search your agent-scoped semantic memories "
         f'for content containing "stdio-{nonce}", then tell me the passphrase you found.',
     )
     logger.info("Claude (session 2): %s", recall_reply)

--- a/src/band/client/rest.py
+++ b/src/band/client/rest.py
@@ -39,6 +39,7 @@ from band_rest import (
     NotFoundError,
     Peer,
     UnauthorizedError,
+    UnprocessableEntityError,
 )
 from band_rest.core import ParsingError
 from band_rest.core.request_options import RequestOptions
@@ -77,6 +78,7 @@ __all__ = [
     "ParsingError",
     "Peer",
     "UnauthorizedError",
+    "UnprocessableEntityError",
     "RequestOptions",
     "DEFAULT_REQUEST_OPTIONS",
 ]

--- a/src/band/core/memory_types.py
+++ b/src/band/core/memory_types.py
@@ -150,3 +150,26 @@ def memory_list_scope_field_description() -> str:
     return "Filter by scope. " + _organization_scope_caveat(
         MemoryListScope.AGENT.value, MemoryListScope.ORGANIZATION.value
     )
+
+
+# Platform error code for a 422 on scope="organization" when the agent's
+# owner belongs to no organization.
+ORGANIZATION_SCOPE_REJECTED_CODE = "org_scope_requires_organization"
+
+
+def is_organization_scope_rejection(error_body: object) -> bool:
+    """True if a REST 422 body is the platform's org-scope-requires-organization rejection."""
+    return (
+        isinstance(error_body, dict)
+        and isinstance(error_body.get("error"), dict)
+        and error_body["error"].get("code") == ORGANIZATION_SCOPE_REJECTED_CODE
+    )
+
+
+def organization_scope_rejected_message(agent_value: str) -> str:
+    """Actionable retry guidance for a 422 org-scope rejection."""
+    return (
+        f'scope="{MemoryStoreScope.ORGANIZATION.value}" was rejected: the '
+        f"agent's owner does not belong to an organization. Retry with "
+        f'scope="{agent_value}" instead.'
+    )

--- a/src/band/core/memory_types.py
+++ b/src/band/core/memory_types.py
@@ -47,16 +47,18 @@ class MemorySegment(StrEnum):
 class MemoryStoreScope(StrEnum):
     """Visibility scope for ``band_store_memory``."""
 
+    AGENT = "agent"  # Private to this agent; no subject_id
     SUBJECT = "subject"  # About one person/agent; requires subject_id
-    ORGANIZATION = "organization"  # Shared org-wide
+    ORGANIZATION = "organization"  # Shared org-wide; requires the agent's owner to belong to an organization
 
 
 class MemoryListScope(StrEnum):
     """Scope filter for ``band_list_memories``."""
 
+    AGENT = "agent"  # Agent-private memories only
     SUBJECT = "subject"  # Subject-scoped memories only
     ORGANIZATION = "organization"  # Organization-scoped memories only
-    ALL = "all"  # Both scopes (no scope filter)
+    ALL = "all"  # Every scope (no scope filter)
 
 
 class MemoryStatus(StrEnum):
@@ -89,8 +91,8 @@ def validate_subject_scope(
         raise ValueError(
             'scope="subject" requires a subject_id (the UUID of the person or '
             "agent the memory is about). You did not provide one. If you do not "
-            'have a concrete subject UUID, retry with scope="organization" and '
-            "omit subject_id. Do not invent a UUID."
+            'have a concrete subject UUID, retry with scope="agent" and omit '
+            "subject_id. Do not invent a UUID."
         )
 
 

--- a/src/band/core/memory_types.py
+++ b/src/band/core/memory_types.py
@@ -127,3 +127,25 @@ def memory_type_field_description() -> str:
         f"{'|'.join(systems)}={'/'.join(types)}" for types, systems in grouped.items()
     )
     return "Memory type - must match the chosen system: " + ", ".join(pairings)
+
+
+def _organization_scope_caveat(agent_value: str, organization_value: str) -> str:
+    """Shared caveat for the store/list scope field descriptions below."""
+    return (
+        f'"{organization_value}" requires the agent\'s owner to belong to an '
+        f'organization; "{agent_value}" (private to this agent) works regardless.'
+    )
+
+
+def memory_store_scope_field_description() -> str:
+    """Build the store_memory ``scope`` field description from the enum."""
+    return "Visibility scope. " + _organization_scope_caveat(
+        MemoryStoreScope.AGENT.value, MemoryStoreScope.ORGANIZATION.value
+    )
+
+
+def memory_list_scope_field_description() -> str:
+    """Build the list_memories ``scope`` field description from the enum."""
+    return "Filter by scope. " + _organization_scope_caveat(
+        MemoryListScope.AGENT.value, MemoryListScope.ORGANIZATION.value
+    )

--- a/src/band/core/memory_types.py
+++ b/src/band/core/memory_types.py
@@ -89,10 +89,11 @@ def validate_subject_scope(
     """Require subject_id when storing a subject-scoped memory."""
     if scope == MemoryStoreScope.SUBJECT and subject_id is None:
         raise ValueError(
-            'scope="subject" requires a subject_id (the UUID of the person or '
-            "agent the memory is about). You did not provide one. If you do not "
-            'have a concrete subject UUID, retry with scope="agent" and omit '
-            "subject_id. Do not invent a UUID."
+            f'scope="{MemoryStoreScope.SUBJECT.value}" requires a subject_id (the '
+            "UUID of the person or agent the memory is about). You did not "
+            "provide one. If you do not have a concrete subject UUID, retry "
+            f'with scope="{MemoryStoreScope.AGENT.value}" and omit subject_id. '
+            "Do not invent a UUID."
         )
 
 

--- a/src/band/runtime/prompts.py
+++ b/src/band/runtime/prompts.py
@@ -102,8 +102,12 @@ real `subject_id` UUID: for someone in the current room (e.g. the user you are t
 A handle or name is never a valid `subject_id` — always look up the UUID `id` field.
 A memory the sender frames about themselves in the first person ("me", "my", "I") has that sender
 as its subject, so resolve the sender's `id` — not your own.
+Default to `scope="{MemoryStoreScope.AGENT.value}"` for anything private to you that is not about one
+subject and is not meant to be shared org-wide — this always works, whether or not you belong to an
+organization.
 Reserve `scope="{MemoryStoreScope.ORGANIZATION.value}"` for knowledge that is genuinely shared across the whole organization
-and is not about any one subject (e.g. cross-room memories not tied to one subject).
+and is not about any one subject (e.g. cross-room memories not tied to one subject). This requires
+your owner to belong to an organization; it fails otherwise.
 """
 
 

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -26,7 +26,12 @@ from pydantic import (
     model_validator,
 )
 
-from band.client.rest import ChatRoomRequest, DEFAULT_REQUEST_OPTIONS, NotFoundError
+from band.client.rest import (
+    ChatRoomRequest,
+    DEFAULT_REQUEST_OPTIONS,
+    NotFoundError,
+    UnprocessableEntityError,
+)
 from band.runtime.capabilities import with_hub_room_contacts
 from band.runtime.participants import participant_snapshot
 from band.core.exceptions import BandToolError
@@ -37,9 +42,11 @@ from band.core.memory_types import (
     MemoryStoreScope,
     MemorySystem,
     MemoryType,
+    is_organization_scope_rejection,
     memory_list_scope_field_description,
     memory_store_scope_field_description,
     memory_type_field_description,
+    organization_scope_rejected_message,
     validate_memory_type_for_system,
     validate_subject_scope,
 )
@@ -2479,10 +2486,17 @@ class AgentTools(AgentToolsProtocol):
         kwargs.update(
             {key: value for key, value in optional_filters.items() if value is not None}
         )
-        response = await self.rest.agent_api_memories.list_agent_memories(
-            **kwargs,
-            request_options=DEFAULT_REQUEST_OPTIONS,
-        )
+        try:
+            response = await self.rest.agent_api_memories.list_agent_memories(
+                **kwargs,
+                request_options=DEFAULT_REQUEST_OPTIONS,
+            )
+        except UnprocessableEntityError as error:
+            if is_organization_scope_rejection(error.body):
+                raise BandToolError(
+                    organization_scope_rejected_message(MemoryListScope.AGENT.value)
+                ) from error
+            raise
 
         return response
 
@@ -2541,10 +2555,17 @@ class AgentTools(AgentToolsProtocol):
             memory_kwargs["subject_id"] = subject_id
         if metadata is not None:
             memory_kwargs["metadata"] = metadata
-        response = await self.rest.agent_api_memories.create_agent_memory(
-            memory=AgentMemoryCreateRequest(**memory_kwargs),
-            request_options=DEFAULT_REQUEST_OPTIONS,
-        )
+        try:
+            response = await self.rest.agent_api_memories.create_agent_memory(
+                memory=AgentMemoryCreateRequest(**memory_kwargs),
+                request_options=DEFAULT_REQUEST_OPTIONS,
+            )
+        except UnprocessableEntityError as error:
+            if is_organization_scope_rejection(error.body):
+                raise BandToolError(
+                    organization_scope_rejected_message(MemoryStoreScope.AGENT.value)
+                ) from error
+            raise
         if not response.data:
             raise RuntimeError("Failed to store memory - no response data")
         return response.data

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -37,6 +37,8 @@ from band.core.memory_types import (
     MemoryStoreScope,
     MemorySystem,
     MemoryType,
+    memory_list_scope_field_description,
+    memory_store_scope_field_description,
     memory_type_field_description,
     validate_memory_type_for_system,
     validate_subject_scope,
@@ -384,12 +386,7 @@ class ListMemoriesInput(BaseModel):
         None, description="Filter by subject UUID (required for subject-scoped queries)"
     )
     scope: MemoryListScope | None = Field(
-        None,
-        description=(
-            'Filter by scope. "organization" requires the agent\'s owner to '
-            'belong to an organization; "agent" (private to this agent) works '
-            "regardless."
-        ),
+        None, description=memory_list_scope_field_description()
     )
     system: MemorySystem | None = Field(None, description="Filter by memory system")
     type: MemoryType | None = Field(None, description="Filter by memory type")
@@ -415,12 +412,7 @@ class StoreMemoryInput(BaseModel):
     segment: MemorySegment = Field(..., description="Logical segment")
     thought: str = Field(..., description="Agent's reasoning for storing this memory")
     scope: MemoryStoreScope = Field(
-        ...,
-        description=(
-            'Visibility scope. "organization" requires the agent\'s owner to '
-            'belong to an organization; "agent" (private to this agent) works '
-            "regardless."
-        ),
+        ..., description=memory_store_scope_field_description()
     )
     subject_id: str | None = Field(
         None,
@@ -2454,9 +2446,9 @@ class AgentTools(AgentToolsProtocol):
 
         Args:
             subject_id: Filter by subject UUID
-            scope: Filter by scope (agent, subject, organization, all). "organization"
-                requires the agent's owner to belong to an organization; "agent"
-                (private to this agent) works regardless.
+            scope: Filter by scope (see MemoryListScope for valid values).
+                Organization scope requires the agent's owner to belong to an
+                organization; agent scope works regardless.
             system: Filter by memory system (sensory, working, long_term)
             type: Filter by memory type
             segment: Filter by segment (user, agent, tool, guideline)
@@ -2514,9 +2506,9 @@ class AgentTools(AgentToolsProtocol):
             type: Memory type (iconic, echoic, haptic, episodic, semantic, procedural)
             segment: Logical segment (user, agent, tool, guideline)
             thought: Agent's reasoning for storing this memory
-            scope: Visibility scope (agent, subject, organization). "organization"
-                requires the agent's owner to belong to an organization; "agent"
-                (private to this agent, no subject_id) works regardless.
+            scope: Visibility scope (see MemoryStoreScope for valid values).
+                Organization scope requires the agent's owner to belong to an
+                organization; agent scope (no subject_id) works regardless.
             subject_id: UUID of the subject (required for subject scope)
             metadata: Additional metadata (tags, references)
 

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -376,14 +376,21 @@ class RespondContactRequestInput(BaseModel):
 class ListMemoriesInput(BaseModel):
     """List memories accessible to the agent.
 
-    Returns memories about the specified subject (cross-agent sharing)
-    and organization-wide shared memories.
+    Returns this agent's own private memories, memories about the specified
+    subject (cross-agent sharing), and organization-wide shared memories.
     """
 
     subject_id: str | None = Field(
         None, description="Filter by subject UUID (required for subject-scoped queries)"
     )
-    scope: MemoryListScope | None = Field(None, description="Filter by scope")
+    scope: MemoryListScope | None = Field(
+        None,
+        description=(
+            'Filter by scope. "organization" requires the agent\'s owner to '
+            'belong to an organization; "agent" (private to this agent) works '
+            "regardless."
+        ),
+    )
     system: MemorySystem | None = Field(None, description="Filter by memory system")
     type: MemoryType | None = Field(None, description="Filter by memory type")
     segment: MemorySegment | None = Field(None, description="Filter by segment")
@@ -396,8 +403,10 @@ class StoreMemoryInput(BaseModel):
     """Store a new memory entry.
 
     The memory will be associated with the authenticated agent as the source.
+    For agent-scoped memories (private to this agent), omit subject_id.
     For subject-scoped memories, provide a subject_id.
-    For organization-scoped memories, omit subject_id.
+    For organization-scoped memories, omit subject_id; this requires the
+    agent's owner to belong to an organization.
     """
 
     content: str = Field(..., description="The memory content")
@@ -405,7 +414,14 @@ class StoreMemoryInput(BaseModel):
     type: MemoryType = Field(..., description=memory_type_field_description())
     segment: MemorySegment = Field(..., description="Logical segment")
     thought: str = Field(..., description="Agent's reasoning for storing this memory")
-    scope: MemoryStoreScope = Field(..., description="Visibility scope")
+    scope: MemoryStoreScope = Field(
+        ...,
+        description=(
+            'Visibility scope. "organization" requires the agent\'s owner to '
+            'belong to an organization; "agent" (private to this agent) works '
+            "regardless."
+        ),
+    )
     subject_id: str | None = Field(
         None,
         description="UUID of the subject this memory is about (required for subject scope)",
@@ -2438,7 +2454,9 @@ class AgentTools(AgentToolsProtocol):
 
         Args:
             subject_id: Filter by subject UUID
-            scope: Filter by scope (subject, organization, all)
+            scope: Filter by scope (agent, subject, organization, all). "organization"
+                requires the agent's owner to belong to an organization; "agent"
+                (private to this agent) works regardless.
             system: Filter by memory system (sensory, working, long_term)
             type: Filter by memory type
             segment: Filter by segment (user, agent, tool, guideline)
@@ -2496,7 +2514,9 @@ class AgentTools(AgentToolsProtocol):
             type: Memory type (iconic, echoic, haptic, episodic, semantic, procedural)
             segment: Logical segment (user, agent, tool, guideline)
             thought: Agent's reasoning for storing this memory
-            scope: Visibility scope (subject, organization)
+            scope: Visibility scope (agent, subject, organization). "organization"
+                requires the agent's owner to belong to an organization; "agent"
+                (private to this agent, no subject_id) works regardless.
             subject_id: UUID of the subject (required for subject scope)
             metadata: Additional metadata (tags, references)
 

--- a/tests/core/test_memory_types.py
+++ b/tests/core/test_memory_types.py
@@ -6,11 +6,14 @@ import pytest
 
 from band.core.memory_types import (
     MEMORY_SYSTEM_TYPE_MAP,
+    ORGANIZATION_SCOPE_REJECTED_CODE,
     MemoryStoreScope,
     MemorySystem,
     SensoryMemoryType,
     WorkingLongTermMemoryType,
     enum_values,
+    is_organization_scope_rejection,
+    organization_scope_rejected_message,
     validate_subject_scope,
 )
 
@@ -72,3 +75,35 @@ class TestValidateSubjectScope:
         so pointing an LLM there on retry just guarantees the next call fails too."""
         with pytest.raises(ValueError, match='scope="agent"'):
             validate_subject_scope(MemoryStoreScope.SUBJECT, None)
+
+
+class TestIsOrganizationScopeRejection:
+    def test_true_for_the_platform_error_shape(self) -> None:
+        """The exact shape the platform sends for a 422 org-scope rejection."""
+        body = {
+            "error": {
+                "code": ORGANIZATION_SCOPE_REJECTED_CODE,
+                "details": {"organization_id": "must be present"},
+            }
+        }
+        assert is_organization_scope_rejection(body) is True
+
+    def test_false_for_a_different_error_code(self) -> None:
+        """A 422 for an unrelated reason must not be misreported as scope rejection."""
+        body = {"error": {"code": "some_other_validation_failure"}}
+        assert is_organization_scope_rejection(body) is False
+
+    def test_false_for_non_dict_bodies(self) -> None:
+        """A REST error body isn't guaranteed to be a dict; must not raise."""
+        assert is_organization_scope_rejection(None) is False
+        assert is_organization_scope_rejection("plain text error") is False
+        assert is_organization_scope_rejection({"error": "not a dict"}) is False
+
+
+class TestOrganizationScopeRejectedMessage:
+    def test_recommends_the_given_agent_value(self) -> None:
+        """Message must name the caller's own agent-scope value (store vs.
+        list use different enums that happen to share the same value)."""
+        message = organization_scope_rejected_message(MemoryStoreScope.AGENT.value)
+        assert 'scope="agent"' in message
+        assert 'scope="organization"' in message

--- a/tests/core/test_memory_types.py
+++ b/tests/core/test_memory_types.py
@@ -50,6 +50,10 @@ class TestValidateSubjectScope:
         """Organization-scoped memories do not need a subject ID."""
         validate_subject_scope(MemoryStoreScope.ORGANIZATION, None)
 
+    def test_allows_agent_scope_without_subject_id(self) -> None:
+        """Agent-scoped memories do not need a subject ID."""
+        validate_subject_scope(MemoryStoreScope.AGENT, None)
+
     def test_allows_subject_scope_with_subject_id(self) -> None:
         """Subject-scoped memories are valid when a subject ID is present."""
         validate_subject_scope(
@@ -60,4 +64,12 @@ class TestValidateSubjectScope:
     def test_rejects_subject_scope_without_subject_id(self) -> None:
         """Subject-scoped memories require a concrete subject ID."""
         with pytest.raises(ValueError, match="requires a subject_id"):
+            validate_subject_scope(MemoryStoreScope.SUBJECT, None)
+
+    def test_no_subject_id_error_recommends_agent_scope(self) -> None:
+        """The fallback the error message recommends must be `scope="agent"`,
+        not `scope="organization"` -- organization scope 422s for the common
+        case (an agent whose owner has no organization; see INT-1307), so
+        pointing an LLM there on retry just guarantees the next call fails too."""
+        with pytest.raises(ValueError, match='scope="agent"'):
             validate_subject_scope(MemoryStoreScope.SUBJECT, None)

--- a/tests/core/test_memory_types.py
+++ b/tests/core/test_memory_types.py
@@ -67,9 +67,8 @@ class TestValidateSubjectScope:
             validate_subject_scope(MemoryStoreScope.SUBJECT, None)
 
     def test_no_subject_id_error_recommends_agent_scope(self) -> None:
-        """The fallback the error message recommends must be `scope="agent"`,
-        not `scope="organization"` -- organization scope 422s for the common
-        case (an agent whose owner has no organization; see INT-1307), so
-        pointing an LLM there on retry just guarantees the next call fails too."""
+        """The fallback must be `scope="agent"`, not `scope="organization"` --
+        organization scope fails for an agent whose owner has no organization,
+        so pointing an LLM there on retry just guarantees the next call fails too."""
         with pytest.raises(ValueError, match='scope="agent"'):
             validate_subject_scope(MemoryStoreScope.SUBJECT, None)

--- a/tests/e2e/baseline/smoke/inspection/test_memory.py
+++ b/tests/e2e/baseline/smoke/inspection/test_memory.py
@@ -20,8 +20,14 @@ from __future__ import annotations
 import pytest
 
 
+from band.client.rest import (
+    DEFAULT_REQUEST_OPTIONS,
+    AgentMemoryCreateRequest,
+    UnprocessableEntityError,
+)
 from band.core.memory_types import (
     MemoryListScope,
+    MemorySegment,
     MemoryStatus,
     MemoryStoreScope,
     MemorySystem,
@@ -29,6 +35,7 @@ from band.core.memory_types import (
 )
 
 from tests.e2e.baseline.agents import Adapter, with_adapters
+from tests.e2e.baseline.settings import BaselineSettings
 from tests.e2e.baseline.smoke.samples.sample_agents import (
     MEMORY_AGENT,
     MEMORY_SECRETARY_AGENT,
@@ -42,7 +49,11 @@ from tests.e2e.baseline.smoke.samples.sample_agents import (
     unique_marker,
 )
 from tests.e2e.baseline.toolkit.observations import MemoryTool
-from tests.e2e.baseline.toolkit.provisioning import ProvisionedAgent, ResourceManager
+from tests.e2e.baseline.toolkit.provisioning import (
+    ProvisionedAgent,
+    ResourceManager,
+    agent_rest_client,
+)
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
@@ -55,7 +66,7 @@ async def test_memory_stored(
     user_ops: UserOps,
     reply_capture: CaptureFactory,
 ) -> None:
-    """The store tool fired (call layer) and an org-scoped memory landed in the
+    """The store tool fired (call layer) and an agent-scoped memory landed in the
     store (store layer), both carrying our marker."""
     marker = unique_marker("mem")
     room_id = await resource_manager.provision_room(
@@ -72,18 +83,18 @@ async def test_memory_stored(
         # One read, both layers (call layer from room events, store layer from
         # the agent's own memories filtered to our marker).
         mem = await capture.memory(
-            agent, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            agent, scope=MemoryListScope.AGENT, content_query=marker
         )
 
     mem.calls.assert_store_called(
         content=marker,
-        scope=MemoryStoreScope.ORGANIZATION,
+        scope=MemoryStoreScope.AGENT,
         system=MemorySystem.LONG_TERM,
         type=WorkingLongTermMemoryType.SEMANTIC,
     )
     mem.stored.assert_stored(
         content=marker,
-        scope=MemoryStoreScope.ORGANIZATION,
+        scope=MemoryStoreScope.AGENT,
         system=MemorySystem.LONG_TERM,
         type=WorkingLongTermMemoryType.SEMANTIC,
     )
@@ -208,7 +219,7 @@ async def test_memory_excluded_from_general_tool_view(
         general = await capture.tool_calls(sender_id=agent.id)
         with_memory = await capture.tool_calls(sender_id=agent.id, include_memory=True)
         mem = await capture.memory(
-            agent, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            agent, scope=MemoryListScope.AGENT, content_query=marker
         )
 
     # Excluded from the general view by default...
@@ -246,7 +257,7 @@ async def test_memory_lifecycle_supersede(
         # status=ALL so the now-superseded record is still returned.
         mem = await capture.memory(
             agent,
-            scope=MemoryListScope.ORGANIZATION,
+            scope=MemoryListScope.AGENT,
             content_query=marker,
             status=MemoryStatus.ALL,
         )
@@ -282,7 +293,7 @@ async def test_memory_lifecycle_archive(
         await capture.wait_for_processed(mid, agent.id)
         mem = await capture.memory(
             agent,
-            scope=MemoryListScope.ORGANIZATION,
+            scope=MemoryListScope.AGENT,
             content_query=marker,
             status=MemoryStatus.ALL,
         )
@@ -315,7 +326,7 @@ async def test_memory_recall(
         )
         await capture.wait_for_processed(mid, agent.id)
         mem = await capture.memory(
-            agent, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            agent, scope=MemoryListScope.AGENT, content_query=marker
         )
 
     mem.calls.assert_store_called(content=marker)
@@ -347,7 +358,7 @@ async def test_memory_store_layer_filtering(
         )
         await capture.wait_for_processed(mid, agent.id)
         mem = await capture.memory(
-            agent, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            agent, scope=MemoryListScope.AGENT, content_query=marker
         )
 
     # Both landed; slice the single collection by dimension.
@@ -362,19 +373,23 @@ async def test_memory_store_layer_filtering(
 
 @with_adapters(Adapter.ANTHROPIC, Adapter.ANTHROPIC, **MEMORY_AGENT)
 @pytest.mark.asyncio(loop_scope="session")
-async def test_memory_visible_cross_agent_cross_room(
+async def test_memory_agent_scope_isolated_across_agents(
     agents: list[ProvisionedAgent],
     resource_manager: ResourceManager,
     user_ops: UserOps,
     reply_capture: CaptureFactory,
 ) -> None:
-    """An organization-scoped memory stored by one agent in one room is visible to
-    a different agent reading from a different room -- memory is org-scoped, not
-    room-scoped, and org memories are shared across agents in the same org."""
+    """An agent-scoped memory is private to the agent that stored it -- a
+    different agent's own agent-scoped read never returns it, even filtered to
+    the same marker. This is the isolation boundary PLT-1396 hardened
+    (organization-scoped reads used to leak cross-tenant when the reading
+    agent's owner had no organization); agent scope has no organization_id to
+    go missing, so nothing but the identity filter keeps this true -- worth
+    locking down directly."""
     agent_w, agent_r = agents
-    marker = unique_marker("xorg")
+    marker = unique_marker("xagent")
     room_w = await resource_manager.provision_room(
-        title="e2e-memory-xroom-writer", participants=[agent_w.id]
+        title="e2e-memory-xagent-writer", participants=[agent_w.id]
     )
     async with reply_capture(room_w) as cap_w:
         mid = await user_ops.send_message(
@@ -385,23 +400,75 @@ async def test_memory_visible_cross_agent_cross_room(
         )
         await cap_w.wait_for_processed(mid, agent_w.id)
         mem_w = await cap_w.memory(
-            agent_w, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            agent_w, scope=MemoryListScope.AGENT, content_query=marker
         )
 
-    # Different agent, different room: read the store through the reader's own
-    # client. No turn is needed -- the writer's store is already durable.
+    # Different agent, different room: read through the reader's own client. No
+    # turn is needed -- the writer's store is already durable.
     room_r = await resource_manager.provision_room(
-        title="e2e-memory-xroom-reader", participants=[agent_r.id]
+        title="e2e-memory-xagent-reader", participants=[agent_r.id]
     )
     async with reply_capture(room_r) as cap_r:
         mem_r = await cap_r.memory(
-            agent_r, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            agent_r, scope=MemoryListScope.AGENT, content_query=marker
         )
 
     # Writer stored it (both layers).
     mem_w.calls.assert_store_called(content=marker)
     mem_w.stored.assert_stored(content=marker)
-    # Reader, in a different room, sees the same org memory without having written
-    # anything itself.
-    mem_r.stored.assert_stored(content=marker)
+    # Reader, a different agent in a different room, sees none of the writer's
+    # agent-scoped memory.
+    mem_r.stored.assert_none()
     assert not mem_r.calls, "reader should not have called any memory tool"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_memory_organization_scope_rejected_on_list(
+    resource_manager: ResourceManager,
+    baseline_settings: BaselineSettings,
+) -> None:
+    """A read explicitly asking for organization scope gets a real 422 from the
+    live platform, not a silent empty 200, when the agent's owner belongs to no
+    organization -- true of every agent this baseline provisions (see
+    INT-1307). This is the exact contract PLT-1396 shipped: before it, a caller
+    in this state could read every organization-scoped memory in the database,
+    because the tenancy filter silently dropped when organization_id was nil.
+    A direct REST call against a provisioned-but-never-run identity -- no LLM
+    turn needed, deterministic, and it exercises the live platform on every run."""
+    agent = await resource_manager.provision_agent("org-scope-list-rejected")
+    client = agent_rest_client(agent, baseline_settings)
+
+    with pytest.raises(UnprocessableEntityError) as exc_info:
+        await client.agent_api_memories.list_agent_memories(
+            scope=MemoryListScope.ORGANIZATION.value,
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
+
+    assert exc_info.value.body["error"]["code"] == "org_scope_requires_organization"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_memory_organization_scope_rejected_on_store(
+    resource_manager: ResourceManager,
+    baseline_settings: BaselineSettings,
+) -> None:
+    """The write-side twin of the read rejection above: storing with an
+    explicit organization scope 422s for an agent whose owner has no
+    organization, rather than silently minting an unreadable orphan row."""
+    agent = await resource_manager.provision_agent("org-scope-store-rejected")
+    client = agent_rest_client(agent, baseline_settings)
+
+    with pytest.raises(UnprocessableEntityError) as exc_info:
+        await client.agent_api_memories.create_agent_memory(
+            memory=AgentMemoryCreateRequest(
+                content=unique_marker("orgreject"),
+                system=MemorySystem.LONG_TERM.value,
+                type=WorkingLongTermMemoryType.SEMANTIC.value,
+                segment=MemorySegment.USER.value,
+                thought="probing the organization-scope guard",
+                scope=MemoryStoreScope.ORGANIZATION.value,
+            ),
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
+
+    assert "organization_id" in exc_info.value.body["error"]["details"]

--- a/tests/e2e/baseline/smoke/inspection/test_memory.py
+++ b/tests/e2e/baseline/smoke/inspection/test_memory.py
@@ -381,11 +381,9 @@ async def test_memory_agent_scope_isolated_across_agents(
 ) -> None:
     """An agent-scoped memory is private to the agent that stored it -- a
     different agent's own agent-scoped read never returns it, even filtered to
-    the same marker. This is the isolation boundary PLT-1396 hardened
-    (organization-scoped reads used to leak cross-tenant when the reading
-    agent's owner had no organization); agent scope has no organization_id to
-    go missing, so nothing but the identity filter keeps this true -- worth
-    locking down directly."""
+    the same marker. Agent scope has no organization_id to go missing, so
+    nothing but the identity filter keeps this true -- worth locking down
+    directly."""
     agent_w, agent_r = agents
     marker = unique_marker("xagent")
     room_w = await resource_manager.provision_room(
@@ -427,14 +425,10 @@ async def test_memory_organization_scope_rejected_on_list(
     resource_manager: ResourceManager,
     baseline_settings: BaselineSettings,
 ) -> None:
-    """A read explicitly asking for organization scope gets a real 422 from the
-    live platform, not a silent empty 200, when the agent's owner belongs to no
-    organization -- true of every agent this baseline provisions (see
-    INT-1307). This is the exact contract PLT-1396 shipped: before it, a caller
-    in this state could read every organization-scoped memory in the database,
-    because the tenancy filter silently dropped when organization_id was nil.
-    A direct REST call against a provisioned-but-never-run identity -- no LLM
-    turn needed, deterministic, and it exercises the live platform on every run."""
+    """A read explicitly asking for organization scope gets a real 422, not a
+    silent empty 200, when the agent's owner belongs to no organization --
+    true of every agent this baseline provisions. A direct REST call against a
+    provisioned-but-never-run identity: no LLM turn needed, deterministic."""
     agent = await resource_manager.provision_agent("org-scope-list-rejected")
     client = agent_rest_client(agent, baseline_settings)
 

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -46,7 +46,7 @@ async def test_store_memory_across_memory_adapters(
     user_ops: UserOps,
     reply_capture: CaptureFactory,
 ) -> None:
-    """Store an organization-scoped memory through each memory-capable adapter."""
+    """Store an agent-scoped memory through each memory-capable adapter."""
     marker = unique_marker("xmem")
     room_id = await resource_manager.provision_room(
         title=f"e2e-cap-memory-{agent.adapter_id}", participants=[agent.id]
@@ -60,7 +60,7 @@ async def test_store_memory_across_memory_adapters(
         )
         await capture.wait_for_processed(mid, agent.id)
         mem = await capture.memory(
-            agent, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            agent, scope=MemoryListScope.AGENT, content_query=marker
         )
 
     mem.stored.assert_stored(content=marker)
@@ -94,7 +94,7 @@ async def test_recall_memory_across_memory_adapters(
         )
         await capture.wait_for_processed(mid, agent.id)
         mem = await capture.memory(
-            agent, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            agent, scope=MemoryListScope.AGENT, content_query=marker
         )
 
     mem.stored.assert_stored(content=marker)
@@ -154,7 +154,7 @@ async def test_memory_survives_adapter_rehydration(
             replies = await capture.wait_for_reply(mid, identity.id)
             mem = await capture.memory(
                 identity,
-                scope=MemoryListScope.ORGANIZATION,
+                scope=MemoryListScope.AGENT,
                 content_query=marker,
             )
 

--- a/tests/e2e/baseline/smoke/samples/sample_agents.py
+++ b/tests/e2e/baseline/smoke/samples/sample_agents.py
@@ -183,7 +183,7 @@ def emit_thoughts_instruction(markers: list[str]) -> str:
 
 
 def store_memory_instruction(marker: str) -> str:
-    """User message forcing one organization-scoped ``band_store_memory`` whose
+    """User message forcing one agent-scoped ``band_store_memory`` whose
     content carries ``marker`` verbatim, with an exact valid system/type combo."""
     return (
         "Call band_store_memory exactly once with these exact arguments: "
@@ -191,7 +191,7 @@ def store_memory_instruction(marker: str) -> str:
         f"system = {MemorySystem.LONG_TERM.value}; "
         f"type = {WorkingLongTermMemoryType.SEMANTIC.value}; "
         f"segment = {MemorySegment.USER.value}; "
-        f"scope = {MemoryStoreScope.ORGANIZATION.value}; "
+        f"scope = {MemoryStoreScope.AGENT.value}; "
         "thought = a brief reason. Do not include subject_id. Do not call any "
         "other tool."
     )
@@ -240,14 +240,14 @@ def store_subject_memory_inferred_instruction(marker: str) -> str:
 
 def supersede_memory_instruction(marker: str) -> str:
     """User message forcing a store-then-supersede lifecycle in one turn: store an
-    org-scoped memory carrying ``marker``, then supersede it by the id the store
+    agent-scoped memory carrying ``marker``, then supersede it by the id the store
     call returns."""
     return (
         f"First call {MemoryTool.STORE.value} with content including the exact "
         f"token {marker}, system={MemorySystem.LONG_TERM.value}, "
         f"type={WorkingLongTermMemoryType.SEMANTIC.value}, "
         f"segment={MemorySegment.USER.value}, "
-        f"scope={MemoryStoreScope.ORGANIZATION.value}, and a brief thought. "
+        f"scope={MemoryStoreScope.AGENT.value}, and a brief thought. "
         f"Then call {MemoryTool.SUPERSEDE.value} with memory_id set to the id "
         "returned by the store call. Do not call any other tool."
     )
@@ -255,14 +255,14 @@ def supersede_memory_instruction(marker: str) -> str:
 
 def archive_memory_instruction(marker: str) -> str:
     """User message forcing a store-then-archive lifecycle in one turn: store an
-    org-scoped memory carrying ``marker``, then archive it by the id the store
+    agent-scoped memory carrying ``marker``, then archive it by the id the store
     call returns."""
     return (
         f"First call {MemoryTool.STORE.value} with content including the exact "
         f"token {marker}, system={MemorySystem.LONG_TERM.value}, "
         f"type={WorkingLongTermMemoryType.SEMANTIC.value}, "
         f"segment={MemorySegment.USER.value}, "
-        f"scope={MemoryStoreScope.ORGANIZATION.value}, and a brief thought. "
+        f"scope={MemoryStoreScope.AGENT.value}, and a brief thought. "
         f"Then call {MemoryTool.ARCHIVE.value} with memory_id set to the id "
         "returned by the store call. Do not call any other tool."
     )
@@ -270,14 +270,14 @@ def archive_memory_instruction(marker: str) -> str:
 
 def recall_memory_instruction(marker: str) -> str:
     """User message forcing a store-then-recall flow in one turn: store an
-    org-scoped memory carrying ``marker``, then look it back up with the list and
+    agent-scoped memory carrying ``marker``, then look it back up with the list and
     get tools (exercises the read-side memory tools)."""
     return (
         f"First call {MemoryTool.STORE.value} with content including the exact "
         f"token {marker}, system={MemorySystem.LONG_TERM.value}, "
         f"type={WorkingLongTermMemoryType.SEMANTIC.value}, "
         f"segment={MemorySegment.USER.value}, "
-        f"scope={MemoryStoreScope.ORGANIZATION.value}, and a brief thought. "
+        f"scope={MemoryStoreScope.AGENT.value}, and a brief thought. "
         f"Then call {MemoryTool.LIST.value} with content_query={marker} to find "
         f"it. Then call {MemoryTool.GET.value} with memory_id set to the id of a "
         "memory the list returned. Do not call any other tool."
@@ -285,7 +285,7 @@ def recall_memory_instruction(marker: str) -> str:
 
 
 def retrieve_memory_instruction(marker: str) -> str:
-    """User message forcing retrieval of an already-stored org memory, then a
+    """User message forcing retrieval of an already-stored agent memory, then a
     chat reply naming what was found -- the rehydration smoke asserts on that
     reply's text, so the instruction must explicitly ask for it rather than
     leaving the agent to infer it against a system prompt that otherwise tells
@@ -299,14 +299,14 @@ def retrieve_memory_instruction(marker: str) -> str:
 
 
 def store_two_memories_instruction(marker: str) -> str:
-    """User message forcing two org-scoped stores that both carry ``marker`` but
+    """User message forcing two agent-scoped stores that both carry ``marker`` but
     differ in system/type, so one ``content_query=marker`` read returns both and
     the store-layer view can be sliced by dimension."""
     return (
         f"Call {MemoryTool.STORE.value} twice, both with content including the "
         f"exact token {marker} and a brief thought, both "
         f"segment={MemorySegment.USER.value} "
-        f"scope={MemoryStoreScope.ORGANIZATION.value}. First store: "
+        f"scope={MemoryStoreScope.AGENT.value}. First store: "
         f"system={MemorySystem.LONG_TERM.value}, "
         f"type={WorkingLongTermMemoryType.SEMANTIC.value}. Second store: "
         f"system={MemorySystem.WORKING.value}, "

--- a/tests/runtime/test_tools.py
+++ b/tests/runtime/test_tools.py
@@ -106,7 +106,7 @@ class TestMemoryTools:
     ) -> None:
         """Agent scope round-trips to the REST payload untouched and needs no
         subject_id -- the scope value real agents fall back to when their owner
-        has no organization (see INT-1307)."""
+        has no organization."""
         response = MagicMock()
         response.data = MagicMock()
         mock_rest_client.agent_api_memories.create_agent_memory = AsyncMock(

--- a/tests/runtime/test_tools.py
+++ b/tests/runtime/test_tools.py
@@ -19,8 +19,10 @@ from band.client.rest import (
     Attachment,
     ChatMessageRequest,
     NotFoundError,
+    UnprocessableEntityError,
 )
 from band.core.exceptions import BandToolError
+from band.core.memory_types import ORGANIZATION_SCOPE_REJECTED_CODE
 from band.core.types import Capability
 from tests.conftest import make_participant_mock
 from band.runtime.tools import (
@@ -149,6 +151,73 @@ class TestMemoryTools:
             scope="agent",
             request_options=DEFAULT_REQUEST_OPTIONS,
         )
+
+    @pytest.mark.asyncio
+    async def test_store_memory_organization_scope_rejection_becomes_actionable(
+        self, mock_rest_client
+    ) -> None:
+        """The platform's 422 for an orgless agent's `scope="organization"`
+        write must reach the caller as guidance to retry with `scope="agent"`,
+        not as the raw `headers: ..., status_code: 422, body: ...` dump the
+        generic exception handler would otherwise produce."""
+        rejection_body = {
+            "error": {
+                "code": ORGANIZATION_SCOPE_REJECTED_CODE,
+                "details": {"organization_id": "must be present"},
+            }
+        }
+        mock_rest_client.agent_api_memories.create_agent_memory = AsyncMock(
+            side_effect=UnprocessableEntityError(body=rejection_body)
+        )
+        tools = AgentTools("room-123", mock_rest_client)
+
+        with pytest.raises(BandToolError, match='scope="agent"'):
+            await tools.store_memory(
+                content="remember this",
+                system="working",
+                type="semantic",
+                segment="user",
+                thought="useful later",
+                scope="organization",
+            )
+
+    @pytest.mark.asyncio
+    async def test_store_memory_unrelated_422_is_not_mistaken_for_scope_rejection(
+        self, mock_rest_client
+    ) -> None:
+        """A 422 for any other reason must propagate as-is -- rewriting it to
+        the scope-retry message would mislead the caller about the actual
+        failure."""
+        mock_rest_client.agent_api_memories.create_agent_memory = AsyncMock(
+            side_effect=UnprocessableEntityError(
+                body={"error": {"code": "some_other_validation_failure"}}
+            )
+        )
+        tools = AgentTools("room-123", mock_rest_client)
+
+        with pytest.raises(UnprocessableEntityError):
+            await tools.store_memory(
+                content="remember this",
+                system="working",
+                type="semantic",
+                segment="user",
+                thought="useful later",
+                scope="organization",
+            )
+
+    @pytest.mark.asyncio
+    async def test_list_memories_organization_scope_rejection_becomes_actionable(
+        self, mock_rest_client
+    ) -> None:
+        """The read-side twin of the store-side test above."""
+        rejection_body = {"error": {"code": ORGANIZATION_SCOPE_REJECTED_CODE}}
+        mock_rest_client.agent_api_memories.list_agent_memories = AsyncMock(
+            side_effect=UnprocessableEntityError(body=rejection_body)
+        )
+        tools = AgentTools("room-123", mock_rest_client)
+
+        with pytest.raises(BandToolError, match='scope="agent"'):
+            await tools.list_memories(scope="organization")
 
     @pytest.mark.asyncio
     async def test_store_memory_rejects_subject_scope_without_subject_id(

--- a/tests/runtime/test_tools.py
+++ b/tests/runtime/test_tools.py
@@ -101,6 +101,56 @@ class TestMemoryTools:
         assert call_kwargs["request_options"] is DEFAULT_REQUEST_OPTIONS
 
     @pytest.mark.asyncio
+    async def test_store_memory_agent_scope_sent_without_subject_id(
+        self, mock_rest_client
+    ) -> None:
+        """Agent scope round-trips to the REST payload untouched and needs no
+        subject_id -- the scope value real agents fall back to when their owner
+        has no organization (see INT-1307)."""
+        response = MagicMock()
+        response.data = MagicMock()
+        mock_rest_client.agent_api_memories.create_agent_memory = AsyncMock(
+            return_value=response
+        )
+        tools = AgentTools("room-123", mock_rest_client)
+
+        await tools.store_memory(
+            content="remember this",
+            system="working",
+            type="semantic",
+            segment="user",
+            thought="useful later",
+            scope="agent",
+        )
+
+        call_kwargs = (
+            mock_rest_client.agent_api_memories.create_agent_memory.call_args.kwargs
+        )
+        memory_payload = call_kwargs["memory"].model_dump(exclude_unset=True)
+        assert memory_payload["scope"] == "agent"
+        assert "subject_id" not in memory_payload
+
+    @pytest.mark.asyncio
+    async def test_list_memories_agent_scope_sent_untouched(
+        self, mock_rest_client
+    ) -> None:
+        """`scope="agent"` passes straight through to the list filter."""
+        response = MagicMock()
+        response.data = []
+        mock_rest_client.agent_api_memories.list_agent_memories = AsyncMock(
+            return_value=response
+        )
+        tools = AgentTools("room-123", mock_rest_client)
+
+        await tools.list_memories(scope="agent")
+
+        mock_rest_client.agent_api_memories.list_agent_memories.assert_awaited_once_with(
+            page_size=50,
+            scope="agent",
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
+
+    @pytest.mark.asyncio
     async def test_store_memory_rejects_subject_scope_without_subject_id(
         self, mock_rest_client
     ) -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -155,6 +155,21 @@ class TestCapabilityGatedSections:
         assert "## Memory Tools" in prompt
         assert "band_store_memory" in prompt
 
+    def test_memory_section_guides_toward_agent_scope(self):
+        """Every agent's live guidance must offer `scope="agent"`, not just
+        `subject`/`organization` -- an agent whose owner has no organization
+        (the common case; see INT-1307) can only express private memory
+        through agent scope. Losing this line silently steers every real
+        agent back toward organization scope, which 422s for them."""
+        features = AdapterFeatures(capabilities={Capability.MEMORY})
+        prompt = render_system_prompt(
+            agent_name="Bot",
+            agent_description="helper",
+            features=features,
+        )
+
+        assert 'scope="agent"' in prompt
+
     def test_memory_section_absent_by_default(self):
         """Memory tool instructions absent when no features."""
         prompt = render_system_prompt(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -156,11 +156,10 @@ class TestCapabilityGatedSections:
         assert "band_store_memory" in prompt
 
     def test_memory_section_guides_toward_agent_scope(self):
-        """Every agent's live guidance must offer `scope="agent"`, not just
-        `subject`/`organization` -- an agent whose owner has no organization
-        (the common case; see INT-1307) can only express private memory
-        through agent scope. Losing this line silently steers every real
-        agent back toward organization scope, which 422s for them."""
+        """Guidance must offer `scope="agent"`, not just `subject`/`organization`
+        -- an agent whose owner has no organization can only express private
+        memory through agent scope; losing this line steers every agent back
+        toward organization scope, which fails for them."""
         features = AdapterFeatures(capabilities={Capability.MEMORY})
         prompt = render_system_prompt(
             agent_name="Bot",


### PR DESCRIPTION
## Summary

- Platform ([PLT-1396](https://linear.app/thenvoi/issue/PLT-1396/fix-memory-read-scoping-when-organization-is-missing)) closed a cross-tenant data leak in organization-scoped memory reads and added a third real scope value — `agent` (private to the storing agent, no organization required). The SDK only exposed `subject`/`organization`, and the live system-prompt guidance every real agent reads steered it toward `organization` scope with no `agent` alternative — which now 422s for any agent whose owner has no organization (verified live: true of every E2E test identity, and there's no self-service org-creation API to fix that).
- Add `AGENT` to `MemoryStoreScope`/`MemoryListScope`; fix `validate_subject_scope`'s fallback suggestion (was pointing back at the now-broken `organization` scope); update master tool text and the live `runtime/prompts.py` guidance every agent gets every turn.
- Migrate the baseline E2E memory suite off `organization` scope onto `agent` scope; invert the cross-agent org-sharing test into a real agent-scope isolation regression test instead of skipping it.
- Add two live (unmocked) tests locking in the platform's fail-closed 422 contract on both read and write.
- Fix a stale customer-facing example that hardcoded `organization` scope.
- Derive the store/list `scope` field descriptions and `validate_subject_scope`'s error text from the enum instead of hand-retyping the org-membership caveat in four places.
- `AgentTools.list_memories`/`store_memory` now catch the platform's org-scope-rejected 422 specifically and raise actionable `scope="agent"` retry guidance instead of letting it fall through to the generic handler, which dumped the raw REST error body (`headers: ..., status_code: 422, body: ...`) at the LLM.

Root-caused via live reproduction against the E2E platform + verification against actual `thenvoi-platform` source (not just the Linear writeup). Full context in [INT-1307](https://linear.app/thenvoi/issue/INT-1307/add-agent-scoped-memory-support-migrate-baseline-e2e-off-organization). A genuine happy-path organization-scope test needs a persistent test org + admin key that doesn't exist yet — tracked separately in [INT-1308](https://linear.app/thenvoi/issue/INT-1308/provision-a-persistent-e2e-test-organization-admin-key-add-real).

## Test plan

- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run pyrefly check`
- [x] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/` — 5084 passed
- [x] Live: `E2E_TESTS_ENABLED=true uv run pytest tests/e2e/baseline/smoke/inspection/test_memory.py` — 11/11 passed
- [x] Live: `test_capability_matrix.py` memory tests, `anthropic` cell — 2/2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nyz1uWgNb2yHExFP6yzfk4
