### PR TITLE
feat: integrate band-sdk-core SubscriptionTracker into BandLink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -748,7 +748,7 @@ agent keys and platform URLs should stay aligned with `.env.test` /
 - `GITHUB_TOKEN`: A Copilot-entitled GitHub token. The baseline `copilot_sdk` and `copilot_acp` builders use Anthropic BYOK and never read it; the only baseline reader is the single Copilot-hosted auth smoke (`test_copilot_hosted_auth_replies`, skips when unset). Also used by Copilot-hosted examples outside the baseline; optional when a stored `copilot login` is present.
 - `E2E_TESTS_ENABLED`: Set to `true` to enable E2E tests (default: disabled)
 - `E2E_LLM_MODEL`: OpenAI model for E2E tests (default: `gpt-5.4-mini`)
-- `E2E_ANTHROPIC_MODEL`: Anthropic model for E2E tests (legacy E2E default: `claude-3-haiku-20240307`; baseline toolkit default: `claude-haiku-4-5` — the baseline judge uses structured outputs, which `claude-3-haiku-20240307` does not support)
+- `E2E_ANTHROPIC_MODEL`: Anthropic model for E2E tests (default: `claude-haiku-4-5` — the baseline judge uses structured outputs, which older Haiku models do not support)
 - `E2E_JUDGE_MODEL`: Anthropic model for the baseline LLM judge (default: falls back to `E2E_ANTHROPIC_MODEL`; must support structured outputs)
 - `E2E_TIMEOUT`: Per-turn response timeout in seconds for E2E tests (default: `120`; a slow test can add headroom with `@pytest.mark.timeout(extra=n)`)
 - `DOCKER_TESTS_ENABLED`: Set to `true` to run `docker_build`-marked tests (e.g. `tests/docker/test_band_python_kit.py`), which shell out to a real `docker build`/`docker run` (default: disabled everywhere, including CI — CI runners do have a Docker daemon, unlike the nested-virtualization `sbx` tests, so this needs the same explicit opt-in as `E2E_TESTS_ENABLED` rather than a plain Docker-availability check)

--- a/README.md
+++ b/README.md
@@ -548,24 +548,25 @@ Emit controls adapter-level telemetry: events the adapter publishes when it obse
 
 Adapter emit support:
 
-| Adapter | `TOOL_CALLS` | `THOUGHTS` | `TASK_EVENTS` |
-| ------- | ----------- | ---------- | ------------- |
-| Codex | Yes | Yes | Yes |
-| Claude SDK | Yes | Yes | - |
-| Agno | Yes | Yes | - |
-| OpenCode | Yes | - | Yes |
-| Letta | Yes | - | Yes |
-| Anthropic | Yes | - | - |
-| CrewAI | Yes | - | - |
-| CrewAI Flow | Yes | - | - |
-| Gemini | Yes | - | - |
-| Google ADK | Yes | - | - |
-| Pydantic AI | Yes | - | - |
-| LangGraph | Yes | - | - |
-| Strands Agents | Yes | - | - |
-| Parlant | - | - | - |
-| A2A / A2A Gateway | - | - | - |
-| ACP Client | - | - | - |
+| Adapter | `TOOL_CALLS` | `THOUGHTS` | `TASK_EVENTS` | `USAGE` |
+| ------- | ----------- | ---------- | ------------- | ------- |
+| Codex | Yes | Yes | Yes | Yes |
+| Claude SDK | Yes | Yes | - | Yes |
+| Copilot SDK | Yes | Yes | - | Yes |
+| Agno | Yes | Yes | - | Yes |
+| OpenCode | Yes | - | Yes | Yes |
+| Letta | Yes | - | Yes | Yes |
+| Anthropic | Yes | - | - | Yes |
+| CrewAI | Yes | - | - | - |
+| CrewAI Flow | Yes | - | - | - |
+| Gemini | Yes | - | - | Yes |
+| Google ADK | Yes | - | - | Yes |
+| Pydantic AI | Yes | - | - | Yes |
+| LangGraph | Yes | - | - | Yes |
+| Strands Agents | Yes | - | - | Yes |
+| Parlant | - | - | - | - |
+| A2A / A2A Gateway | - | - | - | - |
+| ACP Client | - | - | - | - |
 
 Requesting an unsupported `emit` or `capabilities` value raises `BandConfigError` immediately at construction.
 

--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -56,12 +56,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Single source of truth for the two single-topic agent-channel kinds: every
+# site that builds a topic string (_agent_*_topic) or parses one back apart
+# (_drain_reconciliation) reads these, so a typo in one can't silently
+# diverge from the other.
+_AGENT_ROOMS_KIND = "agent_rooms"
+_AGENT_CONTACTS_KIND = "agent_contacts"
+
+
 def _agent_rooms_topic(agent_id: str) -> str:
-    return f"agent_rooms:{agent_id}"
+    return f"{_AGENT_ROOMS_KIND}:{agent_id}"
 
 
 def _agent_contacts_topic(agent_id: str) -> str:
-    return f"agent_contacts:{agent_id}"
+    return f"{_AGENT_CONTACTS_KIND}:{agent_id}"
 
 
 class BandLink:
@@ -232,6 +240,40 @@ class BandLink:
 
     # --- Subscription management (from BandAgent) ---
 
+    def _blocked_by_reconciliation(
+        self, key: str, pending: set[str], *, noun: str
+    ) -> bool:
+        """Whether ``key`` is blocked from a fresh subscribe until the next
+        reconnect drains ``pending`` — the single check both subscribe_room
+        and _subscribe_agent_topic gate on (see design doc for why this, not
+        core's own status, is the authoritative block condition)."""
+        if key not in pending:
+            return False
+        logger.warning(
+            "%s %s needs reconciliation, blocking subscribe until next reconnect",
+            noun,
+            key,
+        )
+        return True
+
+    async def _leave_channel(
+        self,
+        leave: Callable[[], Awaitable[None]],
+        *,
+        description: str,
+        level: int = logging.WARNING,
+    ) -> bool:
+        """Attempt one best-effort channel leave: log and swallow any
+        failure, report whether it actually succeeded. Shared by every leave
+        attempt in this module (rollback, unsubscribe, reconciliation drain)
+        so "did we manage to leave this?" has one implementation."""
+        try:
+            await leave()
+            return True
+        except Exception as e:
+            logger.log(level, "Error %s: %s", description, e)
+            return False
+
     async def subscribe_agent_rooms(self, agent_id: str) -> None:
         """
         Subscribe to agent room events (room_added/removed).
@@ -267,12 +309,11 @@ class BandLink:
         """
         if not self._ws:
             raise RuntimeError("Not connected")
+        ws = self._ws
 
-        if room_id in self._rooms_needing_reconciliation:
-            logger.warning(
-                "Room %s needs reconciliation, blocking subscribe until next reconnect",
-                room_id,
-            )
+        if self._blocked_by_reconciliation(
+            room_id, self._rooms_needing_reconciliation, noun="Room"
+        ):
             return
 
         ticket = self._subscriptions.begin_room_subscribe(room_id=room_id)
@@ -283,7 +324,7 @@ class BandLink:
         try:
             try:
                 # Subscribe to messages (from lines 733-736)
-                await self._ws.join_chat_room_channel(
+                await ws.join_chat_room_channel(
                     room_id,
                     on_message_created=lambda msg: self._on_message_created(
                         room_id, msg
@@ -299,7 +340,7 @@ class BandLink:
 
             try:
                 # Subscribe to participant updates (from lines 739-743)
-                await self._ws.join_room_participants_channel(
+                await ws.join_room_participants_channel(
                     room_id,
                     on_participant_added=lambda p: self._on_participant_added(
                         room_id, p
@@ -312,11 +353,10 @@ class BandLink:
             except Exception as e:
                 logger.warning("Failed to join room_participants:%s: %s", room_id, e)
                 # Clean up the chat_room channel we already joined
-                chat_room_left = True
-                try:
-                    await self._ws.leave_chat_room_channel(room_id)
-                except Exception:
-                    chat_room_left = False
+                chat_room_left = await self._leave_channel(
+                    lambda: ws.leave_chat_room_channel(room_id),
+                    description=f"rolling back chat_room:{room_id}",
+                )
                 result = self._subscriptions.record_room_participants_join_failed(
                     room_id=room_id, ticket=ticket, chat_room_left=chat_room_left
                 )
@@ -376,12 +416,9 @@ class BandLink:
         ``subscribe_room``'s two-topic version but with one join, no
         rollback phase.
         """
-        if topic in self._agent_topics_needing_reconciliation:
-            logger.warning(
-                "Agent topic %s needs reconciliation, blocking subscribe "
-                "until next reconnect",
-                topic,
-            )
+        if self._blocked_by_reconciliation(
+            topic, self._agent_topics_needing_reconciliation, noun="Agent topic"
+        ):
             return
 
         ticket = self._subscriptions.begin_agent_topic_join(topic=topic)
@@ -420,6 +457,7 @@ class BandLink:
         """
         if not self._ws:
             return
+        ws = self._ws
 
         ticket = self._subscriptions.unsubscribe_room(room_id=room_id)
         if ticket is None:
@@ -427,21 +465,14 @@ class BandLink:
 
         outcome = LeaveOutcome.Unknown
         try:
-            chat_room_left = True
-            try:
-                await self._ws.leave_chat_room_channel(room_id)
-            except Exception as e:
-                chat_room_left = False
-                logger.warning("Error unsubscribing from chat_room:%s: %s", room_id, e)
-
-            participants_left = True
-            try:
-                await self._ws.leave_room_participants_channel(room_id)
-            except Exception as e:
-                participants_left = False
-                logger.warning(
-                    "Error unsubscribing from room_participants:%s: %s", room_id, e
-                )
+            chat_room_left = await self._leave_channel(
+                lambda: ws.leave_chat_room_channel(room_id),
+                description=f"unsubscribing from chat_room:{room_id}",
+            )
+            participants_left = await self._leave_channel(
+                lambda: ws.leave_room_participants_channel(room_id),
+                description=f"unsubscribing from room_participants:{room_id}",
+            )
 
             outcome = (
                 LeaveOutcome.Left
@@ -484,12 +515,12 @@ class BandLink:
 
         outcome = LeaveOutcome.Unknown
         try:
-            await leave()
-            outcome = LeaveOutcome.Left
-            logger.debug("Left agent topic %s", topic)
-        except Exception as e:
-            outcome = LeaveOutcome.Failed
-            logger.warning("Error leaving agent topic %s: %s", topic, e)
+            left = await self._leave_channel(
+                leave, description=f"leaving agent topic {topic}"
+            )
+            outcome = LeaveOutcome.Left if left else LeaveOutcome.Failed
+            if left:
+                logger.debug("Left agent topic %s", topic)
         finally:
             self._subscriptions.mark_agent_topic_leave_complete(
                 topic=topic, ticket=ticket, outcome=outcome
@@ -526,45 +557,51 @@ class BandLink:
     async def _drain_reconciliation(self) -> None:
         """Force a clean transport + tracker state for every room/topic left
         ambiguous since the last reconnect, then release the local block.
+
+        ``ws`` is captured once and every iteration re-checks it's still
+        ``self._ws``: a concurrent disconnect()/reconnect() can swap or clear
+        the client while this is mid-await, and stopping there avoids both
+        leaving a stale ``ws`` instance (whose channels this session no
+        longer owns) and wasted work — never a correctness issue on its own,
+        since every leave here is already best-effort, just needless.
         """
         assert (
             self._ws is not None
         )  # only called from the ws client's own reconnect hook
+        ws = self._ws
 
         for room_id in list(self._rooms_needing_reconciliation):
-            try:
-                await self._ws.leave_chat_room_channel(room_id)
-            except Exception as e:
-                logger.debug(
-                    "Best-effort leave of chat_room:%s during reconciliation: %s",
-                    room_id,
-                    e,
-                )
-            try:
-                await self._ws.leave_room_participants_channel(room_id)
-            except Exception as e:
-                logger.debug(
-                    "Best-effort leave of room_participants:%s during "
-                    "reconciliation: %s",
-                    room_id,
-                    e,
-                )
+            if self._ws is not ws:
+                return
+            await self._leave_channel(
+                lambda: ws.leave_chat_room_channel(room_id),
+                description=f"best-effort reconciliation leave of chat_room:{room_id}",
+                level=logging.DEBUG,
+            )
+            await self._leave_channel(
+                lambda: ws.leave_room_participants_channel(room_id),
+                description=(
+                    f"best-effort reconciliation leave of room_participants:{room_id}"
+                ),
+                level=logging.DEBUG,
+            )
             self._subscriptions.acknowledge_room_reconciled(room_id=room_id)
             self._rooms_needing_reconciliation.discard(room_id)
 
         for topic in list(self._agent_topics_needing_reconciliation):
+            if self._ws is not ws:
+                return
             kind, _, agent_id = topic.partition(":")
             leave = (
-                self._ws.leave_agent_rooms_channel
-                if kind == "agent_rooms"
-                else self._ws.leave_agent_contacts_channel
+                ws.leave_agent_rooms_channel
+                if kind == _AGENT_ROOMS_KIND
+                else ws.leave_agent_contacts_channel
             )
-            try:
-                await leave(agent_id)
-            except Exception as e:
-                logger.debug(
-                    "Best-effort leave of %s during reconciliation: %s", topic, e
-                )
+            await self._leave_channel(
+                lambda: leave(agent_id),
+                description=f"best-effort reconciliation leave of {topic}",
+                level=logging.DEBUG,
+            )
             self._subscriptions.acknowledge_agent_topic_reconciled(topic=topic)
             self._agent_topics_needing_reconciliation.discard(topic)
 

--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -19,6 +19,7 @@ from band.client.streaming import WebSocketClient, WebSocketDisconnectReason
 from band.core.types import PlatformConnection
 from band.runtime.types import PlatformMessage
 from band_rest.core.api_error import ApiError
+from band_sdk_core import LeaveOutcome, RoomSubscribeResult, SubscriptionTracker
 
 from band.platform.event import (
     MessageEvent,
@@ -53,6 +54,14 @@ if TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
+
+
+def _agent_rooms_topic(agent_id: str) -> str:
+    return f"agent_rooms:{agent_id}"
+
+
+def _agent_contacts_topic(agent_id: str) -> str:
+    return f"agent_contacts:{agent_id}"
 
 
 class BandLink:
@@ -97,8 +106,13 @@ class BandLink:
         self._ws: WebSocketClient | None = None
         self._is_connected = False
 
-        # Subscription tracking (from BandAgent._subscribed_rooms)
-        self._subscribed_rooms: set[str] = set()
+        # Subscription tracking (band_sdk_core.SubscriptionTracker) plus local
+        # bookkeeping for claims whose real-world outcome is ambiguous (a
+        # cancelled join, a failed rollback, a non-clean leave) — drained only
+        # at the next reconnect boundary, see _drain_reconciliation.
+        self._subscriptions = SubscriptionTracker()
+        self._rooms_needing_reconciliation: set[str] = set()
+        self._agent_topics_needing_reconciliation: set[str] = set()
 
         # Event queue for async iteration
         self._event_queue: asyncio.Queue[PlatformEvent] = asyncio.Queue(maxsize=1000)
@@ -201,7 +215,9 @@ class BandLink:
         await self._ws.__aexit__(None, None, None)
         self._ws = None
         self._is_connected = False
-        self._subscribed_rooms.clear()
+        self._subscriptions.end_session()
+        self._rooms_needing_reconciliation.clear()
+        self._agent_topics_needing_reconciliation.clear()
         logger.info("Disconnected from platform")
 
     async def run_forever(self) -> None:
@@ -224,11 +240,15 @@ class BandLink:
         """
         if not self._ws:
             raise RuntimeError("Not connected")
+        ws = self._ws
 
-        await self._ws.join_agent_rooms_channel(
-            agent_id,
-            on_room_added=self._on_room_added,
-            on_room_removed=self._on_room_removed,
+        await self._subscribe_agent_topic(
+            _agent_rooms_topic(agent_id),
+            lambda: ws.join_agent_rooms_channel(
+                agent_id,
+                on_room_added=self._on_room_added,
+                on_room_removed=self._on_room_removed,
+            ),
         )
 
     async def subscribe_room(self, room_id: str) -> None:
@@ -238,44 +258,93 @@ class BandLink:
         Extracted from BandAgent._subscribe_to_room() lines 724-746.
         Wraps each channel join so a single room failure doesn't crash
         the entire subscription sequence.
+
+        Blocked (a no-op, logged) while ``room_id`` is in
+        ``_rooms_needing_reconciliation`` — the room's outcome from a prior
+        cancelled/ambiguous attempt is unresolved and must not be retried on
+        the same socket. It stays blocked until the next reconnect drains it
+        (see ``_drain_reconciliation``); see the design doc for why.
         """
         if not self._ws:
             raise RuntimeError("Not connected")
 
-        if room_id in self._subscribed_rooms:
+        if room_id in self._rooms_needing_reconciliation:
+            logger.warning(
+                "Room %s needs reconciliation, blocking subscribe until next reconnect",
+                room_id,
+            )
             return
 
-        try:
-            # Subscribe to messages (from lines 733-736)
-            await self._ws.join_chat_room_channel(
-                room_id,
-                on_message_created=lambda msg: self._on_message_created(room_id, msg),
-            )
-        except Exception as e:
-            logger.warning("Failed to join chat_room:%s: %s", room_id, e)
+        ticket = self._subscriptions.begin_room_subscribe(room_id=room_id)
+        if ticket is None:
             return
 
+        settled = False
         try:
-            # Subscribe to participant updates (from lines 739-743)
-            await self._ws.join_room_participants_channel(
-                room_id,
-                on_participant_added=lambda p: self._on_participant_added(room_id, p),
-                on_participant_removed=lambda p: self._on_participant_removed(
-                    room_id, p
-                ),
-                on_room_deleted=lambda p: self._on_room_deleted(room_id, p),
-            )
-        except Exception as e:
-            logger.warning("Failed to join room_participants:%s: %s", room_id, e)
-            # Clean up the chat_room channel we already joined
             try:
-                await self._ws.leave_chat_room_channel(room_id)
-            except Exception:
-                pass
-            return
+                # Subscribe to messages (from lines 733-736)
+                await self._ws.join_chat_room_channel(
+                    room_id,
+                    on_message_created=lambda msg: self._on_message_created(
+                        room_id, msg
+                    ),
+                )
+            except Exception as e:
+                logger.warning("Failed to join chat_room:%s: %s", room_id, e)
+                self._subscriptions.record_chat_room_join_failed(
+                    room_id=room_id, ticket=ticket
+                )
+                settled = True
+                return
 
-        self._subscribed_rooms.add(room_id)
-        logger.debug("Subscribed to room %s", room_id)
+            try:
+                # Subscribe to participant updates (from lines 739-743)
+                await self._ws.join_room_participants_channel(
+                    room_id,
+                    on_participant_added=lambda p: self._on_participant_added(
+                        room_id, p
+                    ),
+                    on_participant_removed=lambda p: self._on_participant_removed(
+                        room_id, p
+                    ),
+                    on_room_deleted=lambda p: self._on_room_deleted(room_id, p),
+                )
+            except Exception as e:
+                logger.warning("Failed to join room_participants:%s: %s", room_id, e)
+                # Clean up the chat_room channel we already joined
+                chat_room_left = True
+                try:
+                    await self._ws.leave_chat_room_channel(room_id)
+                except Exception:
+                    chat_room_left = False
+                result = self._subscriptions.record_room_participants_join_failed(
+                    room_id=room_id, ticket=ticket, chat_room_left=chat_room_left
+                )
+                settled = True
+                if result is RoomSubscribeResult.RollbackFailed:
+                    logger.warning(
+                        "Rollback failed for room %s after participants-join "
+                        "failure; needs reconciliation on next reconnect",
+                        room_id,
+                    )
+                    self._rooms_needing_reconciliation.add(room_id)
+                return
+
+            self._subscriptions.record_both_room_topics_joined(
+                room_id=room_id, ticket=ticket
+            )
+            settled = True
+            logger.debug("Subscribed to room %s", room_id)
+        finally:
+            # Cancellation (or any other unexpected escape) leaves the ticket
+            # unresolved: force it into the one outcome that can express
+            # ambiguity to core (see design doc), and block local resubscribe
+            # until the next reconnect regardless of what core reports back.
+            if not settled:
+                self._subscriptions.record_room_participants_join_failed(
+                    room_id=room_id, ticket=ticket, chat_room_left=False
+                )
+                self._rooms_needing_reconciliation.add(room_id)
 
     async def subscribe_agent_contacts(self, agent_id: str) -> None:
         """
@@ -286,14 +355,62 @@ class BandLink:
         """
         if not self._ws:
             raise RuntimeError("Not connected")
+        ws = self._ws
 
-        await self._ws.join_agent_contacts_channel(
-            agent_id,
-            on_contact_request_received=self._on_contact_request_received,
-            on_contact_request_updated=self._on_contact_request_updated,
-            on_contact_added=self._on_contact_added,
-            on_contact_removed=self._on_contact_removed,
+        await self._subscribe_agent_topic(
+            _agent_contacts_topic(agent_id),
+            lambda: ws.join_agent_contacts_channel(
+                agent_id,
+                on_contact_request_received=self._on_contact_request_received,
+                on_contact_request_updated=self._on_contact_request_updated,
+                on_contact_added=self._on_contact_added,
+                on_contact_removed=self._on_contact_removed,
+            ),
         )
+
+    async def _subscribe_agent_topic(
+        self, topic: str, join: Callable[[], Awaitable[None]]
+    ) -> None:
+        """Shared join/track/rollback shape for the single-topic agent
+        channels (``agent_rooms``, ``agent_contacts``) — mirrors
+        ``subscribe_room``'s two-topic version but with one join, no
+        rollback phase.
+        """
+        if topic in self._agent_topics_needing_reconciliation:
+            logger.warning(
+                "Agent topic %s needs reconciliation, blocking subscribe "
+                "until next reconnect",
+                topic,
+            )
+            return
+
+        ticket = self._subscriptions.begin_agent_topic_join(topic=topic)
+        if ticket is None:
+            return
+
+        settled = False
+        try:
+            await join()
+            self._subscriptions.record_agent_topic_join(
+                topic=topic, ticket=ticket, joined=True
+            )
+            settled = True
+            logger.debug("Joined agent topic %s", topic)
+        except Exception as e:
+            logger.warning("Failed to join agent topic %s: %s", topic, e)
+            self._subscriptions.record_agent_topic_join(
+                topic=topic, ticket=ticket, joined=False
+            )
+            settled = True
+        finally:
+            # record_agent_topic_join(joined=False) never reaches core's own
+            # NeedsReconciliation (see design doc) — the local set is the
+            # only thing that blocks a same-socket retry here.
+            if not settled:
+                self._subscriptions.record_agent_topic_join(
+                    topic=topic, ticket=ticket, joined=False
+                )
+                self._agent_topics_needing_reconciliation.add(topic)
 
     async def unsubscribe_room(self, room_id: str) -> None:
         """
@@ -301,33 +418,88 @@ class BandLink:
 
         Extracted from BandAgent._unsubscribe_from_room() lines 748-769.
         """
-        if not self._ws or room_id not in self._subscribed_rooms:
-            return
-
-        self._subscribed_rooms.discard(room_id)
-
-        try:
-            await self._ws.leave_chat_room_channel(room_id)
-        except Exception as e:
-            logger.warning("Error unsubscribing from chat_room:%s: %s", room_id, e)
-
-        try:
-            await self._ws.leave_room_participants_channel(room_id)
-        except Exception as e:
-            logger.warning(
-                "Error unsubscribing from room_participants:%s: %s", room_id, e
-            )
-
-        logger.debug("Unsubscribed from room %s", room_id)
-
-    async def unsubscribe_agent_contacts(self) -> None:
-        """Unsubscribe from agent contacts channel."""
         if not self._ws:
             return
+
+        ticket = self._subscriptions.unsubscribe_room(room_id=room_id)
+        if ticket is None:
+            return
+
+        outcome = LeaveOutcome.Unknown
         try:
-            await self._ws.leave_agent_contacts_channel(self.agent_id)
+            chat_room_left = True
+            try:
+                await self._ws.leave_chat_room_channel(room_id)
+            except Exception as e:
+                chat_room_left = False
+                logger.warning("Error unsubscribing from chat_room:%s: %s", room_id, e)
+
+            participants_left = True
+            try:
+                await self._ws.leave_room_participants_channel(room_id)
+            except Exception as e:
+                participants_left = False
+                logger.warning(
+                    "Error unsubscribing from room_participants:%s: %s", room_id, e
+                )
+
+            outcome = (
+                LeaveOutcome.Left
+                if (chat_room_left and participants_left)
+                else LeaveOutcome.Failed
+            )
+            logger.debug("Unsubscribed from room %s (outcome=%s)", room_id, outcome)
+        finally:
+            # A cancellation leaves `outcome` at its Unknown default — either
+            # way this resolves the ticket exactly once.
+            self._subscriptions.mark_room_leave_complete(
+                room_id=room_id, ticket=ticket, outcome=outcome
+            )
+            if outcome is not LeaveOutcome.Left:
+                self._rooms_needing_reconciliation.add(room_id)
+
+    async def unsubscribe_agent_contacts(self) -> None:
+        """Unsubscribe from agent contacts channel.
+
+        A true no-op when the topic was never joined — the tracker's
+        ``leave_agent_topic`` returns ``None`` in that case rather than
+        issuing a leave the transport would just reject.
+        """
+        if not self._ws:
+            return
+        ws = self._ws
+
+        await self._leave_agent_topic(
+            _agent_contacts_topic(self.agent_id),
+            lambda: ws.leave_agent_contacts_channel(self.agent_id),
+        )
+
+    async def _leave_agent_topic(
+        self, topic: str, leave: Callable[[], Awaitable[None]]
+    ) -> None:
+        """Shared leave/track shape for the single-topic agent channels."""
+        ticket = self._subscriptions.leave_agent_topic(topic=topic)
+        if ticket is None:
+            return
+
+        outcome = LeaveOutcome.Unknown
+        try:
+            await leave()
+            outcome = LeaveOutcome.Left
+            logger.debug("Left agent topic %s", topic)
         except Exception as e:
-            logger.warning("Error unsubscribing from agent_contacts: %s", e)
+            outcome = LeaveOutcome.Failed
+            logger.warning("Error leaving agent topic %s: %s", topic, e)
+        finally:
+            self._subscriptions.mark_agent_topic_leave_complete(
+                topic=topic, ticket=ticket, outcome=outcome
+            )
+            if outcome is not LeaveOutcome.Left:
+                self._agent_topics_needing_reconciliation.add(topic)
+
+    def is_room_subscribed(self, room_id: str) -> bool:
+        """Whether ``room_id`` is currently fully subscribed (both topics)."""
+        return self._subscriptions.is_room_subscribed(room_id=room_id)
 
     # --- Event handlers (from BandAgent, unified into PlatformEvent) ---
 
@@ -338,9 +510,63 @@ class BandLink:
         this hook, so room subscription tracking must stay intact here.
         RoomPresence can then reconcile tracked rooms against the server state
         without leaking channels or replaying duplicate room joins.
+
+        Also drains anything left in the local reconciliation sets: the
+        transport's own auto-rejoin above can silently succeed for a room/
+        topic whose prior join or leave was ambiguous (cancelled, or a
+        failed rollback), so ``_drain_reconciliation`` forces a clean leave
+        before acknowledging the tracker — this is the only point where that
+        ambiguity is safely resolvable (see design doc).
         """
         logger.info("WebSocket reconnected — reconciling room state")
+        self._subscriptions.on_reconnected()
+        await self._drain_reconciliation()
         self._queue_event(ReconnectedEvent())
+
+    async def _drain_reconciliation(self) -> None:
+        """Force a clean transport + tracker state for every room/topic left
+        ambiguous since the last reconnect, then release the local block.
+        """
+        assert (
+            self._ws is not None
+        )  # only called from the ws client's own reconnect hook
+
+        for room_id in list(self._rooms_needing_reconciliation):
+            try:
+                await self._ws.leave_chat_room_channel(room_id)
+            except Exception as e:
+                logger.debug(
+                    "Best-effort leave of chat_room:%s during reconciliation: %s",
+                    room_id,
+                    e,
+                )
+            try:
+                await self._ws.leave_room_participants_channel(room_id)
+            except Exception as e:
+                logger.debug(
+                    "Best-effort leave of room_participants:%s during "
+                    "reconciliation: %s",
+                    room_id,
+                    e,
+                )
+            self._subscriptions.acknowledge_room_reconciled(room_id=room_id)
+            self._rooms_needing_reconciliation.discard(room_id)
+
+        for topic in list(self._agent_topics_needing_reconciliation):
+            kind, _, agent_id = topic.partition(":")
+            leave = (
+                self._ws.leave_agent_rooms_channel
+                if kind == "agent_rooms"
+                else self._ws.leave_agent_contacts_channel
+            )
+            try:
+                await leave(agent_id)
+            except Exception as e:
+                logger.debug(
+                    "Best-effort leave of %s during reconciliation: %s", topic, e
+                )
+            self._subscriptions.acknowledge_agent_topic_reconciled(topic=topic)
+            self._agent_topics_needing_reconciliation.discard(topic)
 
     async def _on_supersede(self, payload: "SupersedePayload") -> None:
         """Handle terminal supersede event before the platform closes the socket."""

--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -180,8 +180,8 @@ class BandLink:
 
         Extracted from BandAgent.start() lines 158-164.
         """
-        if self._is_connected:
-            logger.warning("Already connected")
+        if self._ws is not None:
+            logger.warning("Already connected or connecting")
             return
 
         self._last_disconnect_reason = None
@@ -256,6 +256,18 @@ class BandLink:
         )
         return True
 
+    def _mark_needing_reconciliation(
+        self, key: str, pending: set[str], ws: WebSocketClient
+    ) -> None:
+        """Block ``key`` from resubscribe until reconciled — but only within
+        the connection session (``ws``) that produced the ambiguity. A
+        session that has since been torn down or replaced (``self._ws`` no
+        longer ``ws``) has already cleared, or will never drain, this entry
+        on its own; adding it here would instead wrongly carry the block
+        into a session that never touched this room/topic."""
+        if self._ws is ws:
+            pending.add(key)
+
     async def _leave_channel(
         self,
         leave: Callable[[], Awaitable[None]],
@@ -291,6 +303,7 @@ class BandLink:
                 on_room_added=self._on_room_added,
                 on_room_removed=self._on_room_removed,
             ),
+            ws,
         )
 
     async def subscribe_room(self, room_id: str) -> None:
@@ -371,7 +384,9 @@ class BandLink:
                         "failure; needs reconciliation on next reconnect",
                         room_id,
                     )
-                    self._rooms_needing_reconciliation.add(room_id)
+                    self._mark_needing_reconciliation(
+                        room_id, self._rooms_needing_reconciliation, ws
+                    )
                 return
 
             self._subscriptions.record_both_room_topics_joined(
@@ -388,7 +403,9 @@ class BandLink:
                 self._subscriptions.record_room_participants_join_failed(
                     room_id=room_id, ticket=ticket, chat_room_left=False
                 )
-                self._rooms_needing_reconciliation.add(room_id)
+                self._mark_needing_reconciliation(
+                    room_id, self._rooms_needing_reconciliation, ws
+                )
 
     async def subscribe_agent_contacts(self, agent_id: str) -> None:
         """
@@ -410,10 +427,11 @@ class BandLink:
                 on_contact_added=self._on_contact_added,
                 on_contact_removed=self._on_contact_removed,
             ),
+            ws,
         )
 
     async def _subscribe_agent_topic(
-        self, topic: str, join: Callable[[], Awaitable[None]]
+        self, topic: str, join: Callable[[], Awaitable[None]], ws: WebSocketClient
     ) -> None:
         """Shared join/track/rollback shape for the single-topic agent
         channels (``agent_rooms``, ``agent_contacts``) — mirrors
@@ -451,7 +469,9 @@ class BandLink:
                 self._subscriptions.record_agent_topic_join(
                     topic=topic, ticket=ticket, joined=False
                 )
-                self._agent_topics_needing_reconciliation.add(topic)
+                self._mark_needing_reconciliation(
+                    topic, self._agent_topics_needing_reconciliation, ws
+                )
 
     async def unsubscribe_room(self, room_id: str) -> None:
         """
@@ -491,7 +511,9 @@ class BandLink:
                 room_id=room_id, ticket=ticket, outcome=outcome
             )
             if outcome is not LeaveOutcome.Left:
-                self._rooms_needing_reconciliation.add(room_id)
+                self._mark_needing_reconciliation(
+                    room_id, self._rooms_needing_reconciliation, ws
+                )
 
     async def unsubscribe_agent_contacts(self) -> None:
         """Unsubscribe from agent contacts channel.
@@ -507,10 +529,11 @@ class BandLink:
         await self._leave_agent_topic(
             _agent_contacts_topic(self.agent_id),
             lambda: ws.leave_agent_contacts_channel(self.agent_id),
+            ws,
         )
 
     async def _leave_agent_topic(
-        self, topic: str, leave: Callable[[], Awaitable[None]]
+        self, topic: str, leave: Callable[[], Awaitable[None]], ws: WebSocketClient
     ) -> None:
         """Shared leave/track shape for the single-topic agent channels."""
         ticket = self._subscriptions.leave_agent_topic(topic=topic)
@@ -530,7 +553,9 @@ class BandLink:
                 topic=topic, ticket=ticket, outcome=outcome
             )
             if outcome is not LeaveOutcome.Left:
-                self._agent_topics_needing_reconciliation.add(topic)
+                self._mark_needing_reconciliation(
+                    topic, self._agent_topics_needing_reconciliation, ws
+                )
 
     def is_room_subscribed(self, room_id: str) -> bool:
         """Whether ``room_id`` is currently fully subscribed (both topics)."""
@@ -1027,6 +1052,3 @@ class BandLink:
                 e,
             )
             return []
-
-
-BandLink = BandLink

--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -352,10 +352,14 @@ class BandLink:
                 )
             except Exception as e:
                 logger.warning("Failed to join room_participants:%s: %s", room_id, e)
-                # Clean up the chat_room channel we already joined
+                # Clean up the chat_room channel we already joined. Logged at
+                # DEBUG here (not WARNING) so a rollback failure produces one
+                # WARNING below, not two for the same event — the exception
+                # detail is still available for diagnosis.
                 chat_room_left = await self._leave_channel(
                     lambda: ws.leave_chat_room_channel(room_id),
                     description=f"rolling back chat_room:{room_id}",
+                    level=logging.DEBUG,
                 )
                 result = self._subscriptions.record_room_participants_join_failed(
                     room_id=room_id, ticket=ticket, chat_room_left=chat_room_left
@@ -557,19 +561,24 @@ class BandLink:
     async def _drain_reconciliation(self) -> None:
         """Force a clean transport + tracker state for every room/topic left
         ambiguous since the last reconnect, then release the local block.
-
-        ``ws`` is captured once and every iteration re-checks it's still
-        ``self._ws``: a concurrent disconnect()/reconnect() can swap or clear
-        the client while this is mid-await, and stopping there avoids both
-        leaving a stale ``ws`` instance (whose channels this session no
-        longer owns) and wasted work — never a correctness issue on its own,
-        since every leave here is already best-effort, just needless.
         """
         assert (
             self._ws is not None
         )  # only called from the ws client's own reconnect hook
         ws = self._ws
 
+        await self._drain_room_reconciliation(ws)
+        await self._drain_agent_topic_reconciliation(ws)
+
+    async def _drain_room_reconciliation(self, ws: WebSocketClient) -> None:
+        """``ws`` is the client captured at the start of the drain, not
+        re-read from ``self._ws``: a concurrent disconnect()/reconnect() can
+        swap or clear it while this is mid-await, and bailing out as soon as
+        that's detected avoids both acting through a stale client (whose
+        channels this session no longer owns) and further pointless work —
+        never a correctness issue on its own, since every leave here is
+        already best-effort, just needless.
+        """
         for room_id in list(self._rooms_needing_reconciliation):
             if self._ws is not ws:
                 return
@@ -588,6 +597,8 @@ class BandLink:
             self._subscriptions.acknowledge_room_reconciled(room_id=room_id)
             self._rooms_needing_reconciliation.discard(room_id)
 
+    async def _drain_agent_topic_reconciliation(self, ws: WebSocketClient) -> None:
+        """Same stale-``ws``-detection rationale as ``_drain_room_reconciliation``."""
         for topic in list(self._agent_topics_needing_reconciliation):
             if self._ws is not ws:
                 return

--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -10,15 +10,14 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from band.client.rest import AsyncRestClient, DEFAULT_REQUEST_OPTIONS
+from band.client.rest import AsyncRestClient
 from band.config.settings import DEFAULT_REST_URL, DEFAULT_WS_URL
 from band.client.streaming import WebSocketClient, WebSocketDisconnectReason
 from band.core.types import PlatformConnection
+from band.platform.message_lifecycle import MessageLifecycle
 from band.runtime.types import PlatformMessage
-from band_rest.core.api_error import ApiError
 from band_sdk_core import LeaveOutcome, RoomSubscribeResult, SubscriptionTracker
 
 from band.platform.event import (
@@ -110,6 +109,11 @@ class BandLink:
         # REST client - exposed directly (from BandAgent._api_client)
         self.rest = AsyncRestClient(api_key=api_key, base_url=rest_url)
 
+        # Pure REST message-lifecycle operations (mark_*/report_activity/
+        # get_next_message/get_stale_processing_messages) — no WebSocket
+        # state, so it lives in its own class rather than this one.
+        self._messages = MessageLifecycle()
+
         # WebSocket client (from BandAgent._ws_client)
         self._ws: WebSocketClient | None = None
         self._is_connected = False
@@ -133,11 +137,6 @@ class BandLink:
         # the serialized _event_queue — so a control signal can act on a cycle
         # already in flight instead of queuing behind it.
         self.on_control: Callable[[AgentControlPayload], Awaitable[None]] | None = None
-
-        # Debounce flag for activity-report failures: keep-alive runs at a few
-        # seconds per room, so a down endpoint would otherwise flood the log on
-        # every refresh. Log the first failure and the recovery, suppress repeats.
-        self._activity_report_failing = False
 
     @property
     def is_connected(self) -> bool:
@@ -836,219 +835,32 @@ class BandLink:
         self._queue_event(event)
 
     # --- Message lifecycle (SDK internal operations) ---
+    #
+    # Thin delegates to MessageLifecycle, which owns pure REST message
+    # operations with no WebSocket state. ``self.rest`` is passed per call
+    # (not captured once) so a caller that reassigns ``link.rest`` after
+    # construction — every mocked test does — is still honored.
 
     async def mark_processing(self, room_id: str, message_id: str) -> bool:
-        """
-        Mark message as being processed on the server.
-
-        This does NOT remove it from /next: the actionable set excludes only
-        'processed', so a crashed or stopped attempt stays replayable. Only
-        mark_processed clears the message from /next.
-        """
-        logger.debug("Marking message %s as processing", message_id)
-        try:
-            await self.rest.agent_api_messages.mark_agent_message_processing(
-                chat_id=room_id,
-                id=message_id,
-                request_options=DEFAULT_REQUEST_OPTIONS,
-            )
-        except Exception as e:
-            logger.warning("Failed to mark message %s as processing: %s", message_id, e)
-            return False
-        return True
+        return await self._messages.mark_processing(self.rest, room_id, message_id)
 
     async def mark_processed(self, room_id: str, message_id: str) -> bool:
-        """
-        Mark message as successfully processed on the server.
-
-        Clears the message from unprocessed queue.
-        """
-        logger.debug("Marking message %s as processed", message_id)
-        try:
-            await self.rest.agent_api_messages.mark_agent_message_processed(
-                chat_id=room_id,
-                id=message_id,
-                request_options=DEFAULT_REQUEST_OPTIONS,
-            )
-        except Exception as e:
-            logger.warning("Failed to mark message %s as processed: %s", message_id, e)
-            return False
-        return True
+        return await self._messages.mark_processed(self.rest, room_id, message_id)
 
     async def mark_failed(self, room_id: str, message_id: str, error: str) -> bool:
-        """
-        Mark message as failed on the server.
-
-        Records the error and may trigger retry logic on the server side.
-        """
-        error = error.strip() or "Unknown error"
-        logger.warning("Marking message %s as failed: %s", message_id, error)
-        try:
-            await self.rest.agent_api_messages.mark_agent_message_failed(
-                chat_id=room_id,
-                id=message_id,
-                error=error,
-                request_options=DEFAULT_REQUEST_OPTIONS,
-            )
-        except Exception as e:
-            logger.warning("Failed to mark message %s as failed: %s", message_id, e)
-            return False
-        return True
+        return await self._messages.mark_failed(self.rest, room_id, message_id, error)
 
     async def report_activity(
         self, room_id: str, working: bool, *, timeout_seconds: int = 2
     ) -> bool:
-        """
-        Report the agent's boolean working state for a room's execution.
-
-        Sends ``working: true`` while a reasoning cycle is active (refreshed on a
-        keep-alive cadence) and ``working: false`` when it ends. Failures are
-        swallowed and returned as ``False`` — the platform's TTL is the backstop,
-        so activity reporting must never break message processing.
-
-        The call is time-bounded by ``timeout_seconds`` (a per-POST deadline, not
-        the client default) so a slow/half-open endpoint can never wedge the
-        reasoning loop's teardown or stall the keep-alive. Retries are disabled:
-        a dropped keep-alive is re-sent on the next cadence tick, and a dropped
-        ``false`` is cleared by the platform TTL, so retrying only adds latency.
-        """
-        try:
-            await self.rest.agent_api_activity.report_agent_chat_activity(
-                chat_id=room_id,
-                working=working,
-                request_options={
-                    "timeout_in_seconds": timeout_seconds,
-                    "max_retries": 0,
-                },
-            )
-        except Exception as e:
-            if not self._activity_report_failing:
-                self._activity_report_failing = True
-                logger.warning(
-                    "Failed to report activity (working=%s) for room %s: %s; "
-                    "suppressing repeat warnings until recovery",
-                    working,
-                    room_id,
-                    e,
-                )
-            else:
-                logger.debug(
-                    "Activity report still failing (working=%s) for room %s: %s",
-                    working,
-                    room_id,
-                    e,
-                )
-            return False
-        if self._activity_report_failing:
-            self._activity_report_failing = False
-            logger.info("Activity reporting recovered for room %s", room_id)
-        return True
+        return await self._messages.report_activity(
+            self.rest, room_id, working, timeout_seconds=timeout_seconds
+        )
 
     async def get_next_message(self, room_id: str) -> PlatformMessage | None:
-        """
-        Get the next actionable message for a room from the server.
-
-        Returns:
-            ``PlatformMessage`` if there's an actionable message, or ``None``
-            if the platform returned no content (204). ``None`` means *the
-            platform told us there's nothing pending* — not "the call failed."
-
-        Raises:
-            ApiError: REST call failed with a non-204 status.
-            Exception: Transport-level failure (connection error, timeout).
-                Callers that want to swallow transient failures should wrap
-                this call explicitly; the previous behavior of conflating
-                "no pending" with "lookup failed" silently dropped messages
-                at the claim step.
-        """
-        logger.debug("Getting next message for room %s", room_id)
-        try:
-            response = await self.rest.agent_api_messages.get_agent_next_message(
-                chat_id=room_id,
-                request_options=DEFAULT_REQUEST_OPTIONS,
-            )
-        except ApiError as e:
-            # 204 No Content means no actionable messages — the only "None"
-            # case the platform expresses through an ApiError.
-            if e.status_code == 204:
-                logger.debug("No actionable messages for room %s", room_id)
-                return None
-            logger.warning("Failed to get next message: %s", e)
-            raise
-
-        if response is None or response.data is None:
-            return None
-
-        item = response.data
-        return PlatformMessage(
-            id=item.id,
-            room_id=item.chat_room_id or room_id,
-            content=item.content,
-            sender_id=item.sender_id,
-            sender_type=item.sender_type,
-            sender_name=item.sender_name or "",
-            message_type=item.message_type,
-            metadata=item.metadata or {},
-            created_at=item.inserted_at or datetime.now(timezone.utc),
-        )
+        return await self._messages.get_next_message(self.rest, room_id)
 
     async def get_stale_processing_messages(
         self, room_id: str
     ) -> list[PlatformMessage]:
-        """
-        Get messages stuck in 'processing' state for a room.
-
-        On agent restart, messages that were being processed when the agent
-        crashed remain in 'processing' state. The long-running runtime uses
-        this as an explicit recovery sweep at startup.
-
-        Note: ``get_next_message`` (the ``/next`` REST endpoint) already
-        includes stuck-processing messages in its "actionable" result set —
-        see ``Chat.get_next_actionable_message`` on the platform side, which
-        excludes only ``processed``. Callers that drive recovery solely
-        through ``/next`` (e.g. the bridge's rehydration nudge and
-        ``OneShotInvoker``'s claim step) do not need to call this method;
-        it exists for paths that want to drain *every* stuck message up
-        front rather than one-per-room.
-
-        Returns:
-            List of PlatformMessage objects in processing state.
-        """
-        try:
-            messages = []
-            page = 1
-            while True:
-                response = await self.rest.agent_api_messages.list_agent_messages(
-                    chat_id=room_id,
-                    status="processing",
-                    page=page,
-                    request_options=DEFAULT_REQUEST_OPTIONS,
-                )
-                for item in response.data:
-                    messages.append(
-                        PlatformMessage(
-                            id=item.id,
-                            room_id=item.chat_room_id or room_id,
-                            content=item.content,
-                            sender_id=item.sender_id,
-                            sender_type=item.sender_type,
-                            sender_name=item.sender_name or "",
-                            message_type=item.message_type,
-                            metadata=item.metadata or {},
-                            created_at=item.inserted_at or datetime.now(timezone.utc),
-                        )
-                    )
-
-                total_pages = response.metadata.total_pages
-                if total_pages is None or page >= total_pages:
-                    break
-                page += 1
-
-            return messages
-        except Exception as e:
-            logger.warning(
-                "Failed to get stale processing messages for room %s: %s",
-                room_id,
-                e,
-            )
-            return []
+        return await self._messages.get_stale_processing_messages(self.rest, room_id)

--- a/src/band/platform/message_lifecycle.py
+++ b/src/band/platform/message_lifecycle.py
@@ -27,9 +27,8 @@ class MessageLifecycle:
     """
 
     def __init__(self) -> None:
-        # Debounce flag for activity-report failures: keep-alive runs at a few
-        # seconds per room, so a down endpoint would otherwise flood the log on
-        # every refresh. Log the first failure and the recovery, suppress repeats.
+        # Debounces activity-report warnings: keep-alive runs every few
+        # seconds, so a down endpoint would otherwise flood the log.
         self._activity_report_failing = False
 
     async def mark_processing(
@@ -107,16 +106,17 @@ class MessageLifecycle:
         """
         Report the agent's boolean working state for a room's execution.
 
-        Sends ``working: true`` while a reasoning cycle is active (refreshed on a
-        keep-alive cadence) and ``working: false`` when it ends. Failures are
-        swallowed and returned as ``False`` — the platform's TTL is the backstop,
-        so activity reporting must never break message processing.
+        ``working=True`` while a reasoning cycle is active (refreshed on a
+        keep-alive cadence), ``False`` once it ends. Never raises — failures
+        are swallowed and returned as ``False``, since the platform's TTL is
+        the backstop and activity reporting must never break message
+        processing.
 
-        The call is time-bounded by ``timeout_seconds`` (a per-POST deadline, not
-        the client default) so a slow/half-open endpoint can never wedge the
-        reasoning loop's teardown or stall the keep-alive. Retries are disabled:
-        a dropped keep-alive is re-sent on the next cadence tick, and a dropped
-        ``false`` is cleared by the platform TTL, so retrying only adds latency.
+        ``timeout_seconds`` bounds each POST so a slow/half-open endpoint
+        can't stall the keep-alive or wedge teardown. Retries are off: a
+        dropped keep-alive gets re-sent next cadence tick, and a dropped
+        ``false`` is cleared by the platform TTL either way — retrying would
+        only add latency.
         """
         try:
             await rest.agent_api_activity.report_agent_chat_activity(
@@ -156,18 +156,16 @@ class MessageLifecycle:
         """
         Get the next actionable message for a room from the server.
 
-        Returns:
-            ``PlatformMessage`` if there's an actionable message, or ``None``
-            if the platform returned no content (204). ``None`` means *the
-            platform told us there's nothing pending* — not "the call failed."
+        Returns ``None`` only when the platform reports 204 (nothing
+        pending) — never to mean "the call failed."
 
         Raises:
-            ApiError: REST call failed with a non-204 status.
-            Exception: Transport-level failure (connection error, timeout).
-                Callers that want to swallow transient failures should wrap
-                this call explicitly; the previous behavior of conflating
-                "no pending" with "lookup failed" silently dropped messages
-                at the claim step.
+            ApiError: non-204 REST failure.
+            Exception: transport-level failure (connection error, timeout).
+
+        Callers that want to swallow transient failures must wrap this call
+        themselves: conflating "no pending" with "lookup failed" used to
+        silently drop messages at the claim step.
         """
         logger.debug("Getting next message for room %s", room_id)
         try:
@@ -206,21 +204,16 @@ class MessageLifecycle:
         """
         Get messages stuck in 'processing' state for a room.
 
-        On agent restart, messages that were being processed when the agent
-        crashed remain in 'processing' state. The long-running runtime uses
-        this as an explicit recovery sweep at startup.
+        Recovery sweep for agent restart: a crash mid-processing leaves
+        messages in 'processing', and the long-running runtime calls this at
+        startup to drain them.
 
-        Note: ``get_next_message`` (the ``/next`` REST endpoint) already
-        includes stuck-processing messages in its "actionable" result set —
-        see ``Chat.get_next_actionable_message`` on the platform side, which
-        excludes only ``processed``. Callers that drive recovery solely
-        through ``/next`` (e.g. the bridge's rehydration nudge and
-        ``OneShotInvoker``'s claim step) do not need to call this method;
-        it exists for paths that want to drain *every* stuck message up
-        front rather than one-per-room.
-
-        Returns:
-            List of PlatformMessage objects in processing state.
+        Redundant for callers already polling ``/next``: it includes
+        stuck-processing messages in its "actionable" set too (excludes only
+        ``processed`` — see ``Chat.get_next_actionable_message`` on the
+        platform side), so the bridge's rehydration nudge and
+        ``OneShotInvoker``'s claim step don't need this method. It exists for
+        callers that want every stuck message up front, not one per room.
         """
         try:
             messages = []

--- a/src/band/platform/message_lifecycle.py
+++ b/src/band/platform/message_lifecycle.py
@@ -1,0 +1,262 @@
+"""Message-lifecycle REST operations — no WebSocket state involved.
+
+Split out of BandLink: mark_processing/processed/failed, report_activity,
+and the /next + stale-processing REST reads share nothing with WebSocket
+connection or subscription state, only a REST client.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from band.client.rest import AsyncRestClient, DEFAULT_REQUEST_OPTIONS
+from band.runtime.types import PlatformMessage
+from band_rest.core.api_error import ApiError
+
+logger = logging.getLogger(__name__)
+
+
+class MessageLifecycle:
+    """Message mark/report/fetch operations for one agent's REST client.
+
+    ``rest`` is taken per call, not cached at construction: the caller
+    (``BandLink``) owns the REST client and may swap it at any point, so
+    every call here uses whatever ``rest`` the caller currently has rather
+    than a snapshot from construction time.
+    """
+
+    def __init__(self) -> None:
+        # Debounce flag for activity-report failures: keep-alive runs at a few
+        # seconds per room, so a down endpoint would otherwise flood the log on
+        # every refresh. Log the first failure and the recovery, suppress repeats.
+        self._activity_report_failing = False
+
+    async def mark_processing(
+        self, rest: AsyncRestClient, room_id: str, message_id: str
+    ) -> bool:
+        """
+        Mark message as being processed on the server.
+
+        This does NOT remove it from /next: the actionable set excludes only
+        'processed', so a crashed or stopped attempt stays replayable. Only
+        mark_processed clears the message from /next.
+        """
+        logger.debug("Marking message %s as processing", message_id)
+        try:
+            await rest.agent_api_messages.mark_agent_message_processing(
+                chat_id=room_id,
+                id=message_id,
+                request_options=DEFAULT_REQUEST_OPTIONS,
+            )
+        except Exception as e:
+            logger.warning("Failed to mark message %s as processing: %s", message_id, e)
+            return False
+        return True
+
+    async def mark_processed(
+        self, rest: AsyncRestClient, room_id: str, message_id: str
+    ) -> bool:
+        """
+        Mark message as successfully processed on the server.
+
+        Clears the message from unprocessed queue.
+        """
+        logger.debug("Marking message %s as processed", message_id)
+        try:
+            await rest.agent_api_messages.mark_agent_message_processed(
+                chat_id=room_id,
+                id=message_id,
+                request_options=DEFAULT_REQUEST_OPTIONS,
+            )
+        except Exception as e:
+            logger.warning("Failed to mark message %s as processed: %s", message_id, e)
+            return False
+        return True
+
+    async def mark_failed(
+        self, rest: AsyncRestClient, room_id: str, message_id: str, error: str
+    ) -> bool:
+        """
+        Mark message as failed on the server.
+
+        Records the error and may trigger retry logic on the server side.
+        """
+        error = error.strip() or "Unknown error"
+        logger.warning("Marking message %s as failed: %s", message_id, error)
+        try:
+            await rest.agent_api_messages.mark_agent_message_failed(
+                chat_id=room_id,
+                id=message_id,
+                error=error,
+                request_options=DEFAULT_REQUEST_OPTIONS,
+            )
+        except Exception as e:
+            logger.warning("Failed to mark message %s as failed: %s", message_id, e)
+            return False
+        return True
+
+    async def report_activity(
+        self,
+        rest: AsyncRestClient,
+        room_id: str,
+        working: bool,
+        *,
+        timeout_seconds: int = 2,
+    ) -> bool:
+        """
+        Report the agent's boolean working state for a room's execution.
+
+        Sends ``working: true`` while a reasoning cycle is active (refreshed on a
+        keep-alive cadence) and ``working: false`` when it ends. Failures are
+        swallowed and returned as ``False`` — the platform's TTL is the backstop,
+        so activity reporting must never break message processing.
+
+        The call is time-bounded by ``timeout_seconds`` (a per-POST deadline, not
+        the client default) so a slow/half-open endpoint can never wedge the
+        reasoning loop's teardown or stall the keep-alive. Retries are disabled:
+        a dropped keep-alive is re-sent on the next cadence tick, and a dropped
+        ``false`` is cleared by the platform TTL, so retrying only adds latency.
+        """
+        try:
+            await rest.agent_api_activity.report_agent_chat_activity(
+                chat_id=room_id,
+                working=working,
+                request_options={
+                    "timeout_in_seconds": timeout_seconds,
+                    "max_retries": 0,
+                },
+            )
+        except Exception as e:
+            if not self._activity_report_failing:
+                self._activity_report_failing = True
+                logger.warning(
+                    "Failed to report activity (working=%s) for room %s: %s; "
+                    "suppressing repeat warnings until recovery",
+                    working,
+                    room_id,
+                    e,
+                )
+            else:
+                logger.debug(
+                    "Activity report still failing (working=%s) for room %s: %s",
+                    working,
+                    room_id,
+                    e,
+                )
+            return False
+        if self._activity_report_failing:
+            self._activity_report_failing = False
+            logger.info("Activity reporting recovered for room %s", room_id)
+        return True
+
+    async def get_next_message(
+        self, rest: AsyncRestClient, room_id: str
+    ) -> PlatformMessage | None:
+        """
+        Get the next actionable message for a room from the server.
+
+        Returns:
+            ``PlatformMessage`` if there's an actionable message, or ``None``
+            if the platform returned no content (204). ``None`` means *the
+            platform told us there's nothing pending* — not "the call failed."
+
+        Raises:
+            ApiError: REST call failed with a non-204 status.
+            Exception: Transport-level failure (connection error, timeout).
+                Callers that want to swallow transient failures should wrap
+                this call explicitly; the previous behavior of conflating
+                "no pending" with "lookup failed" silently dropped messages
+                at the claim step.
+        """
+        logger.debug("Getting next message for room %s", room_id)
+        try:
+            response = await rest.agent_api_messages.get_agent_next_message(
+                chat_id=room_id,
+                request_options=DEFAULT_REQUEST_OPTIONS,
+            )
+        except ApiError as e:
+            # 204 No Content means no actionable messages — the only "None"
+            # case the platform expresses through an ApiError.
+            if e.status_code == 204:
+                logger.debug("No actionable messages for room %s", room_id)
+                return None
+            logger.warning("Failed to get next message: %s", e)
+            raise
+
+        if response is None or response.data is None:
+            return None
+
+        item = response.data
+        return PlatformMessage(
+            id=item.id,
+            room_id=item.chat_room_id or room_id,
+            content=item.content,
+            sender_id=item.sender_id,
+            sender_type=item.sender_type,
+            sender_name=item.sender_name or "",
+            message_type=item.message_type,
+            metadata=item.metadata or {},
+            created_at=item.inserted_at or datetime.now(timezone.utc),
+        )
+
+    async def get_stale_processing_messages(
+        self, rest: AsyncRestClient, room_id: str
+    ) -> list[PlatformMessage]:
+        """
+        Get messages stuck in 'processing' state for a room.
+
+        On agent restart, messages that were being processed when the agent
+        crashed remain in 'processing' state. The long-running runtime uses
+        this as an explicit recovery sweep at startup.
+
+        Note: ``get_next_message`` (the ``/next`` REST endpoint) already
+        includes stuck-processing messages in its "actionable" result set —
+        see ``Chat.get_next_actionable_message`` on the platform side, which
+        excludes only ``processed``. Callers that drive recovery solely
+        through ``/next`` (e.g. the bridge's rehydration nudge and
+        ``OneShotInvoker``'s claim step) do not need to call this method;
+        it exists for paths that want to drain *every* stuck message up
+        front rather than one-per-room.
+
+        Returns:
+            List of PlatformMessage objects in processing state.
+        """
+        try:
+            messages = []
+            page = 1
+            while True:
+                response = await rest.agent_api_messages.list_agent_messages(
+                    chat_id=room_id,
+                    status="processing",
+                    page=page,
+                    request_options=DEFAULT_REQUEST_OPTIONS,
+                )
+                for item in response.data:
+                    messages.append(
+                        PlatformMessage(
+                            id=item.id,
+                            room_id=item.chat_room_id or room_id,
+                            content=item.content,
+                            sender_id=item.sender_id,
+                            sender_type=item.sender_type,
+                            sender_name=item.sender_name or "",
+                            message_type=item.message_type,
+                            metadata=item.metadata or {},
+                            created_at=item.inserted_at or datetime.now(timezone.utc),
+                        )
+                    )
+
+                total_pages = response.metadata.total_pages
+                if total_pages is None or page >= total_pages:
+                    break
+                page += 1
+
+            return messages
+        except Exception as e:
+            logger.warning(
+                "Failed to get stale processing messages for room %s: %s",
+                room_id,
+                e,
+            )
+            return []

--- a/src/band/runtime/presence.py
+++ b/src/band/runtime/presence.py
@@ -421,6 +421,16 @@ class RoomPresence:
             self.rooms.discard(room_id)
             return False
 
+        if not self.link.is_room_subscribed(room_id):
+            # subscribe_room() is best-effort and non-raising by design (a
+            # single room failure must not crash the whole subscription
+            # sequence), so an internal join/rollback failure never reaches
+            # this except block above — check the real outcome instead of
+            # assuming "no exception" means "subscribed".
+            logger.warning("Room %s did not subscribe during %s", room_id, context)
+            self.rooms.discard(room_id)
+            return False
+
         # A callback that raises is the caller's problem, not a failed join:
         # the room is subscribed either way, and untracking it here would drop
         # every event it goes on to deliver.

--- a/src/band/testing/__init__.py
+++ b/src/band/testing/__init__.py
@@ -14,6 +14,11 @@ from band.exports import lazy_exports
 if TYPE_CHECKING:
     from band.testing.fake_tools import FakeAgentTools as FakeAgentTools
     from band.testing.features import feature_kwargs as feature_kwargs
+    from band.testing.phoenix_server import (
+        FakePhoenixServer as FakePhoenixServer,
+        JoinOutcome as JoinOutcome,
+        fake_phoenix_server as fake_phoenix_server,
+    )
     from band.testing.platform import (
         platform_connection_stub as platform_connection_stub,
     )
@@ -32,6 +37,7 @@ __all__, __getattr__ = lazy_exports(
     __name__,
     fake_tools=["FakeAgentTools"],
     features=["feature_kwargs"],
+    phoenix_server=["FakePhoenixServer", "JoinOutcome", "fake_phoenix_server"],
     platform=["platform_connection_stub"],
     strands=[
         "ErrorTurn",

--- a/src/band/testing/__init__.py
+++ b/src/band/testing/__init__.py
@@ -24,6 +24,9 @@ if TYPE_CHECKING:
         TextTurn as TextTurn,
         ToolTurn as ToolTurn,
     )
+    from band.testing.transport import (
+        force_transport_disconnect as force_transport_disconnect,
+    )
 
 __all__, __getattr__ = lazy_exports(
     __name__,
@@ -37,4 +40,5 @@ __all__, __getattr__ = lazy_exports(
         "TextTurn",
         "ToolTurn",
     ],
+    transport=["force_transport_disconnect"],
 )

--- a/src/band/testing/phoenix_server.py
+++ b/src/band/testing/phoenix_server.py
@@ -1,0 +1,184 @@
+"""In-process fake Phoenix Channels server for exercising BandLink's real
+WebSocket stack end to end.
+
+Speaks the real Phoenix Channels V2 wire protocol -- parsed and built with
+phoenix_channels_python_client's own ``PHXProtocolHandler``/``make_message``,
+never reimplemented -- behind a real loopback ``websockets.serve()`` socket.
+Only the platform side of the wire is faked: ``BandLink`` -> ``WebSocketClient``
+-> ``PHXChannelsClient`` all run unmocked, so real reconnect-supervisor
+behavior, real close-code classification, and real join/leave acks are
+actually exercised instead of assumed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
+from enum import StrEnum
+
+from phoenix_channels_python_client.phx_messages import ChannelMessage, Event, PHXEvent
+from phoenix_channels_python_client.protocol_handler import (
+    PHXProtocolHandler,
+    PhoenixChannelsProtocolVersion,
+)
+from phoenix_channels_python_client.utils import make_message
+from websockets.asyncio.server import ServerConnection, serve
+from websockets.exceptions import ConnectionClosed
+
+logger = logging.getLogger(__name__)
+
+
+class JoinOutcome(StrEnum):
+    """What the fake server replies to one ``phx_join`` attempt with."""
+
+    OK = "ok"
+    REJECTED = "rejected"
+
+
+class FakePhoenixServer:
+    """A real loopback WebSocket server speaking Phoenix Channels V2.
+
+    Construct only via :func:`fake_phoenix_server` -- never directly.
+    """
+
+    def __init__(self, *, join_outcomes: dict[str, Sequence[JoinOutcome]]) -> None:
+        self._join_outcomes = {
+            topic: list(outcomes) for topic, outcomes in join_outcomes.items()
+        }
+        self._protocol = PHXProtocolHandler(
+            protocol_version=PhoenixChannelsProtocolVersion.V2
+        )
+        self.url: str = ""
+        self.joined_topics: set[str] = set()
+        self.received: list[ChannelMessage] = []
+        self.connection_count = 0
+        self._connection: ServerConnection | None = None
+        self._connection_ready = asyncio.Event()
+        # The client drops any message whose join_ref doesn't match the
+        # ref it joined that topic with (protocol_handler.py's stale
+        # join_ref guard), so a push() must echo the real one back.
+        self._join_refs: dict[str, str | None] = {}
+
+    def _next_join_outcome(self, topic: str) -> JoinOutcome:
+        """Consume one outcome off ``topic``'s declared sequence, holding on
+        the last entry once exhausted (unlisted topics always succeed)."""
+        outcomes = self._join_outcomes.get(topic)
+        if not outcomes:
+            return JoinOutcome.OK
+        outcome = outcomes[0]
+        if len(outcomes) > 1:
+            outcomes.pop(0)
+        return outcome
+
+    async def _reply(
+        self,
+        connection: ServerConnection,
+        message: ChannelMessage,
+        *,
+        outcome: JoinOutcome,
+    ) -> None:
+        ok = outcome is JoinOutcome.OK
+        payload = (
+            {"status": "ok", "response": {}}
+            if ok
+            else {"status": "error", "response": {"reason": "rejected by fake server"}}
+        )
+        reply = make_message(
+            topic=message.topic,
+            event=PHXEvent.reply,
+            ref=message.ref,
+            join_ref=message.join_ref,
+            payload=payload,
+        )
+        # PHXProtocolHandler.send_message is typed for ClientConnection, but
+        # only calls .send() -- ServerConnection satisfies that identically.
+        await self._protocol.send_message(connection, reply)  # pyrefly: ignore[bad-argument-type]
+
+    async def _handle_message(
+        self, connection: ServerConnection, message: ChannelMessage
+    ) -> None:
+        self.received.append(message)
+        match message.event:
+            case PHXEvent.join:
+                outcome = self._next_join_outcome(message.topic)
+                if outcome is JoinOutcome.OK:
+                    self.joined_topics.add(message.topic)
+                    self._join_refs[message.topic] = message.join_ref
+                await self._reply(connection, message, outcome=outcome)
+            case PHXEvent.leave:
+                self.joined_topics.discard(message.topic)
+                self._join_refs.pop(message.topic, None)
+                await self._reply(connection, message, outcome=JoinOutcome.OK)
+            case _ if message.topic == "phoenix":
+                await self._reply(connection, message, outcome=JoinOutcome.OK)
+            case _:
+                logger.debug(
+                    "Fake Phoenix server ignoring inbound event %s", message.event
+                )
+
+    async def _handler(self, connection: ServerConnection) -> None:
+        self._connection = connection
+        self.connection_count += 1
+        self._connection_ready.set()
+        try:
+            async for raw in connection:
+                message = self._protocol.parse_message(raw)
+                await self._handle_message(connection, message)
+        except ConnectionClosed:
+            # Expected on abort_connection()/close_connection() and on a
+            # genuine client-side drop -- not a fake-server failure.
+            logger.debug("Connection closed")
+
+    async def push(self, topic: str, event: str, payload: dict) -> None:
+        """Inject an inbound event on an already-joined topic, as if the
+        platform sent it unprompted."""
+        await self._connection_ready.wait()
+        assert self._connection is not None
+        message = make_message(
+            topic=topic,
+            event=Event(event),
+            payload=payload,
+            join_ref=self._join_refs.get(topic),
+        )
+        await self._protocol.send_message(self._connection, message)  # pyrefly: ignore[bad-argument-type]
+
+    async def close_connection(self, *, code: int = 1000, reason: str = "") -> None:
+        """Graceful close with a specific close code -- e.g. 1000, which
+        BandLink's reconnect policy treats as intentional and never
+        reconnects from."""
+        await self._connection_ready.wait()
+        assert self._connection is not None
+        await self._connection.close(code=code, reason=reason)
+
+    async def abort_connection(self) -> None:
+        """Sever the connection with no close handshake -- what a real
+        network drop looks like to the client, so its own reconnect logic
+        actually triggers (unlike a graceful close, which the client's
+        policy reads as intentional and never reconnects from)."""
+        await self._connection_ready.wait()
+        assert self._connection is not None
+        self._connection.transport.abort()
+
+
+@asynccontextmanager
+async def fake_phoenix_server(
+    *, join_outcomes: dict[str, Sequence[JoinOutcome]] | None = None
+) -> AsyncIterator[FakePhoenixServer]:
+    """A real loopback Phoenix Channels server for exercising BandLink's real
+    WebSocketClient/PHXChannelsClient stack, no mocks below BandLink.
+
+    ``join_outcomes`` declares the whole join scenario up front, as data: a
+    topic maps to the sequence of outcomes its successive join attempts get.
+    Everything else about the scenario -- when the network drops, what
+    events arrive -- is inherently a sequence of events in time, so it stays
+    as explicit calls on the yielded server (``push``, ``close_connection``,
+    ``abort_connection``).
+    """
+    server = FakePhoenixServer(join_outcomes=join_outcomes or {})
+    async with serve(server._handler, "127.0.0.1", 0) as ws_server:
+        bound_socket = next(iter(ws_server.sockets))
+        port = bound_socket.getsockname()[1]
+        server.url = f"ws://127.0.0.1:{port}"
+        yield server

--- a/src/band/testing/transport.py
+++ b/src/band/testing/transport.py
@@ -1,11 +1,8 @@
 """Test helper for forcing a real WebSocket transport disconnect.
 
-Exists for reconnect-behavior E2E tests: severs the live socket directly so
-the transport's own reconnect logic (and BandLink._on_reconnected) runs for
-real, instead of going through the clean disconnect()/connect() lifecycle a
-test could otherwise only simulate. Production code never needs to force its
-own disconnect this way, so BandLink has no public API for it — this is the
-one place that reaches its transport directly, for that reason.
+Reaches BandLink's transport directly -- the one place in the SDK that
+does -- because production code never needs to force its own disconnect, so
+BandLink has no public API for it.
 """
 
 from __future__ import annotations
@@ -16,19 +13,12 @@ from band.platform.link import BandLink
 async def force_transport_disconnect(link: BandLink) -> None:
     """Abort the live WebSocket connection under ``link``.
 
-    Aborts the raw asyncio transport rather than calling the WebSocket
-    connection's own ``close()``: a graceful close sends close code 1000
-    ("normal closure"), which the transport's reconnect policy correctly
-    treats as an intentional shutdown and never reconnects from
-    (``ReconnectPolicy.reconnect_on_normal_close`` defaults ``False`` and is
-    never overridden here) — so it would silently fail to exercise the
-    reconnect path at all. Aborting severs the connection with no close
-    handshake, which is what a real network drop looks like to the client,
-    so its own auto-reconnect logic actually triggers.
-
-    Raises ``RuntimeError`` if ``link`` has no active transport to abort —
-    a caller-side setup mistake (never connected, or already disconnected),
-    not a condition to swallow.
+    Aborts the raw transport rather than the connection's own ``close()``:
+    a graceful close sends code 1000, which the reconnect policy
+    (``ReconnectPolicy.reconnect_on_normal_close`` defaults ``False``)
+    treats as intentional and never reconnects from. Aborting drops the
+    connection with no close handshake -- a real network failure looks the
+    same to the client, so its own reconnect logic actually fires.
     """
     ws = link._ws
     if ws is None or ws.client is None or ws.client.connection is None:

--- a/src/band/testing/transport.py
+++ b/src/band/testing/transport.py
@@ -1,6 +1,6 @@
 """Test helper for forcing a real WebSocket transport disconnect.
 
-Exists for reconnect-behavior E2E tests: closes the live socket directly so
+Exists for reconnect-behavior E2E tests: severs the live socket directly so
 the transport's own reconnect logic (and BandLink._on_reconnected) runs for
 real, instead of going through the clean disconnect()/connect() lifecycle a
 test could otherwise only simulate. Production code never needs to force its
@@ -14,13 +14,23 @@ from band.platform.link import BandLink
 
 
 async def force_transport_disconnect(link: BandLink) -> None:
-    """Close the live WebSocket connection under ``link``.
+    """Abort the live WebSocket connection under ``link``.
 
-    Raises ``RuntimeError`` if ``link`` has no active transport to close —
+    Aborts the raw asyncio transport rather than calling the WebSocket
+    connection's own ``close()``: a graceful close sends close code 1000
+    ("normal closure"), which the transport's reconnect policy correctly
+    treats as an intentional shutdown and never reconnects from
+    (``ReconnectPolicy.reconnect_on_normal_close`` defaults ``False`` and is
+    never overridden here) — so it would silently fail to exercise the
+    reconnect path at all. Aborting severs the connection with no close
+    handshake, which is what a real network drop looks like to the client,
+    so its own auto-reconnect logic actually triggers.
+
+    Raises ``RuntimeError`` if ``link`` has no active transport to abort —
     a caller-side setup mistake (never connected, or already disconnected),
     not a condition to swallow.
     """
     ws = link._ws
     if ws is None or ws.client is None or ws.client.connection is None:
         raise RuntimeError("BandLink has no active transport connection to close")
-    await ws.client.connection.close()
+    ws.client.connection.transport.abort()

--- a/src/band/testing/transport.py
+++ b/src/band/testing/transport.py
@@ -1,0 +1,26 @@
+"""Test helper for forcing a real WebSocket transport disconnect.
+
+Exists for reconnect-behavior E2E tests: closes the live socket directly so
+the transport's own reconnect logic (and BandLink._on_reconnected) runs for
+real, instead of going through the clean disconnect()/connect() lifecycle a
+test could otherwise only simulate. Production code never needs to force its
+own disconnect this way, so BandLink has no public API for it — this is the
+one place that reaches its transport directly, for that reason.
+"""
+
+from __future__ import annotations
+
+from band.platform.link import BandLink
+
+
+async def force_transport_disconnect(link: BandLink) -> None:
+    """Close the live WebSocket connection under ``link``.
+
+    Raises ``RuntimeError`` if ``link`` has no active transport to close —
+    a caller-side setup mistake (never connected, or already disconnected),
+    not a condition to swallow.
+    """
+    ws = link._ws
+    if ws is None or ws.client is None or ws.client.connection is None:
+        raise RuntimeError("BandLink has no active transport connection to close")
+    await ws.client.connection.close()

--- a/tests/e2e/baseline/smoke/behavior/test_reconnect.py
+++ b/tests/e2e/baseline/smoke/behavior/test_reconnect.py
@@ -10,7 +10,7 @@ matrix (matches test_isolation.py / test_processing_barrier.py precedent).
 
 from __future__ import annotations
 
-import logging
+from unittest.mock import AsyncMock
 
 import pytest
 from band.testing import force_transport_disconnect
@@ -34,7 +34,6 @@ async def test_room_survives_real_transport_reconnect(
     resource_manager: ResourceManager,
     user_ops: UserOps,
     reply_capture: CaptureFactory,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A real socket drop mid-session must not strand the room: the transport's
     own reconnect plus BandLink._on_reconnected must leave it fully usable.
@@ -43,15 +42,27 @@ async def test_room_survives_real_transport_reconnect(
     the test can reach the running agent's own transport via
     ``agent.runtime.link`` — both already-public properties — to force the
     disconnect.
-    """
-    caplog.set_level(logging.INFO, logger="band.platform.link")
 
+    Proof that ``_on_reconnected`` itself ran comes from a spy wrapping
+    ``link._drain_reconciliation``, not from the message round-trip alone:
+    a room's ``ExecutionContext`` also carries an independent
+    ``idle_resync_seconds`` REST re-poll (default 60s) with no relationship
+    to WebSocket reconnect at all, so a reply arriving after the disconnect
+    does not by itself prove the reconnect path executed — it could equally
+    be explained by that unrelated fallback quietly picking up the slack
+    while the socket stayed dead. The spy is a direct, structural signal
+    instead of an inference through log text or a side effect.
+    """
     identity = await cell.provision(label=f"reconnect-{cell.adapter_id}")
     room_id = await resource_manager.provision_room(
         title=f"e2e-reconnect-{cell.adapter_id}", participants=[identity.id]
     )
 
     async with cell.run_as_with_handle(identity) as agent:
+        link = agent.runtime.link
+        drain_spy = AsyncMock(wraps=link._drain_reconciliation)
+        link._drain_reconciliation = drain_spy
+
         before_marker = unique_marker("before")
         async with reply_capture(room_id) as capture:
             mark = capture.messages.snapshot()
@@ -64,7 +75,7 @@ async def test_room_survives_real_transport_reconnect(
             replies = await capture.wait_for_reply(mid, identity.id, since=mark)
             replies.assert_contains_any([before_marker])
 
-        await force_transport_disconnect(agent.runtime.link)
+        await force_transport_disconnect(link)
 
         after_marker = unique_marker("after")
         async with reply_capture(room_id) as capture:
@@ -77,8 +88,9 @@ async def test_room_survives_real_transport_reconnect(
             )
             # No sleep, no separate reconnect wait: reply delivery is only
             # possible once the room's channels are live again, so this
-            # barrier's own bounded wait is the deterministic proof.
+            # barrier's own bounded wait is the deterministic proof the
+            # room itself still works.
             replies = await capture.wait_for_reply(mid, identity.id, since=mark)
             replies.assert_contains_any([after_marker])
 
-    assert "WebSocket reconnected" in caplog.text
+        drain_spy.assert_awaited()

--- a/tests/e2e/baseline/smoke/behavior/test_reconnect.py
+++ b/tests/e2e/baseline/smoke/behavior/test_reconnect.py
@@ -1,0 +1,84 @@
+"""Live reconnect-behavior coverage for BandLink's SubscriptionTracker adoption.
+
+Forces a real WebSocket transport disconnect (not the clean disconnect()/
+connect() lifecycle) so the transport's own reconnect logic and
+BandLink._on_reconnected run for real against the live platform — the part a
+mocked-transport unit test can't prove. Single fixed adapter: this is a
+transport-layer concern, not adapter-specific, so it doesn't need the full
+matrix (matches test_isolation.py / test_processing_barrier.py precedent).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from band.testing import force_transport_disconnect
+
+from tests.e2e.baseline.agents import Adapter, per_adapter
+from tests.e2e.baseline.smoke.samples.sample_agents import (
+    REPLY_PROMPT,
+    liveness_probe,
+    unique_marker,
+)
+from tests.e2e.baseline.toolkit.capture import CaptureFactory
+from tests.e2e.baseline.toolkit.provisioning import AdapterCell, ResourceManager
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+
+@per_adapter(Adapter.ANTHROPIC, prompt=REPLY_PROMPT)
+@pytest.mark.timeout(extra=60)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_room_survives_real_transport_reconnect(
+    cell: AdapterCell,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A real socket drop mid-session must not strand the room: the transport's
+    own reconnect plus BandLink._on_reconnected must leave it fully usable.
+
+    Requests ``cell.run_as_with_handle`` (not the managed ``agent`` fixture) so
+    the test can reach the running agent's own transport via
+    ``agent.runtime.link`` — both already-public properties — to force the
+    disconnect.
+    """
+    caplog.set_level(logging.INFO, logger="band.platform.link")
+
+    identity = await cell.provision(label=f"reconnect-{cell.adapter_id}")
+    room_id = await resource_manager.provision_room(
+        title=f"e2e-reconnect-{cell.adapter_id}", participants=[identity.id]
+    )
+
+    async with cell.run_as_with_handle(identity) as agent:
+        before_marker = unique_marker("before")
+        async with reply_capture(room_id) as capture:
+            mark = capture.messages.snapshot()
+            mid = await user_ops.send_message(
+                room_id,
+                liveness_probe(before_marker),
+                mention_id=identity.id,
+                mention_name=identity.name,
+            )
+            replies = await capture.wait_for_reply(mid, identity.id, since=mark)
+            replies.assert_contains_any([before_marker])
+
+        await force_transport_disconnect(agent.runtime.link)
+
+        after_marker = unique_marker("after")
+        async with reply_capture(room_id) as capture:
+            mark = capture.messages.snapshot()
+            mid = await user_ops.send_message(
+                room_id,
+                liveness_probe(after_marker),
+                mention_id=identity.id,
+                mention_name=identity.name,
+            )
+            # No sleep, no separate reconnect wait: reply delivery is only
+            # possible once the room's channels are live again, so this
+            # barrier's own bounded wait is the deterministic proof.
+            replies = await capture.wait_for_reply(mid, identity.id, since=mark)
+            replies.assert_contains_any([after_marker])
+
+    assert "WebSocket reconnected" in caplog.text

--- a/tests/e2e/baseline/toolkit/provisioning.py
+++ b/tests/e2e/baseline/toolkit/provisioning.py
@@ -407,6 +407,30 @@ class ResourceManager:
 
 
 @asynccontextmanager
+async def running_agent_with_handle(
+    provisioned: ProvisionedAgent,
+    adapter: SimpleAdapter[Any],
+    settings: BaselineSettings,
+) -> AsyncGenerator[Agent, None]:
+    """Like ``running_agent``, but yields the live ``Agent`` itself.
+
+    ``running_agent`` only yields the identity because no caller has needed the
+    object itself — reconnect-behavior tests do, to reach the running agent's
+    transport via ``agent.runtime.link`` (both already-public properties).
+    """
+    endpoints = settings.endpoints
+    agent = Agent.create(
+        adapter=adapter,
+        agent_id=provisioned.id,
+        api_key=provisioned.api_key,
+        ws_url=endpoints.ws_url,
+        rest_url=endpoints.rest_url,
+    )
+    async with agent:
+        yield agent
+
+
+@asynccontextmanager
 async def running_agent(
     provisioned: ProvisionedAgent,
     adapter: SimpleAdapter[Any],
@@ -424,15 +448,7 @@ async def running_agent(
     platform rehydrating the room's history on bootstrap (``/context``), which is
     exactly what a rejoin scenario asserts.
     """
-    endpoints = settings.endpoints
-    agent = Agent.create(
-        adapter=adapter,
-        agent_id=provisioned.id,
-        api_key=provisioned.api_key,
-        ws_url=endpoints.ws_url,
-        rest_url=endpoints.rest_url,
-    )
-    async with agent:
+    async with running_agent_with_handle(provisioned, adapter, settings):
         yield provisioned
 
 
@@ -561,6 +577,28 @@ class AdapterCell:
         with self.resources.track_running(identity.id):
             async with running_agent(identity, adapter, self.settings):
                 yield identity
+
+    @asynccontextmanager
+    async def run_as_with_handle(
+        self,
+        identity: ProvisionedAgent,
+        *,
+        prompt: str | None = None,
+        features: AdapterFeatures | None = None,
+        tools: list[ToolSpec] | None = None,
+    ) -> AsyncGenerator[Agent, None]:
+        """Like :meth:`run_as`, but yields the live ``Agent`` itself.
+
+        For tests that need to reach the running agent's transport (e.g.
+        ``band.testing.transport.force_transport_disconnect`` for reconnect
+        coverage) via ``agent.runtime.link``.
+        """
+        adapter = self.build(prompt=prompt, features=features, tools=tools)
+        with self.resources.track_running(identity.id):
+            async with running_agent_with_handle(
+                identity, adapter, self.settings
+            ) as agent:
+                yield agent
 
     @asynccontextmanager
     async def running(

--- a/tests/platform/conftest.py
+++ b/tests/platform/conftest.py
@@ -1,0 +1,26 @@
+"""Shared test helpers for tests/platform."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+
+def gated_coroutine() -> tuple[
+    Callable[..., Awaitable[None]], asyncio.Event, asyncio.Event
+]:
+    """A mock coroutine that blocks until released, so a caller can cancel
+    it genuinely mid-await instead of before it ever starts.
+
+    Returns ``(side_effect, started, release)`` — set ``side_effect`` as an
+    AsyncMock's ``side_effect``, ``await started.wait()`` to know the call is
+    truly in-flight, then cancel and/or ``release.set()``.
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def side_effect(*args, **kwargs):
+        started.set()
+        await release.wait()
+
+    return side_effect, started, release

--- a/tests/platform/conftest.py
+++ b/tests/platform/conftest.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
 
 
 def gated_coroutine() -> tuple[
@@ -24,3 +29,30 @@ def gated_coroutine() -> tuple[
         await release.wait()
 
     return side_effect, started, release
+
+
+@asynccontextmanager
+async def cancelled_mid_await(
+    gate: AsyncMock, call: Coroutine[Any, Any, None]
+) -> AsyncIterator[None]:
+    """Run ``call`` as a task, cancel it only once it has genuinely entered
+    its await (gated on ``gate``, not before the call ever starts) — the one
+    reusable shape behind every "cancel this call mid-flight" test.
+
+    Hands control back once ``call`` is in-flight, so the caller's block can
+    inject something else while it's still suspended (e.g. a concurrent
+    ``disconnect()``) before cancellation happens. On exit: cancels, asserts
+    ``CancelledError`` propagates uncaught, and clears ``gate``'s side effect
+    so it reverts to ordinary mock behavior for anything after.
+    """
+    side_effect, started, _release = gated_coroutine()
+    gate.side_effect = side_effect
+    task = asyncio.create_task(call)
+    await started.wait()
+    try:
+        yield
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        gate.side_effect = None

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -3,41 +3,64 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+import logging
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
+from band_rest import (
+    AsyncRestClient,
+    NotFoundError,
+    UnauthorizedError,
+    UnprocessableEntityError,
+)
+from band_rest.core.api_error import ApiError
 
-from band.client.streaming import SupersedePayload
-from band.platform.event import WebSocketDisconnectedEvent
+from band.client.streaming import (
+    MessageCreatedPayload,
+    MessageMetadata,
+    ParticipantAddedPayload,
+    ParticipantRemovedPayload,
+    RoomAddedPayload,
+    RoomDeletedPayload,
+    RoomRemovedPayload,
+    SupersedePayload,
+    WebSocketClient,
+)
+from band.platform.event import (
+    MessageEvent,
+    ParticipantAddedEvent,
+    ParticipantRemovedEvent,
+    RoomAddedEvent,
+    RoomDeletedEvent,
+    RoomRemovedEvent,
+    WebSocketDisconnectedEvent,
+)
 from band.platform.link import BandLink
 
+from tests.conftest import make_message_event
 from tests.platform.conftest import cancelled_mid_await
 
 
 @pytest.fixture
 def mock_ws_client():
-    """Mock WebSocketClient for testing BandLink."""
-    ws = AsyncMock()
+    """Autospecced WebSocketClient for testing BandLink.
+
+    ``spec=WebSocketClient`` (via ``create_autospec``) so a rename/removal of
+    a real method surfaces as a test failure here, instead of the mock
+    silently auto-fabricating whatever attribute BandLink happens to call.
+    """
+    ws = create_autospec(WebSocketClient, instance=True)
 
     # Async context manager support
-    ws.__aenter__ = AsyncMock(return_value=ws)
-    ws.__aexit__ = AsyncMock(return_value=None)
+    ws.__aenter__.return_value = ws
+    ws.__aexit__.return_value = None
 
-    # Mock channel operations
-    ws.join_chat_room_channel = AsyncMock()
-    ws.leave_chat_room_channel = AsyncMock()
-    ws.join_agent_control_channel = AsyncMock()
-    ws.leave_agent_control_channel = AsyncMock()
     ws.last_disconnect_reason = None
 
     def record_terminal_disconnect(reason):
         ws.last_disconnect_reason = reason
 
-    ws.record_terminal_disconnect = MagicMock(side_effect=record_terminal_disconnect)
-    ws.join_agent_rooms_channel = AsyncMock()
-    ws.join_room_participants_channel = AsyncMock()
-    ws.leave_room_participants_channel = AsyncMock()
-    ws.run_forever = AsyncMock()
+    ws.record_terminal_disconnect.side_effect = record_terminal_disconnect
 
     return ws
 
@@ -414,6 +437,24 @@ class TestBandLinkSubscriptions:
         # Should not raise
         await link.unsubscribe_room("room-123")
 
+    @patch("band.platform.link.WebSocketClient")
+    async def test_unsubscribe_room_noop_when_connected_but_never_subscribed(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """A connected link with no prior subscribe_room() call must hit the
+        tracker's own ``ticket is None`` no-op — distinct from the
+        not-connected case above, which short-circuits earlier on ``self._ws``
+        and never reaches the tracker at all."""
+        mock_ws_class.return_value = mock_ws_client
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+
+        await link.unsubscribe_room("room-123")
+
+        mock_ws_client.leave_chat_room_channel.assert_not_called()
+        mock_ws_client.leave_room_participants_channel.assert_not_called()
+
 
 class TestBandLinkSubscriptionRaceAndReconciliation:
     """SubscriptionTracker-backed dedup, reconciliation blocking, and
@@ -439,6 +480,72 @@ class TestBandLinkSubscriptionRaceAndReconciliation:
 
         assert mock_ws_client.join_chat_room_channel.call_count == 1
         assert link.is_room_subscribed("room-123") is True
+
+    @patch("band.platform.link.WebSocketClient")
+    async def test_subscribe_room_first_join_failure_is_not_blocking(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """A failure on the *first* join (chat_room) has no rollback to be
+        ambiguous about — record_chat_room_join_failed resolves it cleanly,
+        unlike the second-join-plus-failed-rollback case, so a retry must
+        succeed immediately with no reconnect needed."""
+        mock_ws_class.return_value = mock_ws_client
+        mock_ws_client.join_chat_room_channel.side_effect = Exception(
+            "chat_room join failed"
+        )
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+
+        await link.subscribe_room("room-123")
+        assert link.is_room_subscribed("room-123") is False
+
+        mock_ws_client.join_chat_room_channel.side_effect = None
+        await link.subscribe_room("room-123")
+        assert link.is_room_subscribed("room-123") is True
+
+    @patch("band.platform.link.WebSocketClient")
+    async def test_drain_reconciliation_bails_on_ws_swap_mid_drain(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """A concurrent disconnect()/connect() completing while
+        _drain_reconciliation() is mid-loop must stop it from acting through
+        the now-stale ``ws`` it captured at the start. The staleness check
+        only runs at the top of each loop iteration (never mid-room), so
+        whichever room is first in flight when the swap happens still
+        completes its own pair of leave calls — the guarantee is that the
+        *other* room, and the agent-topic drain that runs after, are never
+        touched. Room iteration order is a plain ``set`` (unordered), so the
+        swap fires unconditionally on the first ``leave_chat_room_channel``
+        call and assertions are made by count, not by which literal room id
+        went first."""
+        mock_ws_class.return_value = mock_ws_client
+        other_ws = create_autospec(WebSocketClient, instance=True)
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+        link._rooms_needing_reconciliation.update({"room-1", "room-2"})
+        link._agent_topics_needing_reconciliation.add("agent_rooms:agent-123")
+
+        def swap_ws_mid_leave(room_id: str) -> None:
+            link._ws = other_ws
+
+        mock_ws_client.leave_chat_room_channel.side_effect = swap_ws_mid_leave
+
+        await link._drain_reconciliation()
+
+        # Only the room in flight when the swap happened got its pair of
+        # leave calls (and its own acknowledge/discard); the other was never
+        # reached once the staleness check caught the swap.
+        assert mock_ws_client.leave_chat_room_channel.call_count == 1
+        assert mock_ws_client.leave_room_participants_channel.call_count == 1
+        assert len(link._rooms_needing_reconciliation) == 1
+
+        # The agent-topic drain runs next and finds a stale `ws` right away —
+        # it never touches the topic at all.
+        mock_ws_client.leave_agent_rooms_channel.assert_not_called()
+        other_ws.leave_agent_rooms_channel.assert_not_called()
+        assert link._agent_topics_needing_reconciliation == {"agent_rooms:agent-123"}
 
     @patch("band.platform.link.WebSocketClient")
     async def test_subscribe_room_blocked_after_failed_rollback_until_reconnect(
@@ -597,7 +704,6 @@ class TestBandLinkEventQueue:
 
     def test_queue_event_adds_to_queue(self):
         """_queue_event() should add event to queue."""
-        from tests.conftest import make_message_event
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
 
@@ -608,7 +714,6 @@ class TestBandLinkEventQueue:
 
     async def test_async_iteration_gets_events(self):
         """async for should yield events from queue."""
-        from tests.conftest import make_message_event
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
 
@@ -621,7 +726,6 @@ class TestBandLinkEventQueue:
 
     def test_queue_drops_when_full(self):
         """Queue should drop events when full (no blocking)."""
-        from tests.conftest import make_message_event
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
 
@@ -641,22 +745,15 @@ class TestBandLinkEventHandlers:
 
     async def test_on_room_added_queues_room_added_event(self):
         """_on_room_added() should queue RoomAddedEvent."""
-        from band.platform.event import RoomAddedEvent
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
 
-        # Create mock payload
-        payload = MagicMock()
-        payload.id = "room-123"
-        payload.model_dump.return_value = {
-            "id": "room-123",
-            "title": "Test Room",
-            "owner": {"id": "u1", "name": "User", "type": "User"},
-            "status": "active",
-            "type": "direct",
-            "created_at": "2024-01-01T00:00:00Z",
-            "participant_role": "member",
-        }
+        payload = RoomAddedPayload(
+            id="room-123",
+            inserted_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+            title="Test Room",
+        )
 
         await link._on_room_added(payload)
 
@@ -668,19 +765,15 @@ class TestBandLinkEventHandlers:
 
     async def test_on_room_removed_queues_room_removed_event(self):
         """_on_room_removed() should queue RoomRemovedEvent."""
-        from band.platform.event import RoomRemovedEvent
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
 
-        payload = MagicMock()
-        payload.id = "room-123"
-        payload.model_dump.return_value = {
-            "id": "room-123",
-            "status": "removed",
-            "type": "direct",
-            "title": "Test Room",
-            "removed_at": "2024-01-01T00:00:00Z",
-        }
+        payload = RoomRemovedPayload(
+            id="room-123",
+            inserted_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+            title="Test Room",
+        )
 
         await link._on_room_removed(payload)
 
@@ -691,22 +784,20 @@ class TestBandLinkEventHandlers:
 
     async def test_on_message_created_queues_message_event(self):
         """_on_message_created() should queue MessageEvent."""
-        from band.platform.event import MessageEvent
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
 
-        payload = MagicMock()
-        payload.id = "msg-123"
-        payload.content = "Hello"
-        payload.sender_id = "user-456"
-        payload.sender_type = "User"
-        payload.chat_room_id = "room-123"
-        payload.message_type = "text"
-        payload.inserted_at = "2024-01-01T00:00:00Z"
-        payload.updated_at = "2024-01-01T00:00:00Z"
-        payload.metadata = MagicMock()
-        payload.metadata.mentions = []
-        payload.metadata.status = "sent"
+        payload = MessageCreatedPayload(
+            id="msg-123",
+            content="Hello",
+            message_type="text",
+            sender_id="user-456",
+            sender_type="User",
+            chat_room_id="room-123",
+            inserted_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+            metadata=MessageMetadata(mentions=[], status="sent"),
+        )
 
         await link._on_message_created("room-123", payload)
 
@@ -718,8 +809,6 @@ class TestBandLinkEventHandlers:
 
     async def test_on_participant_added_queues_participant_added_event(self):
         """_on_participant_added() should queue ParticipantAddedEvent."""
-        from band.client.streaming import ParticipantAddedPayload
-        from band.platform.event import ParticipantAddedEvent
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
 
@@ -735,8 +824,6 @@ class TestBandLinkEventHandlers:
 
     async def test_on_participant_removed_queues_participant_removed_event(self):
         """_on_participant_removed() should queue ParticipantRemovedEvent."""
-        from band.client.streaming import ParticipantRemovedPayload
-        from band.platform.event import ParticipantRemovedEvent
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
 
@@ -753,8 +840,6 @@ class TestBandLinkEventHandlers:
 
     async def test_on_room_deleted_queues_room_deleted_event(self):
         """_on_room_deleted() should queue RoomDeletedEvent."""
-        from band.client.streaming import RoomDeletedPayload
-        from band.platform.event import RoomDeletedEvent
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
 
@@ -890,7 +975,6 @@ class TestGetNextMessage:
     async def test_returns_none_on_204(self) -> None:
         """204 No Content is the platform's "no actionable message" signal —
         the only ``ApiError`` that should resolve to ``None``."""
-        from band_rest.core.api_error import ApiError
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
         link.rest = MagicMock()
@@ -906,7 +990,6 @@ class TestGetNextMessage:
         can distinguish "no pending" from "lookup failed." The old behavior
         swallowed both as ``None``, which silently dropped messages at the
         OneShot claim step."""
-        from band_rest.core.api_error import ApiError
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
         link.rest = MagicMock()
@@ -929,6 +1012,68 @@ class TestGetNextMessage:
         with pytest.raises(ConnectionError):
             await link.get_next_message("room-1")
 
+    @pytest.mark.asyncio
+    async def test_returns_platform_message_on_success(self) -> None:
+        """The happy path: a real response body is projected into a
+        PlatformMessage — no test elsewhere in the suite exercises this
+        construction, only the error/edge branches around it."""
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        item = MagicMock(
+            id="msg-1",
+            chat_room_id="room-1",
+            content="hello",
+            sender_id="user-1",
+            sender_type="User",
+            sender_name="User One",
+            message_type="text",
+            metadata={"mentions": []},
+            inserted_at=None,
+        )
+        link.rest.agent_api_messages.get_agent_next_message = AsyncMock(
+            return_value=MagicMock(data=item)
+        )
+
+        message = await link.get_next_message("room-1")
+
+        assert message is not None
+        assert message.id == "msg-1"
+        assert message.room_id == "room-1"
+        assert message.content == "hello"
+        assert message.sender_name == "User One"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_empty_response_body(self) -> None:
+        """A 2xx with no ``data`` (server bug or an edge-case empty body) is
+        treated the same as "nothing pending" — not a crash."""
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        response = MagicMock(data=None)
+        link.rest.agent_api_messages.get_agent_next_message = AsyncMock(
+            return_value=response
+        )
+
+        assert await link.get_next_message("room-1") is None
+
+
+def make_stale_message(
+    *, id: str, room_id: str, content: str, sender_id: str, sender_name: str
+) -> MagicMock:
+    """A fake REST `processing`-status message item, shaped like the
+    band_rest SDK's response model just enough for
+    ``get_stale_processing_messages`` to project it into a ``PlatformMessage``."""
+    msg = MagicMock()
+    msg.id = id
+    msg.chat_room_id = room_id
+    msg.content = content
+    msg.sender_id = sender_id
+    msg.sender_type = "User"
+    msg.sender_name = sender_name
+    msg.message_type = "text"
+    msg.metadata = {}
+    msg.inserted_at = None
+    return msg
+
 
 class TestGetStaleProcessingMessages:
     """Tests for stale processing recovery pagination."""
@@ -939,27 +1084,20 @@ class TestGetStaleProcessingMessages:
         link = BandLink(agent_id="agent-123", api_key="test-key")
         link.rest = MagicMock()
 
-        msg_1 = MagicMock()
-        msg_1.id = "msg-1"
-        msg_1.chat_room_id = "room-1"
-        msg_1.content = "first"
-        msg_1.sender_id = "user-1"
-        msg_1.sender_type = "User"
-        msg_1.sender_name = "User One"
-        msg_1.message_type = "text"
-        msg_1.metadata = {}
-        msg_1.inserted_at = None
-
-        msg_2 = MagicMock()
-        msg_2.id = "msg-2"
-        msg_2.chat_room_id = "room-1"
-        msg_2.content = "second"
-        msg_2.sender_id = "user-2"
-        msg_2.sender_type = "User"
-        msg_2.sender_name = "User Two"
-        msg_2.message_type = "text"
-        msg_2.metadata = {}
-        msg_2.inserted_at = None
+        msg_1 = make_stale_message(
+            id="msg-1",
+            room_id="room-1",
+            content="first",
+            sender_id="user-1",
+            sender_name="User One",
+        )
+        msg_2 = make_stale_message(
+            id="msg-2",
+            room_id="room-1",
+            content="second",
+            sender_id="user-2",
+            sender_name="User Two",
+        )
 
         response_page_1 = MagicMock()
         response_page_1.data = [msg_1]
@@ -990,16 +1128,13 @@ class TestGetStaleProcessingMessages:
         link = BandLink(agent_id="agent-123", api_key="test-key")
         link.rest = MagicMock()
 
-        msg = MagicMock()
-        msg.id = "msg-1"
-        msg.chat_room_id = "room-1"
-        msg.content = "first"
-        msg.sender_id = "user-1"
-        msg.sender_type = "User"
-        msg.sender_name = "User One"
-        msg.message_type = "text"
-        msg.metadata = {}
-        msg.inserted_at = None
+        msg = make_stale_message(
+            id="msg-1",
+            room_id="room-1",
+            content="first",
+            sender_id="user-1",
+            sender_name="User One",
+        )
 
         response_page_1 = MagicMock()
         response_page_1.data = [msg]
@@ -1013,6 +1148,22 @@ class TestGetStaleProcessingMessages:
 
         assert [message.id for message in messages] == ["msg-1"]
         link.rest.agent_api_messages.list_agent_messages.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_on_failure(self):
+        """This is a best-effort startup recovery sweep: a REST failure
+        (mid-pagination or otherwise) must not crash agent startup — it
+        returns an empty list instead of raising, unlike get_next_message's
+        propagate-on-failure contract above."""
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        link.rest.agent_api_messages.list_agent_messages = AsyncMock(
+            side_effect=Exception("network down")
+        )
+
+        messages = await link.get_stale_processing_messages("room-1")
+
+        assert messages == []
 
 
 class TestReportActivity:
@@ -1060,7 +1211,6 @@ class TestReportActivity:
 
     @pytest.mark.asyncio
     async def test_returns_false_on_not_found(self):
-        from band_rest import NotFoundError
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
         link.rest = MagicMock()
@@ -1074,7 +1224,6 @@ class TestReportActivity:
 
     @pytest.mark.asyncio
     async def test_returns_false_on_unauthorized(self):
-        from band_rest import UnauthorizedError
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
         link.rest = MagicMock()
@@ -1088,7 +1237,6 @@ class TestReportActivity:
 
     @pytest.mark.asyncio
     async def test_returns_false_on_unprocessable_entity(self):
-        from band_rest import UnprocessableEntityError
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
         link.rest = MagicMock()
@@ -1121,7 +1269,6 @@ class TestReportActivity:
         real wire contract: instantiate the real client and assert the method
         exists and is callable.
         """
-        from band_rest import AsyncRestClient
 
         client = AsyncRestClient(api_key="test-key", base_url="https://test.com")
         method = getattr(client.agent_api_activity, "report_agent_chat_activity", None)
@@ -1129,7 +1276,6 @@ class TestReportActivity:
 
     @pytest.mark.asyncio
     async def test_repeated_failures_warn_once_then_recover(self, caplog):
-        import logging
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
         link.rest = MagicMock()

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Awaitable, Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -9,6 +11,26 @@ import pytest
 from band.client.streaming import SupersedePayload
 from band.platform.event import WebSocketDisconnectedEvent
 from band.platform.link import BandLink
+
+
+def gated_coroutine() -> tuple[
+    Callable[..., Awaitable[None]], asyncio.Event, asyncio.Event
+]:
+    """A mock coroutine that blocks until released, so a caller can cancel
+    it genuinely mid-await instead of before it ever starts.
+
+    Returns ``(side_effect, started, release)`` — set ``side_effect`` as an
+    AsyncMock's ``side_effect``, ``await started.wait()`` to know the call is
+    truly in-flight, then cancel and/or ``release.set()``.
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def side_effect(*args, **kwargs):
+        started.set()
+        await release.wait()
+
+    return side_effect, started, release
 
 
 @pytest.fixture
@@ -71,7 +93,7 @@ class TestBandLinkConstruction:
 
         assert link.is_connected is False
         assert link._ws is None
-        assert link._subscribed_rooms == set()
+        assert link.is_room_subscribed("room-123") is False
 
     def test_init_empty_event_queue(self):
         """Should start with empty event queue."""
@@ -144,21 +166,34 @@ class TestBandLinkConnection:
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
         await link.connect()
-        link._subscribed_rooms.add("room-1")
-        link._subscribed_rooms.add("room-2")
+        await link.subscribe_room("room-1")
+        await link.subscribe_room("room-2")
 
         await link.disconnect()
 
-        assert link._subscribed_rooms == set()
+        assert link.is_room_subscribed("room-1") is False
+        assert link.is_room_subscribed("room-2") is False
 
-    async def test_reconnect_keeps_tracked_room_subscriptions(self):
-        """_on_reconnected() should preserve room tracking for PHX re-subscriptions."""
+    @patch("band.platform.link.WebSocketClient")
+    async def test_reconnect_keeps_tracked_room_subscriptions(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """_on_reconnected() should preserve room tracking for PHX
+        re-subscriptions — a normally-subscribed room needs no reconciliation
+        leave, so the drain must leave it untouched."""
+        mock_ws_class.return_value = mock_ws_client
+
         link = BandLink(agent_id="agent-123", api_key="test-key")
-        link._subscribed_rooms.update({"room-1", "room-2"})
+        await link.connect()
+        await link.subscribe_room("room-1")
+        await link.subscribe_room("room-2")
 
         await link._on_reconnected()
 
-        assert link._subscribed_rooms == {"room-1", "room-2"}
+        assert link.is_room_subscribed("room-1") is True
+        assert link.is_room_subscribed("room-2") is True
+        mock_ws_client.leave_chat_room_channel.assert_not_called()
+        mock_ws_client.leave_room_participants_channel.assert_not_called()
 
     async def test_disconnect_when_not_connected_is_noop(self):
         """disconnect() when not connected should be a no-op."""
@@ -222,7 +257,7 @@ class TestBandLinkConnection:
         link = BandLink(agent_id="agent-123", api_key="test-key")
         link._ws = mock_ws_client
         link._is_connected = True
-        link._subscribed_rooms.add("room-1")
+        await link.subscribe_room("room-1")
         payload = SupersedePayload(
             reason="session.already_connected",
             message="This connection has been superseded by a newer session for this agent.",
@@ -238,7 +273,7 @@ class TestBandLinkConnection:
         mock_ws_client.__aexit__.assert_called_once_with(None, None, None)
         assert link.is_connected is False
         assert link._ws is None
-        assert link._subscribed_rooms == set()
+        assert link.is_room_subscribed("room-1") is False
         assert link.last_disconnect_reason is not None
         assert link.last_disconnect_reason.reason == "session.already_connected"
 
@@ -295,14 +330,14 @@ class TestBandLinkSubscriptions:
     async def test_subscribe_room_tracks_subscription(
         self, mock_ws_class, mock_ws_client
     ):
-        """subscribe_room() should track room in _subscribed_rooms."""
+        """subscribe_room() should track the room as subscribed."""
         mock_ws_class.return_value = mock_ws_client
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
         await link.connect()
         await link.subscribe_room("room-123")
 
-        assert "room-123" in link._subscribed_rooms
+        assert link.is_room_subscribed("room-123") is True
 
     @patch("band.platform.link.WebSocketClient")
     async def test_subscribe_room_idempotent(self, mock_ws_class, mock_ws_client):
@@ -345,7 +380,7 @@ class TestBandLinkSubscriptions:
     async def test_unsubscribe_room_removes_from_tracking(
         self, mock_ws_class, mock_ws_client
     ):
-        """unsubscribe_room() should remove room from _subscribed_rooms."""
+        """unsubscribe_room() should remove the room from tracking."""
         mock_ws_class.return_value = mock_ws_client
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
@@ -353,7 +388,7 @@ class TestBandLinkSubscriptions:
         await link.subscribe_room("room-123")
         await link.unsubscribe_room("room-123")
 
-        assert "room-123" not in link._subscribed_rooms
+        assert link.is_room_subscribed("room-123") is False
 
     @patch("band.platform.link.WebSocketClient")
     async def test_unsubscribe_room_handles_leave_errors(
@@ -361,17 +396,17 @@ class TestBandLinkSubscriptions:
     ):
         """unsubscribe_room() should handle errors gracefully."""
         mock_ws_class.return_value = mock_ws_client
-        mock_ws_client.leave_chat_room_channel.side_effect = Exception("Leave failed")
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
         await link.connect()
-        link._subscribed_rooms.add("room-123")
+        await link.subscribe_room("room-123")
+        mock_ws_client.leave_chat_room_channel.side_effect = Exception("Leave failed")
 
         # Should not raise, just log warning
         await link.unsubscribe_room("room-123")
 
-        # Room should still be removed from tracking
-        assert "room-123" not in link._subscribed_rooms
+        # Room should still be removed from tracking despite the leave failure
+        assert link.is_room_subscribed("room-123") is False
 
     async def test_unsubscribe_room_noop_when_not_subscribed(self):
         """unsubscribe_room() should be no-op for unsubscribed room."""
@@ -379,6 +414,161 @@ class TestBandLinkSubscriptions:
 
         # Should not raise
         await link.unsubscribe_room("room-123")
+
+
+class TestBandLinkSubscriptionRaceAndReconciliation:
+    """SubscriptionTracker-backed dedup, reconciliation blocking, and
+    cancellation safety for subscribe_room/unsubscribe_room."""
+
+    @patch("band.platform.link.WebSocketClient")
+    async def test_concurrent_subscribe_room_only_one_join(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """Two concurrent subscribe_room() calls for the same room must not
+        both attempt the wire join: begin_room_subscribe's pre-await claim
+        check makes the loser a synchronous no-op rather than a second
+        `join_chat_room_channel` call."""
+        mock_ws_class.return_value = mock_ws_client
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+
+        await asyncio.gather(
+            link.subscribe_room("room-123"),
+            link.subscribe_room("room-123"),
+        )
+
+        assert mock_ws_client.join_chat_room_channel.call_count == 1
+        assert link.is_room_subscribed("room-123") is True
+
+    @patch("band.platform.link.WebSocketClient")
+    async def test_subscribe_room_blocked_after_failed_rollback_until_reconnect(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """A room whose rollback also failed (both topics ambiguous
+        server-side) must not be resubscribed on the same socket — it stays
+        blocked until the next reconnect drains the reconciliation set."""
+        mock_ws_class.return_value = mock_ws_client
+        mock_ws_client.join_room_participants_channel.side_effect = Exception(
+            "participants join failed"
+        )
+        mock_ws_client.leave_chat_room_channel.side_effect = Exception(
+            "rollback leave also failed"
+        )
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+
+        await link.subscribe_room("room-123")
+        assert link.is_room_subscribed("room-123") is False
+
+        # Blocked: a retry before the next reconnect must not attempt a join.
+        mock_ws_client.join_chat_room_channel.reset_mock()
+        await link.subscribe_room("room-123")
+        mock_ws_client.join_chat_room_channel.assert_not_called()
+
+        # The next reconnect drains the reconciliation set, unblocking it.
+        mock_ws_client.join_room_participants_channel.side_effect = None
+        mock_ws_client.leave_chat_room_channel.side_effect = None
+        await link._on_reconnected()
+
+        await link.subscribe_room("room-123")
+        assert link.is_room_subscribed("room-123") is True
+
+    @patch("band.platform.link.WebSocketClient")
+    async def test_reconnect_issues_best_effort_leave_before_acknowledging(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """_on_reconnected() must force a clean transport leave for every
+        room still needing reconciliation before acknowledging the tracker —
+        closes the gap where PHXChannelsClient's own auto-rejoin can
+        silently re-establish a stale-registered topic ahead of this hook."""
+        mock_ws_class.return_value = mock_ws_client
+        mock_ws_client.join_room_participants_channel.side_effect = Exception("boom")
+        mock_ws_client.leave_chat_room_channel.side_effect = Exception(
+            "rollback also failed"
+        )
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+        await link.subscribe_room("room-123")
+
+        mock_ws_client.leave_chat_room_channel.side_effect = None
+        mock_ws_client.leave_chat_room_channel.reset_mock()
+        mock_ws_client.leave_room_participants_channel.reset_mock()
+
+        await link._on_reconnected()
+
+        mock_ws_client.leave_chat_room_channel.assert_called_once_with("room-123")
+        mock_ws_client.leave_room_participants_channel.assert_called_once_with(
+            "room-123"
+        )
+
+    @patch("band.platform.link.WebSocketClient")
+    async def test_subscribe_room_cancelled_mid_join_blocks_until_reconnect(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """Cancellation mid-await must resolve the ticket (never leak it)
+        and block the room until the next reconnect — proven with a gated
+        coroutine so the cancel lands truly mid-flight, not before entry."""
+        mock_ws_class.return_value = mock_ws_client
+        side_effect, started, release = gated_coroutine()
+        mock_ws_client.join_chat_room_channel.side_effect = side_effect
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+
+        task = asyncio.create_task(link.subscribe_room("room-123"))
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert link.is_room_subscribed("room-123") is False
+
+        mock_ws_client.join_chat_room_channel.side_effect = None
+        mock_ws_client.join_chat_room_channel.reset_mock()
+        await link.subscribe_room("room-123")
+        mock_ws_client.join_chat_room_channel.assert_not_called()
+
+        await link._on_reconnected()
+
+        await link.subscribe_room("room-123")
+        assert link.is_room_subscribed("room-123") is True
+
+    @patch("band.platform.link.WebSocketClient")
+    async def test_unsubscribe_room_cancelled_mid_leave_blocks_until_reconnect(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """Same guarantee on the leave path: a cancelled unsubscribe_room()
+        resolves to LeaveOutcome.Unknown and blocks the room, never leaking
+        the ticket."""
+        mock_ws_class.return_value = mock_ws_client
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+        await link.subscribe_room("room-123")
+
+        side_effect, started, release = gated_coroutine()
+        mock_ws_client.leave_chat_room_channel.side_effect = side_effect
+
+        task = asyncio.create_task(link.unsubscribe_room("room-123"))
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert link.is_room_subscribed("room-123") is False
+
+        mock_ws_client.leave_chat_room_channel.side_effect = None
+        mock_ws_client.join_chat_room_channel.reset_mock()
+        await link.subscribe_room("room-123")
+        mock_ws_client.join_chat_room_channel.assert_not_called()
+
+        await link._on_reconnected()
+
+        await link.subscribe_room("room-123")
+        assert link.is_room_subscribed("room-123") is True
 
 
 class TestBandLinkEventQueue:

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -124,6 +124,24 @@ class TestBandLinkConnection:
         assert mock_ws_class.call_count == 1
 
     @patch("band.platform.link.WebSocketClient")
+    async def test_concurrent_connect_only_creates_one_websocket(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """Two genuinely concurrent connect() calls must not both build a
+        WebSocketClient: the guard has to be the synchronous `self._ws`
+        assignment itself, not `self._is_connected` (only set true after
+        two awaits) — otherwise the second call races past the flag and
+        leaks the first client."""
+        mock_ws_class.return_value = mock_ws_client
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+
+        await asyncio.gather(link.connect(), link.connect())
+
+        assert mock_ws_class.call_count == 1
+        assert link.is_connected is True
+
+    @patch("band.platform.link.WebSocketClient")
     async def test_disconnect_exits_websocket_context(
         self, mock_ws_class, mock_ws_client
     ):
@@ -549,6 +567,42 @@ class TestBandLinkSubscriptionRaceAndReconciliation:
         await link._on_reconnected()
 
         await link.subscribe_room("room-123")
+        assert link.is_room_subscribed("room-123") is True
+
+    @patch("band.platform.link.WebSocketClient")
+    async def test_disconnect_during_cancelled_subscribe_does_not_block_next_session(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """A subscribe_room() cancelled after disconnect() already tore
+        down the session must not leave a reconciliation entry that blocks
+        the room on a later, unrelated connection — the block only belongs
+        to the session that produced the ambiguity, never one that outlives
+        it."""
+        mock_ws_class.return_value = mock_ws_client
+        side_effect, started, release = gated_coroutine()
+        mock_ws_client.join_chat_room_channel.side_effect = side_effect
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+
+        task = asyncio.create_task(link.subscribe_room("room-123"))
+        await started.wait()
+
+        await link.disconnect()
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # A fresh connection is unrelated to the torn-down session's
+        # ambiguity — subscribing must actually attempt the join, not
+        # silently no-op as if still blocked.
+        mock_ws_client.join_chat_room_channel.side_effect = None
+        mock_ws_client.join_chat_room_channel.reset_mock()
+        await link.connect()
+        await link.subscribe_room("room-123")
+
+        mock_ws_client.join_chat_room_channel.assert_called_once()
         assert link.is_room_subscribed("room-123") is True
 
 

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -11,7 +11,7 @@ from band.client.streaming import SupersedePayload
 from band.platform.event import WebSocketDisconnectedEvent
 from band.platform.link import BandLink
 
-from tests.platform.conftest import gated_coroutine
+from tests.platform.conftest import cancelled_mid_await
 
 
 @pytest.fixture
@@ -511,17 +511,14 @@ class TestBandLinkSubscriptionRaceAndReconciliation:
         and block the room until the next reconnect — proven with a gated
         coroutine so the cancel lands truly mid-flight, not before entry."""
         mock_ws_class.return_value = mock_ws_client
-        side_effect, started, release = gated_coroutine()
-        mock_ws_client.join_chat_room_channel.side_effect = side_effect
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
         await link.connect()
 
-        task = asyncio.create_task(link.subscribe_room("room-123"))
-        await started.wait()
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
+        async with cancelled_mid_await(
+            mock_ws_client.join_chat_room_channel, link.subscribe_room("room-123")
+        ):
+            pass
 
         assert link.is_room_subscribed("room-123") is False
 
@@ -548,18 +545,13 @@ class TestBandLinkSubscriptionRaceAndReconciliation:
         await link.connect()
         await link.subscribe_room("room-123")
 
-        side_effect, started, release = gated_coroutine()
-        mock_ws_client.leave_chat_room_channel.side_effect = side_effect
-
-        task = asyncio.create_task(link.unsubscribe_room("room-123"))
-        await started.wait()
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
+        async with cancelled_mid_await(
+            mock_ws_client.leave_chat_room_channel, link.unsubscribe_room("room-123")
+        ):
+            pass
 
         assert link.is_room_subscribed("room-123") is False
 
-        mock_ws_client.leave_chat_room_channel.side_effect = None
         mock_ws_client.join_chat_room_channel.reset_mock()
         await link.subscribe_room("room-123")
         mock_ws_client.join_chat_room_channel.assert_not_called()
@@ -579,20 +571,14 @@ class TestBandLinkSubscriptionRaceAndReconciliation:
         to the session that produced the ambiguity, never one that outlives
         it."""
         mock_ws_class.return_value = mock_ws_client
-        side_effect, started, release = gated_coroutine()
-        mock_ws_client.join_chat_room_channel.side_effect = side_effect
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
         await link.connect()
 
-        task = asyncio.create_task(link.subscribe_room("room-123"))
-        await started.wait()
-
-        await link.disconnect()
-
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
+        async with cancelled_mid_await(
+            mock_ws_client.join_chat_room_channel, link.subscribe_room("room-123")
+        ):
+            await link.disconnect()
 
         # A fresh connection is unrelated to the torn-down session's
         # ambiguity — subscribing must actually attempt the join, not

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -1137,7 +1137,7 @@ class TestReportActivity:
             side_effect=Exception("down")
         )
 
-        with caplog.at_level(logging.WARNING, logger="band.platform.link"):
+        with caplog.at_level(logging.WARNING, logger="band.platform.message_lifecycle"):
             assert await link.report_activity("room-1", True) is False
             assert await link.report_activity("room-1", True) is False
 
@@ -1146,7 +1146,7 @@ class TestReportActivity:
 
         # Recovery logs once at INFO and re-arms the warning.
         link.rest.agent_api_activity.report_agent_chat_activity = AsyncMock()
-        with caplog.at_level(logging.INFO, logger="band.platform.link"):
+        with caplog.at_level(logging.INFO, logger="band.platform.message_lifecycle"):
             caplog.clear()
             assert await link.report_activity("room-1", True) is True
         assert any("recovered" in r.message.lower() for r in caplog.records)

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -12,25 +11,7 @@ from band.client.streaming import SupersedePayload
 from band.platform.event import WebSocketDisconnectedEvent
 from band.platform.link import BandLink
 
-
-def gated_coroutine() -> tuple[
-    Callable[..., Awaitable[None]], asyncio.Event, asyncio.Event
-]:
-    """A mock coroutine that blocks until released, so a caller can cancel
-    it genuinely mid-await instead of before it ever starts.
-
-    Returns ``(side_effect, started, release)`` — set ``side_effect`` as an
-    AsyncMock's ``side_effect``, ``await started.wait()`` to know the call is
-    truly in-flight, then cancel and/or ``release.set()``.
-    """
-    started = asyncio.Event()
-    release = asyncio.Event()
-
-    async def side_effect(*args, **kwargs):
-        started.set()
-        await release.wait()
-
-    return side_effect, started, release
+from tests.platform.conftest import gated_coroutine
 
 
 @pytest.fixture

--- a/tests/platform/test_link_contacts.py
+++ b/tests/platform/test_link_contacts.py
@@ -1,5 +1,7 @@
 """Unit tests for BandLink contact subscription."""
 
+import asyncio
+
 import pytest
 from unittest.mock import AsyncMock, patch
 
@@ -17,6 +19,8 @@ from band.client.streaming import (
     ContactRemovedPayload,
     WireEvent,
 )
+
+from tests.platform.conftest import gated_coroutine
 
 
 @pytest.fixture
@@ -83,14 +87,31 @@ class TestContactSubscription:
     async def test_unsubscribe_agent_contacts_leaves_channel(
         self, mock_ws_class, mock_ws_client
     ):
-        """unsubscribe_agent_contacts() should leave agent contacts channel."""
+        """unsubscribe_agent_contacts() should leave an actually-joined
+        agent contacts channel."""
+        mock_ws_class.return_value = mock_ws_client
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+        await link.subscribe_agent_contacts("agent-123")
+        await link.unsubscribe_agent_contacts()
+
+        mock_ws_client.leave_agent_contacts_channel.assert_called_once_with("agent-123")
+
+    @patch("band.platform.link.WebSocketClient")
+    async def test_unsubscribe_agent_contacts_noop_when_never_subscribed(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """unsubscribe_agent_contacts() is a true no-op when the topic was
+        never joined — the tracker's leave_agent_topic() returns None rather
+        than issuing a leave the transport would just reject."""
         mock_ws_class.return_value = mock_ws_client
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
         await link.connect()
         await link.unsubscribe_agent_contacts()
 
-        mock_ws_client.leave_agent_contacts_channel.assert_called_once_with("agent-123")
+        mock_ws_client.leave_agent_contacts_channel.assert_not_called()
 
     @patch("band.platform.link.WebSocketClient")
     async def test_unsubscribe_agent_contacts_handles_errors(
@@ -98,21 +119,83 @@ class TestContactSubscription:
     ):
         """unsubscribe_agent_contacts() should handle errors gracefully."""
         mock_ws_class.return_value = mock_ws_client
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+        await link.subscribe_agent_contacts("agent-123")
         mock_ws_client.leave_agent_contacts_channel.side_effect = Exception(
             "Leave failed"
         )
 
-        link = BandLink(agent_id="agent-123", api_key="test-key")
-        await link.connect()
-
         # Should not raise
         await link.unsubscribe_agent_contacts()
+
+        mock_ws_client.leave_agent_contacts_channel.assert_called_once_with("agent-123")
 
     async def test_unsubscribe_agent_contacts_noop_when_not_connected(self):
         """unsubscribe_agent_contacts() should be no-op when not connected."""
         link = BandLink(agent_id="agent-123", api_key="test-key")
         # Should not raise
         await link.unsubscribe_agent_contacts()
+
+
+class TestContactTopicRaceAndReconciliation:
+    """SubscriptionTracker-backed dedup, reconciliation blocking, and
+    cancellation safety for the agent-level topics — mirrors
+    TestBandLinkSubscriptionRaceAndReconciliation in test_link.py for the
+    room path, scoped to agent_contacts (agent_rooms shares the same
+    _subscribe_agent_topic/_leave_agent_topic helpers)."""
+
+    @patch("band.platform.link.WebSocketClient")
+    async def test_concurrent_subscribe_agent_contacts_only_one_join(
+        self, mock_ws_class, mock_ws_client
+    ):
+        mock_ws_class.return_value = mock_ws_client
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+
+        await asyncio.gather(
+            link.subscribe_agent_contacts("agent-123"),
+            link.subscribe_agent_contacts("agent-123"),
+        )
+
+        assert mock_ws_client.join_agent_contacts_channel.call_count == 1
+
+    @patch("band.platform.link.WebSocketClient")
+    async def test_cancelled_join_blocks_agent_contacts_until_reconnect(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """record_agent_topic_join(joined=False) never reaches core's own
+        NeedsReconciliation (unlike a room's second-phase rollback failure)
+        — the local reconciliation set is what actually blocks the retry
+        here, proven with a gated coroutine so the cancel lands truly
+        mid-flight."""
+        mock_ws_class.return_value = mock_ws_client
+        side_effect, started, _release = gated_coroutine()
+        mock_ws_client.join_agent_contacts_channel.side_effect = side_effect
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+
+        task = asyncio.create_task(link.subscribe_agent_contacts("agent-123"))
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Blocked: a retry before the next reconnect must not attempt a join.
+        mock_ws_client.join_agent_contacts_channel.side_effect = None
+        mock_ws_client.join_agent_contacts_channel.reset_mock()
+        await link.subscribe_agent_contacts("agent-123")
+        mock_ws_client.join_agent_contacts_channel.assert_not_called()
+
+        # The reconnect boundary force-leaves before acknowledging, unblocking it.
+        await link._on_reconnected()
+        mock_ws_client.leave_agent_contacts_channel.assert_called_once_with("agent-123")
+
+        await link.subscribe_agent_contacts("agent-123")
+        mock_ws_client.join_agent_contacts_channel.assert_called_once()
 
 
 class TestContactEventHandlers:

--- a/tests/platform/test_link_contacts.py
+++ b/tests/platform/test_link_contacts.py
@@ -20,7 +20,7 @@ from band.client.streaming import (
     WireEvent,
 )
 
-from tests.platform.conftest import gated_coroutine
+from tests.platform.conftest import cancelled_mid_await
 
 
 @pytest.fixture
@@ -172,20 +172,17 @@ class TestContactTopicRaceAndReconciliation:
         here, proven with a gated coroutine so the cancel lands truly
         mid-flight."""
         mock_ws_class.return_value = mock_ws_client
-        side_effect, started, _release = gated_coroutine()
-        mock_ws_client.join_agent_contacts_channel.side_effect = side_effect
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
         await link.connect()
 
-        task = asyncio.create_task(link.subscribe_agent_contacts("agent-123"))
-        await started.wait()
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
+        async with cancelled_mid_await(
+            mock_ws_client.join_agent_contacts_channel,
+            link.subscribe_agent_contacts("agent-123"),
+        ):
+            pass
 
         # Blocked: a retry before the next reconnect must not attempt a join.
-        mock_ws_client.join_agent_contacts_channel.side_effect = None
         mock_ws_client.join_agent_contacts_channel.reset_mock()
         await link.subscribe_agent_contacts("agent-123")
         mock_ws_client.join_agent_contacts_channel.assert_not_called()

--- a/tests/platform/test_link_contacts.py
+++ b/tests/platform/test_link_contacts.py
@@ -163,6 +163,33 @@ class TestContactTopicRaceAndReconciliation:
         assert mock_ws_client.join_agent_contacts_channel.call_count == 1
 
     @patch("band.platform.link.WebSocketClient")
+    async def test_ordinary_join_failure_is_not_blocking(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """An ordinary (non-cancelled) join failure resolves cleanly via
+        record_agent_topic_join(joined=False) — settled=True before the
+        finally block, so unlike cancellation it never reaches the local
+        reconciliation set. A retry must succeed immediately, no reconnect
+        needed."""
+        mock_ws_class.return_value = mock_ws_client
+        mock_ws_client.join_agent_contacts_channel.side_effect = Exception(
+            "join failed"
+        )
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        await link.connect()
+
+        await link.subscribe_agent_contacts("agent-123")
+
+        mock_ws_client.join_agent_contacts_channel.side_effect = None
+        mock_ws_client.join_agent_contacts_channel.reset_mock()
+        await link.subscribe_agent_contacts("agent-123")
+
+        # A genuinely fresh join attempt, not the retry silently no-opping
+        # as if still blocked.
+        mock_ws_client.join_agent_contacts_channel.assert_called_once()
+
+    @patch("band.platform.link.WebSocketClient")
     async def test_cancelled_join_blocks_agent_contacts_until_reconnect(
         self, mock_ws_class, mock_ws_client
     ):

--- a/tests/platform/test_link_real_wire.py
+++ b/tests/platform/test_link_real_wire.py
@@ -1,0 +1,46 @@
+"""BandLink behavior proven against a real (fake-server-backed) wire, not
+mocks -- covers what mocked tests in test_link.py structurally can't: real
+Phoenix protocol round trips through WebSocketClient/PHXChannelsClient.
+
+See tests/testing/test_phoenix_server.py for tests of the fake server's own
+protocol mechanics (default join outcome, leave acks, push delivery, close
+vs. abort semantics); this file is scoped to BandLink-specific behavior the
+fake exists to prove.
+"""
+
+from __future__ import annotations
+
+from band.platform.link import BandLink
+from band.testing import JoinOutcome, fake_phoenix_server
+
+
+def make_link(server_url: str) -> BandLink:
+    return BandLink(
+        agent_id="agent-123",
+        api_key="test-key",
+        ws_url=server_url,
+        rest_url="https://test.invalid",
+    )
+
+
+async def test_room_participants_rejection_rolls_back_chat_room_over_the_real_wire() -> (
+    None
+):
+    """The two-phase room join's rollback (subscribe_room's second-join
+    failure path) sends a real phx_leave for chat_room and gets it acked by
+    a real server -- a mocked leave_chat_room_channel call can only prove
+    BandLink *attempted* the rollback, never that the wire round trip is
+    actually correct."""
+    async with fake_phoenix_server(
+        join_outcomes={"room_participants:room-1": [JoinOutcome.REJECTED]}
+    ) as server:
+        link = make_link(server.url)
+        await link.connect()
+
+        await link.subscribe_room("room-1")
+
+        assert link.is_room_subscribed("room-1") is False
+        # The rollback's leave actually reached the server and was acked --
+        # not just that BandLink called a mocked leave method.
+        assert "chat_room:room-1" not in server.joined_topics
+        assert "room_participants:room-1" not in server.joined_topics

--- a/tests/runtime/test_presence.py
+++ b/tests/runtime/test_presence.py
@@ -31,6 +31,7 @@ def mock_link():
     link.subscribe_agent_rooms = AsyncMock()
     link.subscribe_room = AsyncMock()
     link.unsubscribe_room = AsyncMock()
+    link.is_room_subscribed = MagicMock(return_value=True)
 
     # REST client mock
     link.rest = MagicMock()
@@ -272,6 +273,45 @@ class TestJoiningOnce:
         await presence.start()
 
         assert presence.rooms == {"room-1"}
+
+    async def test_a_room_that_never_actually_subscribed_is_untracked(
+        self, mock_link, presences
+    ):
+        """subscribe_room() is best-effort and non-raising by design, so a
+        real join/rollback failure never raises up to _join_room's except
+        block. is_room_subscribed() must be checked instead of assuming
+        "no exception" means "subscribed" — otherwise the room stays
+        (wrongly) in self.rooms forever, treated as surviving on every
+        future reconnect."""
+        mock_link.rest.agent_api_chats.list_agent_chats = listing([chat_row("room-1")])
+        mock_link.is_room_subscribed = MagicMock(return_value=False)
+        joined = []
+        presence = presences(auto_subscribe_existing=True)
+        presence.on_room_joined = AsyncMock(side_effect=lambda *a: joined.append(a))
+
+        await presence.start()
+
+        assert presence.rooms == set()
+        assert joined == []
+
+    async def test_a_room_that_never_subscribed_is_rejoined_on_reconnect(
+        self, mock_link, presences
+    ):
+        """A room _join_room discarded (never actually subscribed) must be
+        treated as newly-discovered on the next reconnect, not skipped as
+        "surviving"."""
+        mock_link.rest.agent_api_chats.list_agent_chats = listing([chat_row("room-1")])
+        mock_link.is_room_subscribed = MagicMock(return_value=False)
+        presence = presences(auto_subscribe_existing=True)
+        await presence.start()
+        assert presence.rooms == set()
+
+        mock_link.is_room_subscribed = MagicMock(return_value=True)
+        mock_link.rest.agent_api_chats.list_agent_chats = listing([chat_row("room-1")])
+        await presence._handle_reconnect()
+
+        assert presence.rooms == {"room-1"}
+        assert mock_link.subscribe_room.call_count == 2  # startup attempt + reconnect
 
 
 class TestRoomPresenceRoomRemoved:

--- a/tests/testing/test_phoenix_server.py
+++ b/tests/testing/test_phoenix_server.py
@@ -1,0 +1,127 @@
+"""Tests for the fake_phoenix_server testing utility itself.
+
+Drives it through a real BandLink -- the actual consumer -- rather than
+hand-crafting wire frames, so these tests double as proof the fake speaks a
+protocol BandLink's real WebSocketClient/PHXChannelsClient stack accepts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from band.platform.event import RoomAddedEvent
+from band.platform.link import BandLink
+from band.testing import JoinOutcome, fake_phoenix_server
+
+
+def make_link(server_url: str) -> BandLink:
+    return BandLink(
+        agent_id="agent-123",
+        api_key="test-key",
+        ws_url=server_url,
+        rest_url="https://test.invalid",
+    )
+
+
+async def wait_until(predicate, *, timeout: float = 5.0) -> None:
+    async def poll() -> None:
+        while not predicate():
+            await asyncio.sleep(0.02)
+
+    await asyncio.wait_for(poll(), timeout=timeout)
+
+
+async def test_default_join_outcome_is_ok() -> None:
+    """No declared policy -- every join succeeds, observed on both sides."""
+    async with fake_phoenix_server() as server:
+        link = make_link(server.url)
+        await link.connect()
+
+        await link.subscribe_room("room-1")
+
+        assert link.is_room_subscribed("room-1") is True
+        assert server.joined_topics >= {"chat_room:room-1", "room_participants:room-1"}
+
+
+async def test_declared_join_outcome_rejects() -> None:
+    """A REJECTED policy drives BandLink's real rollback path against a
+    genuine phx_reply error, not a mocked exception."""
+    async with fake_phoenix_server(
+        join_outcomes={"chat_room:room-1": [JoinOutcome.REJECTED]}
+    ) as server:
+        link = make_link(server.url)
+        await link.connect()
+
+        await link.subscribe_room("room-1")
+
+        assert link.is_room_subscribed("room-1") is False
+        assert "chat_room:room-1" not in server.joined_topics
+
+
+async def test_leave_is_acked() -> None:
+    async with fake_phoenix_server() as server:
+        link = make_link(server.url)
+        await link.connect()
+        await link.subscribe_room("room-1")
+
+        await link.unsubscribe_room("room-1")
+
+        assert link.is_room_subscribed("room-1") is False
+        assert "chat_room:room-1" not in server.joined_topics
+        assert "room_participants:room-1" not in server.joined_topics
+
+
+async def test_push_delivers_inbound_event() -> None:
+    """An unprompted server push reaches BandLink's real event queue over
+    the real wire, not via a mocked handler call."""
+    async with fake_phoenix_server() as server:
+        link = make_link(server.url)
+        await link.connect()
+        await link.subscribe_agent_rooms("agent-123")
+
+        await server.push(
+            "agent_rooms:agent-123",
+            "room_added",
+            {
+                "id": "room-9",
+                "inserted_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+            },
+        )
+
+        event = await asyncio.wait_for(link.__anext__(), timeout=5.0)
+        assert isinstance(event, RoomAddedEvent)
+        assert event.room_id == "room-9"
+
+
+async def test_graceful_close_with_normal_code_does_not_reconnect() -> None:
+    """Close code 1000 is what BandLink's reconnect policy treats as
+    intentional -- the client must never open a second connection."""
+    async with fake_phoenix_server() as server:
+        link = make_link(server.url)
+        await link.connect()
+        assert server.connection_count == 1
+
+        await server.close_connection(code=1000)
+        await asyncio.sleep(0.3)
+
+        assert server.connection_count == 1
+
+
+async def test_abort_triggers_real_reconnect_and_drain() -> None:
+    """A transport-level abort (no close handshake) is what a genuine
+    network drop looks like -- the client's own reconnect logic must fire
+    for real, and BandLink's reconciliation drain must run as part of it."""
+    async with fake_phoenix_server() as server:
+        link = make_link(server.url)
+        await link.connect()
+        await link.subscribe_room("room-1")
+        drain_spy = AsyncMock(wraps=link._drain_reconciliation)
+        link._drain_reconciliation = drain_spy
+
+        await server.abort_connection()
+        await wait_until(lambda: server.connection_count == 2)
+        await wait_until(lambda: drain_spy.await_count > 0)
+
+        assert link.is_room_subscribed("room-1") is True

--- a/tests/testing/test_transport.py
+++ b/tests/testing/test_transport.py
@@ -1,0 +1,57 @@
+"""Tests for the force_transport_disconnect testing utility."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from band.platform.link import BandLink
+from band.testing import force_transport_disconnect
+
+
+def make_link() -> BandLink:
+    return BandLink(agent_id="agent-123", api_key="test-key")
+
+
+async def test_closes_the_live_transport_connection() -> None:
+    """The happy path: closes the real connection under a connected link."""
+    link = make_link()
+    connection = AsyncMock()
+    ws = MagicMock()
+    ws.client = MagicMock(connection=connection)
+    link._ws = ws
+
+    await force_transport_disconnect(link)
+
+    connection.close.assert_awaited_once()
+
+
+async def test_raises_when_never_connected() -> None:
+    """No ``_ws`` at all — a caller-side setup mistake, not a no-op."""
+    link = make_link()
+
+    with pytest.raises(RuntimeError, match="no active transport connection"):
+        await force_transport_disconnect(link)
+
+
+async def test_raises_when_client_not_yet_established() -> None:
+    """``_ws`` exists but its inner PHXChannelsClient hasn't been created yet."""
+    link = make_link()
+    ws = MagicMock()
+    ws.client = None
+    link._ws = ws
+
+    with pytest.raises(RuntimeError, match="no active transport connection"):
+        await force_transport_disconnect(link)
+
+
+async def test_raises_when_connection_not_yet_open() -> None:
+    """``client`` exists but hasn't opened its socket yet."""
+    link = make_link()
+    ws = MagicMock()
+    ws.client = MagicMock(connection=None)
+    link._ws = ws
+
+    with pytest.raises(RuntimeError, match="no active transport connection"):
+        await force_transport_disconnect(link)

--- a/tests/testing/test_transport.py
+++ b/tests/testing/test_transport.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -14,17 +14,23 @@ def make_link() -> BandLink:
     return BandLink(agent_id="agent-123", api_key="test-key")
 
 
-async def test_closes_the_live_transport_connection() -> None:
-    """The happy path: closes the real connection under a connected link."""
+async def test_aborts_the_live_transport() -> None:
+    """The happy path: aborts the raw transport under a connected link.
+
+    Not ``connection.close()`` — a graceful close (code 1000) is exactly
+    what the reconnect policy treats as intentional and never reconnects
+    from, so the test-only tool has to bypass it and abort the underlying
+    asyncio transport instead, matching a real network drop.
+    """
     link = make_link()
-    connection = AsyncMock()
+    connection = MagicMock()
     ws = MagicMock()
     ws.client = MagicMock(connection=connection)
     link._ws = ws
 
     await force_transport_disconnect(link)
 
-    connection.close.assert_awaited_once()
+    connection.transport.abort.assert_called_once()
 
 
 async def test_raises_when_never_connected() -> None:


### PR DESCRIPTION
## Summary
- Replace `BandLink`'s hand-rolled `_subscribed_rooms` set with `band_sdk_core.SubscriptionTracker` (already pinned, no core bump needed): ticket-based claims close a TOCTOU race on concurrent `subscribe_room()` calls, and a reconnect-boundary reconciliation set blocks resubscribing a room/agent-topic left ambiguous by cancellation or a failed rollback, until the transport is forced back to a known-clean state.
- Also extends dedup to the three agent-level topics (`agent_rooms`, `agent_contacts`), which previously had zero tracking at all.
- Fixes a pre-existing `RoomPresence` bug (independent of the tracker): a room that failed to subscribe stayed marked as joined in `self.rooms` forever, since `subscribe_room()` is non-raising by design. The new `is_room_subscribed()` query makes the real outcome checkable instead of assuming "no exception" means "subscribed."

## Follow-up (not in this PR)
`band-sdk-typescript`'s `BandLink.ts` has the identical unpatched bug (same bare `Set<string>`, same zero-dedup gap on agent topics) and no TS-side ticket exists yet. This design isn't Python-specific — the wasm bindings expose the same `SubscriptionTracker` API with 1:1 method parity — so a companion TS ticket mirroring this one is recommended.

## Test plan
- [x] `uv run pytest tests/platform/test_link.py tests/platform/test_link_contacts.py tests/runtime/test_presence.py -v` — all green, including new coverage for concurrent-subscribe races, reconciliation-boundary blocking, gated mid-await cancellation, and the reconnect-boundary best-effort leave
- [x] `uv run --all-packages pytest --ignore=tests/integration/ --ignore=tests/e2e/` — 5123 passed, 122 skipped, 0 failed
- [x] `uv run ruff check .` / `uv run ruff format .` — clean
- [x] `uv run pyrefly check` — 0 errors

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LccTh6HdVnp4JdQQPN6Vhq