### PR TITLE
chore(mcp): pin next band-mcp release to 2.1.0

### DIFF
--- a/packages/band-mcp/src/band_mcp/__init__.py
+++ b/packages/band-mcp/src/band_mcp/__init__.py
@@ -1,4 +1,8 @@
-"""Band MCP Server - Model Context Protocol integration for Band."""
+"""Band MCP Server - Model Context Protocol integration for Band.
+
+`__version__` is the published band-mcp package version, bumped by
+release-please on each release.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Corrects band-mcp's next release version from the false **3.0.0** release-please currently proposes to **2.1.0**.

A previously merged squash commit touched both the SDK tree and `packages/band-mcp` while carrying a breaking-change footer that applied only to the SDK. Release-please attributes a commit to every package whose files it touches, and a footer can't be scoped within a commit — so band-mcp inherited the SDK's major bump. Its real pending changes are additive, hence a minor: 2.1.0.

This PR deliberately touches **only** `packages/band-mcp` (a docstring note on `__version__`), so the pin below is attributed to band-mcp alone — the root package excludes `packages` and never sees it. Do not add root-tree files to this PR.

**The line below is the fix** — it must survive into the squash commit body, so please keep the PR description intact when merging.

Part of INT-1316.

Release-As: 2.1.0

Made with [Cursor](https://cursor.com)