### PR TITLE
ci: revert split release PRs, prune dead release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,34 +1,15 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
-  "separate-pull-requests": true,
   "packages": {
     ".": {
       "package-name": "band-sdk",
       "changelog-path": "CHANGELOG.md",
-      "include-component-in-tag": true,
-      "exclude-paths": ["packages"],
-      "extra-files": [
-        "src/band/__init__.py",
-        {
-          "type": "generic",
-          "path": "pyproject.toml",
-          "glob": false
-        }
-      ]
+      "exclude-paths": ["packages"]
     },
     "packages/band-mcp": {
       "package-name": "band-mcp",
-      "changelog-path": "CHANGELOG.md",
-      "include-component-in-tag": true,
-      "extra-files": [
-        "src/band_mcp/__init__.py",
-        {
-          "type": "generic",
-          "path": "pyproject.toml",
-          "glob": false
-        }
-      ]
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary

- **Reverts `separate-pull-requests: true`** (added in #576). It broke release PR CI: `release.yml`'s uv.lock sync step only re-locks the first PR from `steps.release.outputs.pr`, so the band-mcp release PR (#577) was left with `pyproject 3.0.0` vs `uv.lock 2.0.1` and fails `uv lock --check` in every job. One combined release PR is what the existing workflow supports (proven by #560/#569 getting their locks synced), and matches the TypeScript repo's config shape.
- **Prunes config that verifiably did nothing:**
  - `extra-files` — the Generic updater only rewrites lines annotated with `x-release-please-version`, and the repo has none. The Python strategy's built-in updaters do the real bumps (`pyproject.toml` via its TOML updater, `src/band_mcp/__init__.py` via the name-derived path). `src/band/__init__.py` was never updated by any release PR and doesn't need to be — it reads its version via `importlib.metadata`.
  - `include-component-in-tag: true` — documented default; tags stay `band-sdk-v*` / `band-mcp-v*`.
- **Keeps `exclude-paths: ["packages"]`** so band-mcp work never bumps band-sdk.

Versions, tags, changelogs, and GitHub releases stay fully per-package — only the release PR packaging changes back to one combined PR with a section per package.

After merge, release-please will close #577/#578 and open one combined PR. band-mcp will still show a false 3.0.0 there until a follow-up `packages/band-mcp`-only PR pins its next release to 2.1.0 (kept separate so the pin's squash footer can't touch band-sdk).

Part of INT-1316.

## Test plan

- [x] `jq` validates the config JSON
- [x] Removed knobs verified against the release-please schema/source and the diffs of release PRs #560/#569/#577/#578
- [ ] After merge: release-please opens a single combined release PR whose uv.lock gets synced and whose CI is green

Made with [Cursor](https://cursor.com)