### PR TITLE
fix(docker): copy band-mcp manifest into kit build context

### DIFF
--- a/docker/band_python_kit/Dockerfile
+++ b/docker/band_python_kit/Dockerfile
@@ -30,6 +30,13 @@ COPY --from=uv /uv /uvx /usr/local/bin/
 WORKDIR /build
 COPY pyproject.toml uv.lock README.md ./
 COPY src ./src
+# The lockfile's [tool.uv.workspace] includes packages/* (today, only
+# band-mcp); `uv sync --locked` validates every member's pyproject.toml
+# against the lock even though this image only installs the root band-sdk
+# project, so --locked fails as stale without it. Verified: only the
+# manifest is read for that check, not the member's src/ or README — a
+# second workspace member under packages/ needs its own line here too.
+COPY packages/band-mcp/pyproject.toml ./packages/band-mcp/pyproject.toml
 
 # Prefer HTTPS for GitHub URLs to avoid SSH key requirements in container builds.
 RUN git config --global --add url."https://github.com/".insteadOf "git@github.com:" \


### PR DESCRIPTION
## Summary
- `docker/band_python_kit/Dockerfile`'s builder stage only `COPY`ed `src/` into the build context, never any workspace member under `packages/`. Since `band-mcp` joined `[tool.uv.workspace]` (#552), any real build of this Dockerfile has failed `uv sync --locked` (treats the lock as stale because a workspace member's `pyproject.toml` is missing from the container filesystem) — never caught because `DOCKER_TESTS_ENABLED` defaults off everywhere, including CI.
- Fix: `COPY packages/band-mcp/pyproject.toml ./packages/band-mcp/pyproject.toml`. Verified only the manifest is read for the `--locked` consistency check (not `src/` or `README.md`), so this copies the one file that's actually load-bearing rather than the whole `packages/` tree.

Found while live-testing INT-982's `band-kit provision` (needed a fresh local kit image); unrelated to that PR so it's split out here.

## Test plan
- [x] `docker build -f docker/band_python_kit/Dockerfile -t band-python-kit:local .` — now succeeds (`Resolved 366 packages`, matches the committed lock exactly; previously failed at "Resolved 365 packages... lockfile needs to be updated")
- [x] `uv run pytest tests/docker/` (excluding the three live-gated modules) — 176 passed, 2 skipped, unaffected
- [x] Full live proof downstream: the resulting image booted a real sandbox against dev Band, launcher synced/exec'd the customer entrypoint, and a room message round-tripped end to end (see INT-982's PR #586)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L95pyAWjRJoEEPNwbjxA23