### PR TITLE
ci: split release-please PRs per package

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
+  "separate-pull-requests": true,
   "packages": {
     ".": {
       "package-name": "band-sdk",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": true,
-      "exclude-paths": ["packages/band-mcp"],
+      "exclude-paths": ["packages"],
       "extra-files": [
         "src/band/__init__.py",
         {


### PR DESCRIPTION
## Summary
- Stop combining `band-sdk` and `band-mcp` into one `chore: release main` PR (`separate-pull-requests: true`), matching the [manifest releaser docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md).
- Widen root `exclude-paths` to `packages` so nested-package-only commits are skipped for `band-sdk`.
- Does **not** un-attribute the already-merged INT-1261 squash: do not merge https://github.com/band-ai/band-sdk-python/pull/569 as-is (it would publish a fake `band-mcp` 3.0.0). After this lands, pin the next MCP release with a **separate** PR that only touches `packages/band-mcp` and has `Release-As: 2.1.0` in the commit body (same squash would also pin `band-sdk` if it includes this config file).

Fixes INT-1316

## Test plan
- [ ] Confirm changelog-path stays package-relative `CHANGELOG.md` (root → `CHANGELOG.md`, MCP → `packages/band-mcp/CHANGELOG.md`)
- [ ] After merge, the next release-please run opens two PRs instead of `chore: release main`
- [ ] Do not merge #569 until the `Release-As: 2.1.0` follow-up has rewritten the MCP bump


Made with [Cursor](https://cursor.com)