### PR TITLE
feat: integrate band-sdk-core RoomRoster into RoomPresence

### DIFF
--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -117,6 +117,9 @@ class BandLink:
         # WebSocket client (from BandAgent._ws_client)
         self._ws: WebSocketClient | None = None
         self._is_connected = False
+        # True for the span of connect() before _ws is assigned, so a second
+        # concurrent connect() sees it even mid-handshake (see connect()).
+        self._connecting = False
 
         # Subscription tracking (band_sdk_core.SubscriptionTracker) plus local
         # bookkeeping for claims whose real-world outcome is ambiguous (a
@@ -179,36 +182,45 @@ class BandLink:
 
         Extracted from BandAgent.start() lines 158-164.
         """
-        if self._ws is not None:
+        if self._connecting or self._ws is not None:
             logger.warning("Already connected or connecting")
             return
 
-        self._last_disconnect_reason = None
-        ws = WebSocketClient(
-            self.ws_url,
-            self.api_key,
-            self.agent_id,
-            on_reconnect=self._on_reconnected,
-            on_disconnect=self._on_disconnected,
-        )
-        self._ws = ws
+        # Set synchronously, before the first await below, so a second
+        # concurrent connect() sees it immediately -- _ws alone can't do
+        # that job, since it's only assigned once fully connected below
+        # (never a half-connected client a caller could act on).
+        self._connecting = True
         try:
-            await ws.__aenter__()
-            await ws.join_agent_control_channel(
+            self._last_disconnect_reason = None
+            ws = WebSocketClient(
+                self.ws_url,
+                self.api_key,
                 self.agent_id,
-                on_supersede=self._on_supersede,
-                on_control=self._on_control,
+                on_reconnect=self._on_reconnected,
+                on_disconnect=self._on_disconnected,
             )
-        except BaseException:
-            # BaseException, not Exception: a cancellation reaching this
-            # await (e.g. the caller's own task being cancelled) must roll
-            # _ws back too, or every later connect() sees it as non-None and
-            # silently no-ops forever with _is_connected still False.
-            await ws.__aexit__(None, None, None)
-            self._ws = None
-            raise
-        self._is_connected = True
-        logger.info("Connected to platform")
+            try:
+                await ws.__aenter__()
+                await ws.join_agent_control_channel(
+                    self.agent_id,
+                    on_supersede=self._on_supersede,
+                    on_control=self._on_control,
+                )
+            except BaseException:
+                # BaseException, not Exception: a cancellation reaching one
+                # of these awaits (e.g. the caller's own task being
+                # cancelled) must still close the half-opened client, or it
+                # leaks -- _ws itself was never assigned, so there's nothing
+                # to roll back on that side.
+                await ws.__aexit__(None, None, None)
+                raise
+
+            self._ws = ws
+            self._is_connected = True
+            logger.info("Connected to platform")
+        finally:
+            self._connecting = False
 
     async def disconnect(self) -> None:
         """

--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -184,22 +184,27 @@ class BandLink:
             return
 
         self._last_disconnect_reason = None
-        self._ws = WebSocketClient(
+        ws = WebSocketClient(
             self.ws_url,
             self.api_key,
             self.agent_id,
             on_reconnect=self._on_reconnected,
             on_disconnect=self._on_disconnected,
         )
-        await self._ws.__aenter__()
+        self._ws = ws
         try:
-            await self._ws.join_agent_control_channel(
+            await ws.__aenter__()
+            await ws.join_agent_control_channel(
                 self.agent_id,
                 on_supersede=self._on_supersede,
                 on_control=self._on_control,
             )
-        except Exception:
-            await self._ws.__aexit__(None, None, None)
+        except BaseException:
+            # BaseException, not Exception: a cancellation reaching this
+            # await (e.g. the caller's own task being cancelled) must roll
+            # _ws back too, or every later connect() sees it as non-None and
+            # silently no-ops forever with _is_connected still False.
+            await ws.__aexit__(None, None, None)
             self._ws = None
             raise
         self._is_connected = True

--- a/src/band/runtime/presence.py
+++ b/src/band/runtime/presence.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Awaitable, Callable, Set
+from typing import Any, Awaitable, Callable
+
+from band_sdk_core import RoomMembership, RoomRoster
 
 from band.client.rest import DEFAULT_REQUEST_OPTIONS
 from band.platform.event import (
@@ -87,7 +89,7 @@ class RoomPresence:
         self.auto_subscribe_existing = auto_subscribe_existing
 
         # Track rooms we're present in
-        self.rooms: Set[str] = set()
+        self.roster = RoomRoster()
 
         # Callbacks (set by user or AgentRuntime)
         self.on_room_joined: Callable[[str, dict], Awaitable[None]] | None = None
@@ -102,6 +104,23 @@ class RoomPresence:
         # Internal task for consuming events from link
         self._event_task: asyncio.Task | None = None
 
+    async def _notify(
+        self,
+        callback: Callable[..., Awaitable[None]] | None,
+        *args: Any,
+        label: str,
+        level: int = logging.WARNING,
+        exc_info: bool = False,
+    ) -> None:
+        """Invoke an optional user callback; a raise there is the caller's
+        problem, never ours to propagate."""
+        if callback is None:
+            return
+        try:
+            await callback(*args)
+        except Exception as e:
+            logger.log(level, "%s callback error: %s", label, e, exc_info=exc_info)
+
     async def start(self) -> None:
         """
         Start presence management.
@@ -111,6 +130,12 @@ class RoomPresence:
         3. Subscribe to existing rooms (if configured)
         4. Spawn task to consume events from link
         """
+        if self._event_task is not None and not self._event_task.done():
+            raise RuntimeError(
+                f"RoomPresence for agent {self.link.agent_id} is already running; "
+                "call stop() before starting again"
+            )
+
         # Connect if needed
         if not self.link.is_connected:
             await self.link.connect()
@@ -153,15 +178,16 @@ class RoomPresence:
                 pass
             self._event_task = None
 
-        # Notify left for all rooms
-        for room_id in list(self.rooms):
-            if self.on_room_left:
-                try:
-                    await self.on_room_left(room_id)
-                except Exception as e:
-                    logger.warning("on_room_left error for %s: %s", room_id, e)
-
-        self.rooms.clear()
+        admitted_room_ids = self.roster.tracked_room_ids()
+        self.roster.clear()
+        for room_id in admitted_room_ids:
+            try:
+                await self.link.unsubscribe_room(room_id)
+            except Exception as e:
+                logger.warning(
+                    "Failed to unsubscribe room %s during stop: %s", room_id, e
+                )
+            await self._notify(self.on_room_left, room_id, label="on_room_left")
         logger.info("RoomPresence stopped")
 
     async def _on_platform_event(self, event: PlatformEvent) -> None:
@@ -235,19 +261,21 @@ class RoomPresence:
             logger.warning("%s event without room_id", event.type)
             return
 
-        # Unsubscribe from room channels
+        # Unconditional, harmless no-op if never subscribed.
         await self.link.unsubscribe_room(room_id)
+        if not self.roster.record_room_removed(room_id):
+            logger.debug(
+                "%s event for untracked room %s, ignoring", event.type, room_id
+            )
+            return
 
-        # Untrack room
-        self.rooms.discard(room_id)
-
-        # Notify callback
-        if self.on_room_left:
-            try:
-                await self.on_room_left(room_id)
-            except Exception as e:
-                logger.error("on_room_left error for %s: %s", room_id, e, exc_info=True)
-
+        await self._notify(
+            self.on_room_left,
+            room_id,
+            label="on_room_left",
+            level=logging.ERROR,
+            exc_info=True,
+        )
         logger.info("Agent left room via %s: %s", event.type, room_id)
 
     async def _handle_reconnect(self) -> None:
@@ -264,8 +292,6 @@ class RoomPresence:
         transient API failure.
         """
         logger.info("Handling reconnection — syncing rooms from API")
-        old_rooms = self.rooms.copy()
-
         try:
             try:
                 rooms_from_api = await self._list_existing_rooms()
@@ -273,59 +299,67 @@ class RoomPresence:
                 logger.warning("Failed to sync rooms after reconnect: %s", e)
                 return
 
-            current_room_ids = set(rooms_from_api)
-            self.rooms = old_rooms & current_room_ids
-
-            gone_rooms = old_rooms - current_room_ids
-            for room_id in gone_rooms:
-                try:
-                    await self.link.unsubscribe_room(room_id)
-                except Exception as e:
-                    logger.warning(
-                        "Failed to unsubscribe room %s during reconnect: %s",
-                        room_id,
-                        e,
-                    )
-                self.rooms.discard(room_id)
-                if self.on_room_left:
-                    try:
-                        await self.on_room_left(room_id)
-                    except Exception as e:
-                        logger.warning(
-                            "on_room_left error for %s during reconnect: %s",
-                            room_id,
-                            e,
-                        )
-
-            surviving_room_ids = sorted(self.rooms)
-
-            if self.auto_subscribe_existing:
-                # Surviving rooms are already in self.rooms, so this joins
-                # exactly the ones that appeared while the socket was down.
-                await self._subscribe_rooms(rooms_from_api, context="reconnect")
-
-            if self.on_room_event:
-                reconnect_event = ReconnectedEvent()
-                for room_id in surviving_room_ids:
-                    try:
-                        await self.on_room_event(room_id, reconnect_event)
-                    except Exception as e:
-                        logger.warning(
-                            "on_room_event error for %s during reconnect: %s",
-                            room_id,
-                            e,
-                        )
-
+            reconciliation = self.roster.reconcile(
+                self._reconcile_target_room_ids(rooms_from_api)
+            )
+            await self._leave_removed_rooms(reconciliation.removed)
+            await self._admit_reconciled_rooms(reconciliation.admitting, rooms_from_api)
+            await self._notify_resync(reconciliation.resync)
         finally:
             # Notify callers so they can resync /next for messages missed during downtime
-            if self.on_reconnected:
-                try:
-                    await self.on_reconnected()
-                except asyncio.CancelledError:
-                    # Preserve structured concurrency: never swallow cancellation.
-                    raise
-                except Exception as e:
-                    logger.warning("on_reconnected callback error: %s", e)
+            await self._notify(self.on_reconnected, label="on_reconnected")
+
+    def _reconcile_target_room_ids(
+        self, rooms_from_api: dict[str, dict[str, Any]]
+    ) -> list[str]:
+        """The snapshot to diff against: every current room when auto-subscribing
+        new ones, otherwise only rooms already admitted — so a room we were never
+        asked to join can't enter reconcile()'s atomic admission-claim at all."""
+        if self.auto_subscribe_existing:
+            return list(rooms_from_api.keys())
+        tracked = set(self.roster.tracked_room_ids())
+        return [room_id for room_id in rooms_from_api if room_id in tracked]
+
+    async def _leave_removed_rooms(self, room_ids: list[str]) -> None:
+        """Unsubscribe and notify for every room reconcile() found gone.
+        These were Admitted by construction (reconcile partitions
+        admitted_rooms), so no was_admitted gating is needed here."""
+        for room_id in room_ids:
+            try:
+                await self.link.unsubscribe_room(room_id)
+            except Exception as e:
+                logger.warning(
+                    "Failed to unsubscribe room %s during reconnect: %s", room_id, e
+                )
+            await self._notify(self.on_room_left, room_id, label="on_room_left")
+
+    async def _admit_reconciled_rooms(
+        self,
+        admitting: list[tuple[str, int]],
+        rooms_from_api: dict[str, dict[str, Any]],
+    ) -> None:
+        """Resolve every ticket reconcile() pre-claimed for a newly discovered
+        room, in parallel — mirrors _subscribe_rooms's old fan-out."""
+        if not admitting:
+            return
+        await asyncio.gather(
+            *[
+                self._complete_room_admission(
+                    room_id, ticket, rooms_from_api[room_id], context="reconnect"
+                )
+                for room_id, ticket in admitting
+            ]
+        )
+
+    async def _notify_resync(self, room_ids: list[str]) -> None:
+        """Tell surviving rooms to resync. reconcile() already sorts these."""
+        if not self.on_room_event:
+            return
+        reconnect_event = ReconnectedEvent()
+        for room_id in room_ids:
+            await self._notify(
+                self.on_room_event, room_id, reconnect_event, label="on_room_event"
+            )
 
     async def _handle_room_event(self, event: PlatformEvent) -> None:
         """
@@ -338,7 +372,7 @@ class RoomPresence:
             return
 
         # Only forward events for rooms we're tracking
-        if room_id not in self.rooms:
+        if self.roster.room_membership(room_id) is not RoomMembership.Admitted:
             logger.debug("Event for untracked room %s, ignoring", room_id)
             return
 
@@ -399,48 +433,70 @@ class RoomPresence:
         *,
         context: str,
     ) -> bool:
-        """Track, subscribe to and announce one room, at most once.
+        """Claim admission for one room, at most once, and resolve it.
 
         The startup snapshot and a ``room_added`` event can name the same room,
         because the agent's room channel is live before the snapshot is read.
-        Claiming the room in ``self.rooms`` before the first await is what makes
-        the second caller a no-op instead of a second channel join and a second
-        ``on_room_joined``.
+        Claiming the room via ``begin_room_admission`` before the first await is
+        what makes the second caller a no-op instead of a second channel join
+        and a second ``on_room_joined``.
         """
-        if room_id in self.rooms:
+        ticket = self.roster.begin_room_admission(room_id, passes_filter=True)
+        if ticket is None:
             logger.debug("Already joined room %s, ignoring %s", room_id, context)
             return False
-        self.rooms.add(room_id)
+        return await self._complete_room_admission(
+            room_id, ticket, payload, context=context
+        )
 
+    async def _complete_room_admission(
+        self,
+        room_id: str,
+        ticket: int,
+        payload: dict[str, Any],
+        *,
+        context: str,
+    ) -> bool:
+        """Subscribe to a claimed room and resolve its ticket, whatever happens.
+
+        ``record_room_admission`` is a safe no-op on an already-resolved/stale
+        ticket, so a bare ``finally`` is enough to roll a cancelled or failed
+        subscribe back to ``Unadmitted`` — no extra "settled" bookkeeping needed.
+        """
+        succeeded = False
         try:
-            await self.link.subscribe_room(room_id)
-        except Exception as e:
-            logger.warning(
-                "Failed to subscribe to room %s during %s: %s", room_id, context, e
-            )
-            self.rooms.discard(room_id)
-            return False
+            try:
+                await self.link.subscribe_room(room_id)
+            except Exception as e:
+                logger.warning(
+                    "Failed to subscribe to room %s during %s: %s", room_id, context, e
+                )
+                return False
 
-        if not self.link.is_room_subscribed(room_id):
-            # subscribe_room() is best-effort and non-raising by design (a
-            # single room failure must not crash the whole subscription
-            # sequence), so an internal join/rollback failure never reaches
-            # this except block above — check the real outcome instead of
-            # assuming "no exception" means "subscribed".
-            logger.warning("Room %s did not subscribe during %s", room_id, context)
-            self.rooms.discard(room_id)
-            return False
+            if not self.link.is_room_subscribed(room_id):
+                # subscribe_room() is best-effort and non-raising by design (a
+                # single room failure must not crash the whole subscription
+                # sequence), so an internal join/rollback failure never reaches
+                # this except block above — check the real outcome instead of
+                # assuming "no exception" means "subscribed".
+                logger.warning("Room %s did not subscribe during %s", room_id, context)
+                return False
+
+            succeeded = True
+        finally:
+            self.roster.record_room_admission(room_id, ticket, succeeded)
 
         # A callback that raises is the caller's problem, not a failed join:
         # the room is subscribed either way, and untracking it here would drop
         # every event it goes on to deliver.
-        if self.on_room_joined:
-            try:
-                await self.on_room_joined(room_id, payload)
-            except Exception as e:
-                logger.error(
-                    "on_room_joined error for %s: %s", room_id, e, exc_info=True
-                )
+        await self._notify(
+            self.on_room_joined,
+            room_id,
+            payload,
+            label="on_room_joined",
+            level=logging.ERROR,
+            exc_info=True,
+        )
 
         logger.info("Agent joined room: %s", room_id)
         return True
@@ -451,19 +507,14 @@ class RoomPresence:
         *,
         context: str,
     ) -> None:
-        """Join every room not already joined, in parallel."""
-        pending = {
-            room_id: payload
-            for room_id, payload in rooms_to_join.items()
-            if room_id not in self.rooms
-        }
-        if not pending:
+        """Join every room in parallel."""
+        if not rooms_to_join:
             return
 
         results = await asyncio.gather(
             *[
                 self._join_room(room_id, payload, context=context)
-                for room_id, payload in pending.items()
+                for room_id, payload in rooms_to_join.items()
             ],
         )
         succeeded = sum(results)

--- a/src/band/runtime/presence.py
+++ b/src/band/runtime/presence.py
@@ -106,6 +106,11 @@ class RoomPresence:
         # True for the span of start() before _event_task exists to guard
         # against a second concurrent call (see start()).
         self._starting = False
+        # Serializes start()'s and stop()'s bodies against each other: a
+        # stop() racing an in-flight start() must wait for it to finish
+        # (and thus actually create _event_task) rather than finding
+        # nothing to tear down and returning while start() is still running.
+        self._lifecycle_lock = asyncio.Lock()
 
     async def _notify(
         self,
@@ -147,19 +152,20 @@ class RoomPresence:
         # since it isn't assigned until the very end of this method.
         self._starting = True
         try:
-            # Connect if needed
-            if not self.link.is_connected:
-                await self.link.connect()
+            async with self._lifecycle_lock:
+                # Connect if needed
+                if not self.link.is_connected:
+                    await self.link.connect()
 
-            # Subscribe to room added/removed events
-            await self.link.subscribe_agent_rooms(self.link.agent_id)
+                # Subscribe to room added/removed events
+                await self.link.subscribe_agent_rooms(self.link.agent_id)
 
-            # Subscribe to existing rooms
-            if self.auto_subscribe_existing:
-                await self._subscribe_to_existing_rooms()
+                # Subscribe to existing rooms
+                if self.auto_subscribe_existing:
+                    await self._subscribe_to_existing_rooms()
 
-            # Spawn task to consume events from link's async iterator
-            self._event_task = asyncio.create_task(self._consume_events())
+                # Spawn task to consume events from link's async iterator
+                self._event_task = asyncio.create_task(self._consume_events())
         finally:
             self._starting = False
 
@@ -181,19 +187,24 @@ class RoomPresence:
 
         Cancels event consumer, unsubscribes from all rooms and clears state.
         Does NOT disconnect the link (caller may want to reuse it).
-        """
-        # Cancel event consumer task
-        if self._event_task and not self._event_task.done():
-            self._event_task.cancel()
-            try:
-                await self._event_task
-            except asyncio.CancelledError:
-                pass
-            self._event_task = None
 
-        admitted_room_ids = self.roster.tracked_room_ids()
-        self.roster.clear()
-        await self._leave_and_notify(admitted_room_ids, context="stop")
+        Waits for an in-flight start() to finish (see _lifecycle_lock) rather
+        than finding nothing to tear down yet -- otherwise start() could go
+        on to create _event_task after this method already returned.
+        """
+        async with self._lifecycle_lock:
+            # Cancel event consumer task
+            if self._event_task and not self._event_task.done():
+                self._event_task.cancel()
+                try:
+                    await self._event_task
+                except asyncio.CancelledError:
+                    pass
+                self._event_task = None
+
+            admitted_room_ids = self.roster.tracked_room_ids()
+            self.roster.clear()
+            await self._leave_and_notify(admitted_room_ids, context="stop")
         logger.info("RoomPresence stopped")
 
     async def _on_platform_event(self, event: PlatformEvent) -> None:

--- a/src/band/runtime/presence.py
+++ b/src/band/runtime/presence.py
@@ -180,14 +180,7 @@ class RoomPresence:
 
         admitted_room_ids = self.roster.tracked_room_ids()
         self.roster.clear()
-        for room_id in admitted_room_ids:
-            try:
-                await self.link.unsubscribe_room(room_id)
-            except Exception as e:
-                logger.warning(
-                    "Failed to unsubscribe room %s during stop: %s", room_id, e
-                )
-            await self._notify(self.on_room_left, room_id, label="on_room_left")
+        await self._leave_and_notify(admitted_room_ids, context="stop")
         logger.info("RoomPresence stopped")
 
     async def _on_platform_event(self, event: PlatformEvent) -> None:
@@ -324,14 +317,28 @@ class RoomPresence:
         """Unsubscribe and notify for every room reconcile() found gone.
         These were Admitted by construction (reconcile partitions
         admitted_rooms), so no was_admitted gating is needed here."""
-        for room_id in room_ids:
-            try:
-                await self.link.unsubscribe_room(room_id)
-            except Exception as e:
-                logger.warning(
-                    "Failed to unsubscribe room %s during reconnect: %s", room_id, e
-                )
-            await self._notify(self.on_room_left, room_id, label="on_room_left")
+        await self._leave_and_notify(room_ids, context="reconnect")
+
+    async def _leave_and_notify(self, room_ids: list[str], *, context: str) -> None:
+        """Unsubscribe and fire on_room_left for each room, in parallel —
+        mirrors the admit side's fan-out (unsubscribe_room is keyed entirely
+        by room_id, so concurrent calls for different rooms touch no shared
+        state). Shared by stop() and _leave_removed_rooms, which differ only
+        in why the rooms are going away."""
+        if not room_ids:
+            return
+        await asyncio.gather(
+            *[self._leave_one_room(room_id, context=context) for room_id in room_ids]
+        )
+
+    async def _leave_one_room(self, room_id: str, *, context: str) -> None:
+        try:
+            await self.link.unsubscribe_room(room_id)
+        except Exception as e:
+            logger.warning(
+                "Failed to unsubscribe room %s during %s: %s", room_id, context, e
+            )
+        await self._notify(self.on_room_left, room_id, label="on_room_left")
 
     async def _admit_reconciled_rooms(
         self,
@@ -342,7 +349,7 @@ class RoomPresence:
         room, in parallel — mirrors _subscribe_rooms's old fan-out."""
         if not admitting:
             return
-        await asyncio.gather(
+        results = await asyncio.gather(
             *[
                 self._complete_room_admission(
                     room_id, ticket, rooms_from_api[room_id], context="reconnect"
@@ -350,6 +357,7 @@ class RoomPresence:
                 for room_id, ticket in admitting
             ]
         )
+        self._log_admission_results(results, context="reconnect")
 
     async def _notify_resync(self, room_ids: list[str]) -> None:
         """Tell surviving rooms to resync. reconcile() already sorts these."""
@@ -517,6 +525,12 @@ class RoomPresence:
                 for room_id, payload in rooms_to_join.items()
             ],
         )
+        self._log_admission_results(results, context=context)
+
+    def _log_admission_results(self, results: list[bool], *, context: str) -> None:
+        """Aggregate succeeded/failed summary for one batch of parallel
+        room admissions — shared by _subscribe_rooms and
+        _admit_reconciled_rooms."""
         succeeded = sum(results)
         failed = len(results) - succeeded
 

--- a/src/band/runtime/presence.py
+++ b/src/band/runtime/presence.py
@@ -202,6 +202,11 @@ class RoomPresence:
                     pass
                 self._event_task = None
 
+            # `clear()`'s own return value is not a substitute here: it
+            # includes every tracked room regardless of membership (an
+            # in-flight Admitting one too), while a leave/on_room_left is
+            # only correct for rooms that reached Admitted -- one never
+            # announced as joined must not be announced as left either.
             admitted_room_ids = self.roster.tracked_room_ids()
             self.roster.clear()
             await self._leave_and_notify(admitted_room_ids, context="stop")
@@ -491,19 +496,33 @@ class RoomPresence:
         """Subscribe to a claimed room and resolve its ticket, whatever happens.
 
         ``record_room_admission`` is a safe no-op on an already-resolved/stale
-        ticket, so a bare ``finally`` is enough to roll a cancelled or failed
-        subscribe back to ``Unadmitted`` — no extra "settled" bookkeeping needed.
-        Its return value still matters on the success path though: a ticket
-        can go stale mid-flight (e.g. ``stop()``'s ``roster.clear()`` racing
-        this call before ``self._event_task`` exists to be cancelled), and a
+        ticket, so a bare ``finally`` is enough to roll a failed subscribe
+        back to ``Unadmitted`` -- no extra "settled" bookkeeping needed. Its
+        return value still matters on the success path though: a ticket can
+        go stale mid-flight (e.g. ``stop()``'s ``roster.clear()`` racing this
+        call before ``self._event_task`` exists to be cancelled), and a
         stale-but-succeeded subscribe must not announce a room the roster no
         longer considers ours -- nor leave the real transport subscription
         behind for a room the roster has already forgotten about.
+
+        A genuine cancellation *while awaiting* ``subscribe_room`` itself is
+        the one case the ``finally`` alone can't cover: the join may have
+        already reached the server before the cancellation lands, and once
+        this coroutine unwinds there is no later return value to check --
+        only ``BandLink``'s own next-reconnect reconciliation would ever
+        notice, and the roster (already rolled back to ``Unadmitted`` by the
+        ``finally``) has nothing to hand ``stop()``/``reconcile()`` to target
+        it for cleanup meanwhile. That specific await gets its own best-effort
+        unsubscribe before re-raising, below.
         """
         succeeded = False
         try:
             try:
-                await self.link.subscribe_room(room_id)
+                try:
+                    await self.link.subscribe_room(room_id)
+                except asyncio.CancelledError:
+                    await self._unsubscribe_room(room_id, context=context)
+                    raise
             except Exception as e:
                 logger.warning(
                     "Failed to subscribe to room %s during %s: %s", room_id, context, e
@@ -553,14 +572,27 @@ class RoomPresence:
         *,
         context: str,
     ) -> None:
-        """Join every room in parallel."""
-        if not rooms_to_join:
+        """Join every room in parallel.
+
+        Excludes rooms a concurrent ``room_added`` event already admitted
+        before this ran (the startup-snapshot-vs-live-event race
+        ``_join_room``'s docstring describes) -- ``_join_room`` would still
+        safely no-op on one of those via its own ticket claim, but counting
+        that no-op as an admission attempt in ``_log_admission_results``
+        misreports an already-successful join as a failure.
+        """
+        new_rooms = {
+            room_id: payload
+            for room_id, payload in rooms_to_join.items()
+            if self.roster.room_membership(room_id) is not RoomMembership.Admitted
+        }
+        if not new_rooms:
             return
 
         results = await asyncio.gather(
             *[
                 self._join_room(room_id, payload, context=context)
-                for room_id, payload in rooms_to_join.items()
+                for room_id, payload in new_rooms.items()
             ],
         )
         self._log_admission_results(results, context=context)

--- a/src/band/runtime/presence.py
+++ b/src/band/runtime/presence.py
@@ -200,11 +200,7 @@ class RoomPresence:
                 # Terminal for this connection (e.g. another consumer of the
                 # same key superseded it). The transport will not recover by
                 # itself, so the owner must be told rather than left waiting.
-                if self.on_disconnected:
-                    try:
-                        await self.on_disconnected()
-                    except Exception as e:
-                        logger.warning("on_disconnected callback error: %s", e)
+                await self._notify(self.on_disconnected, label="on_disconnected")
             case (
                 ContactRequestReceivedEvent()
                 | ContactRequestUpdatedEvent()
@@ -384,13 +380,14 @@ class RoomPresence:
             logger.debug("Event for untracked room %s, ignoring", room_id)
             return
 
-        if self.on_room_event:
-            try:
-                await self.on_room_event(room_id, event)
-            except Exception as e:
-                logger.error(
-                    "on_room_event error for %s: %s", room_id, e, exc_info=True
-                )
+        await self._notify(
+            self.on_room_event,
+            room_id,
+            event,
+            label="on_room_event",
+            level=logging.ERROR,
+            exc_info=True,
+        )
 
     async def _handle_contact_event(self, event: ContactEvent) -> None:
         """
@@ -399,16 +396,13 @@ class RoomPresence:
         Contact events have no room context and are agent-level.
         Forwards to on_contact_event callback.
         """
-        if self.on_contact_event:
-            try:
-                await self.on_contact_event(event)
-            except Exception as e:
-                logger.error(
-                    "on_contact_event error for %s: %s",
-                    type(event).__name__,
-                    e,
-                    exc_info=True,
-                )
+        await self._notify(
+            self.on_contact_event,
+            event,
+            label=f"on_contact_event ({type(event).__name__})",
+            level=logging.ERROR,
+            exc_info=True,
+        )
 
     async def _list_existing_rooms(self) -> dict[str, dict[str, Any]]:
         """Every current room the filter accepts, keyed by room ID.
@@ -470,6 +464,11 @@ class RoomPresence:
         ``record_room_admission`` is a safe no-op on an already-resolved/stale
         ticket, so a bare ``finally`` is enough to roll a cancelled or failed
         subscribe back to ``Unadmitted`` — no extra "settled" bookkeeping needed.
+        Its return value still matters on the success path though: a ticket
+        can go stale mid-flight (e.g. ``stop()``'s ``roster.clear()`` racing
+        this call before ``self._event_task`` exists to be cancelled), and a
+        stale-but-succeeded subscribe must not announce a room the roster no
+        longer considers ours.
         """
         succeeded = False
         try:
@@ -492,7 +491,15 @@ class RoomPresence:
 
             succeeded = True
         finally:
-            self.roster.record_room_admission(room_id, ticket, succeeded)
+            admitted = self.roster.record_room_admission(room_id, ticket, succeeded)
+
+        if not admitted:
+            logger.debug(
+                "Admission ticket for room %s went stale during %s, ignoring",
+                room_id,
+                context,
+            )
+            return False
 
         # A callback that raises is the caller's problem, not a failed join:
         # the room is subscribed either way, and untracking it here would drop

--- a/src/band/runtime/presence.py
+++ b/src/band/runtime/presence.py
@@ -103,6 +103,9 @@ class RoomPresence:
 
         # Internal task for consuming events from link
         self._event_task: asyncio.Task | None = None
+        # True for the span of start() before _event_task exists to guard
+        # against a second concurrent call (see start()).
+        self._starting = False
 
     async def _notify(
         self,
@@ -130,25 +133,35 @@ class RoomPresence:
         3. Subscribe to existing rooms (if configured)
         4. Spawn task to consume events from link
         """
-        if self._event_task is not None and not self._event_task.done():
+        if self._starting or (
+            self._event_task is not None and not self._event_task.done()
+        ):
             raise RuntimeError(
                 f"RoomPresence for agent {self.link.agent_id} is already running; "
                 "call stop() before starting again"
             )
 
-        # Connect if needed
-        if not self.link.is_connected:
-            await self.link.connect()
+        # Set synchronously, before the first await below, so a second
+        # concurrent start() call sees it even while this one is still
+        # mid-connect/mid-subscribe -- _event_task alone can't do that job,
+        # since it isn't assigned until the very end of this method.
+        self._starting = True
+        try:
+            # Connect if needed
+            if not self.link.is_connected:
+                await self.link.connect()
 
-        # Subscribe to room added/removed events
-        await self.link.subscribe_agent_rooms(self.link.agent_id)
+            # Subscribe to room added/removed events
+            await self.link.subscribe_agent_rooms(self.link.agent_id)
 
-        # Subscribe to existing rooms
-        if self.auto_subscribe_existing:
-            await self._subscribe_to_existing_rooms()
+            # Subscribe to existing rooms
+            if self.auto_subscribe_existing:
+                await self._subscribe_to_existing_rooms()
 
-        # Spawn task to consume events from link's async iterator
-        self._event_task = asyncio.create_task(self._consume_events())
+            # Spawn task to consume events from link's async iterator
+            self._event_task = asyncio.create_task(self._consume_events())
+        finally:
+            self._starting = False
 
         logger.info("RoomPresence started for agent %s", self.link.agent_id)
 
@@ -328,13 +341,18 @@ class RoomPresence:
         )
 
     async def _leave_one_room(self, room_id: str, *, context: str) -> None:
+        await self._unsubscribe_room(room_id, context=context)
+        await self._notify(self.on_room_left, room_id, label="on_room_left")
+
+    async def _unsubscribe_room(self, room_id: str, *, context: str) -> None:
+        """Best-effort unsubscribe: a transport-layer failure here must not
+        crash whatever join/leave sequence triggered it."""
         try:
             await self.link.unsubscribe_room(room_id)
         except Exception as e:
             logger.warning(
                 "Failed to unsubscribe room %s during %s: %s", room_id, context, e
             )
-        await self._notify(self.on_room_left, room_id, label="on_room_left")
 
     async def _admit_reconciled_rooms(
         self,
@@ -468,7 +486,8 @@ class RoomPresence:
         can go stale mid-flight (e.g. ``stop()``'s ``roster.clear()`` racing
         this call before ``self._event_task`` exists to be cancelled), and a
         stale-but-succeeded subscribe must not announce a room the roster no
-        longer considers ours.
+        longer considers ours -- nor leave the real transport subscription
+        behind for a room the roster has already forgotten about.
         """
         succeeded = False
         try:
@@ -495,10 +514,11 @@ class RoomPresence:
 
         if not admitted:
             logger.debug(
-                "Admission ticket for room %s went stale during %s, ignoring",
+                "Admission ticket for room %s went stale during %s, unsubscribing",
                 room_id,
                 context,
             )
+            await self._unsubscribe_room(room_id, context=context)
             return False
 
         # A callback that raises is the caller's problem, not a failed join:

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -165,6 +165,27 @@ class TestBandLinkConnection:
         assert link.is_connected is True
 
     @patch("band.platform.link.WebSocketClient")
+    async def test_cancelled_connect_clears_ws_for_a_later_retry(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """A connect() cancelled while awaiting __aenter__() must roll _ws
+        back to None -- otherwise every later connect() sees a non-None _ws
+        and silently no-ops forever, with is_connected stuck False."""
+        mock_ws_class.return_value = mock_ws_client
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+
+        async with cancelled_mid_await(mock_ws_client.__aenter__, link.connect()):
+            pass
+
+        assert link._ws is None
+        assert link.is_connected is False
+        mock_ws_client.__aexit__.assert_called_once()
+
+        await link.connect()
+
+        assert link.is_connected is True
+
+    @patch("band.platform.link.WebSocketClient")
     async def test_disconnect_exits_websocket_context(
         self, mock_ws_class, mock_ws_client
     ):

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -151,10 +151,10 @@ class TestBandLinkConnection:
         self, mock_ws_class, mock_ws_client
     ):
         """Two genuinely concurrent connect() calls must not both build a
-        WebSocketClient: the guard has to be the synchronous `self._ws`
-        assignment itself, not `self._is_connected` (only set true after
-        two awaits) — otherwise the second call races past the flag and
-        leaks the first client."""
+        WebSocketClient: the guard has to be the synchronous `self._connecting`
+        assignment, not `self._is_connected` (only set true after two awaits)
+        or `self._ws` (only assigned once fully connected) — otherwise the
+        second call races past the flag and leaks the first client."""
         mock_ws_class.return_value = mock_ws_client
 
         link = BandLink(agent_id="agent-123", api_key="test-key")
@@ -165,12 +165,13 @@ class TestBandLinkConnection:
         assert link.is_connected is True
 
     @patch("band.platform.link.WebSocketClient")
-    async def test_cancelled_connect_clears_ws_for_a_later_retry(
+    async def test_cancelled_connect_closes_the_half_opened_client_and_allows_retry(
         self, mock_ws_class, mock_ws_client
     ):
-        """A connect() cancelled while awaiting __aenter__() must roll _ws
-        back to None -- otherwise every later connect() sees a non-None _ws
-        and silently no-ops forever, with is_connected stuck False."""
+        """A connect() cancelled while awaiting __aenter__() must close the
+        half-opened client it made, and a later connect() must actually
+        retry -- not see a leftover non-None _ws and silently no-op forever
+        with is_connected stuck False."""
         mock_ws_class.return_value = mock_ws_client
         link = BandLink(agent_id="agent-123", api_key="test-key")
 
@@ -179,6 +180,7 @@ class TestBandLinkConnection:
 
         assert link._ws is None
         assert link.is_connected is False
+        assert link._connecting is False
         mock_ws_client.__aexit__.assert_called_once()
 
         await link.connect()

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -31,6 +31,18 @@ from band_rest import (
 )
 
 from band.core.types import PlatformConnection, PlatformMessage
+from band.runtime.presence import RoomPresence
+
+
+def admit_room(presence: RoomPresence, room_id: str) -> None:
+    """Seed ``room_id`` as already ``Admitted`` on a presence's roster.
+
+    For tests about dispatch/routing, not about the join flow itself — goes
+    through RoomRoster's own public methods, not a private attribute.
+    """
+    ticket = presence.roster.begin_room_admission(room_id, passes_filter=True)
+    assert ticket is not None
+    presence.roster.record_room_admission(room_id, ticket, True)
 
 
 def make_participant(p: dict[str, Any]) -> ChatParticipant:

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -45,6 +45,14 @@ def admit_room(presence: RoomPresence, room_id: str) -> None:
     presence.roster.record_room_admission(room_id, ticket, True)
 
 
+def chat_row(room_id: str) -> MagicMock:
+    """One room as the chats listing returns it."""
+    room = MagicMock()
+    room.id = room_id
+    room.model_dump.return_value = {"id": room_id}
+    return room
+
+
 def make_participant(p: dict[str, Any]) -> ChatParticipant:
     return ChatParticipant(
         id=p["id"],

--- a/tests/runtime/test_presence.py
+++ b/tests/runtime/test_presence.py
@@ -21,7 +21,7 @@ from tests.conftest import (
     make_room_removed_event,
 )
 from tests.platform.conftest import cancelled_mid_await
-from tests.runtime.conftest import admit_room
+from tests.runtime.conftest import admit_room, chat_row
 
 
 @pytest.fixture
@@ -235,14 +235,6 @@ class TestRoomPresenceRoomAdded:
 
         assert presence.roster.room_membership("room-123") is RoomMembership.Unadmitted
         mock_link.subscribe_room.assert_not_called()
-
-
-def chat_row(room_id):
-    """One room as the chats listing returns it."""
-    room = MagicMock()
-    room.id = room_id
-    room.model_dump.return_value = {"id": room_id}
-    return room
 
 
 def listing(*pages):
@@ -473,13 +465,12 @@ class TestRoomPresenceRoomRemoved:
         return exists specifically to gate this."""
         presence = presences(auto_subscribe_existing=False)
         await presence.start()
-        on_left = AsyncMock()
-        presence.on_room_left = on_left
+        presence.on_room_left = AsyncMock()
 
         event = make_room_removed_event(room_id="room-never-joined")
         await presence._handle_room_removed(event)
 
-        on_left.assert_not_called()
+        presence.on_room_left.assert_not_called()
         mock_link.unsubscribe_room.assert_called_once_with("room-never-joined")
 
 
@@ -592,12 +583,8 @@ class TestRoomPresenceReconnect:
         self, mock_link, presences
     ):
         """A room_added delivered after reconcile() already admitted the
-        same room via its own admitting list must be a harmless no-op — not
-        a second subscribe or announce. Proves the TOCTOU self-healing the
-        design doc calls out for reconnect's atomic admission claim; the
-        single event-consumer task invariant is what makes this the only
-        reachable interleaving (a room-scoped event can't be dequeued
-        mid-admission of that same room)."""
+        same room must be a no-op, not a second subscribe or announce —
+        proves the ticket-dedup self-healing the design doc describes."""
         mock_link.rest.agent_api_chats.list_agent_chats = listing([])
         joined = []
         presence = presences(auto_subscribe_existing=True)

--- a/tests/runtime/test_presence.py
+++ b/tests/runtime/test_presence.py
@@ -381,6 +381,30 @@ class TestAdmissionRaces:
         assert mock_link.subscribe_room.call_count == 1
         assert len(joined) == 1
 
+    async def test_stale_ticket_after_concurrent_clear_does_not_notify(
+        self, mock_link, presences
+    ):
+        """A ticket invalidated mid-flight (e.g. stop()'s roster.clear()
+        racing an in-flight admission before self._event_task exists to be
+        cancelled) must not announce the room as joined, even though
+        subscribe_room() itself succeeded — record_room_admission's return
+        value is the roster's own authority on whether the ticket still
+        counted."""
+        presence = presences(auto_subscribe_existing=False)
+        await presence.start()
+        ticket = presence.roster.begin_room_admission("room-1", passes_filter=True)
+        presence.roster.clear()
+
+        presence.on_room_joined = AsyncMock()
+
+        result = await presence._complete_room_admission(
+            "room-1", ticket, {}, context="room_added"
+        )
+
+        assert result is False
+        presence.on_room_joined.assert_not_called()
+        assert presence.roster.room_membership("room-1") is RoomMembership.Unadmitted
+
 
 class TestRoomPresenceRoomRemoved:
     """Test room_removed event handling."""

--- a/tests/runtime/test_presence.py
+++ b/tests/runtime/test_presence.py
@@ -20,7 +20,7 @@ from tests.conftest import (
     make_room_deleted_event,
     make_room_removed_event,
 )
-from tests.platform.conftest import cancelled_mid_await
+from tests.platform.conftest import cancelled_mid_await, gated_coroutine
 from tests.runtime.conftest import admit_room, chat_row
 
 
@@ -148,6 +148,28 @@ class TestRoomPresenceStart:
 
         await presence.stop()
         assert first_task.done()
+
+    async def test_concurrent_start_calls_only_one_wins(self, mock_link, presences):
+        """Two start() calls racing before the first has a chance to assign
+        _event_task must not both proceed to create a consumer task -- the
+        second must raise, mirroring the sequential case above."""
+        side_effect, started, release = gated_coroutine()
+        mock_link.connect.side_effect = side_effect
+        mock_link.is_connected = False
+        presence = presences(auto_subscribe_existing=False)
+
+        first_call = asyncio.create_task(presence.start())
+        await started.wait()
+
+        with pytest.raises(RuntimeError):
+            await presence.start()
+
+        release.set()
+        await first_call
+
+        assert presence._event_task is not None
+        await presence.stop()
+        assert presence._event_task.done()
 
 
 class TestRoomPresenceStop:
@@ -389,7 +411,9 @@ class TestAdmissionRaces:
         cancelled) must not announce the room as joined, even though
         subscribe_room() itself succeeded — record_room_admission's return
         value is the roster's own authority on whether the ticket still
-        counted."""
+        counted. The real transport subscription it just made must also be
+        torn down: the roster no longer tracks the room, so no later cleanup
+        pass (stop()/reconcile()) will ever target it by room_id."""
         presence = presences(auto_subscribe_existing=False)
         await presence.start()
         ticket = presence.roster.begin_room_admission("room-1", passes_filter=True)
@@ -404,6 +428,7 @@ class TestAdmissionRaces:
         assert result is False
         presence.on_room_joined.assert_not_called()
         assert presence.roster.room_membership("room-1") is RoomMembership.Unadmitted
+        mock_link.unsubscribe_room.assert_called_once_with("room-1")
 
 
 class TestRoomPresenceRoomRemoved:

--- a/tests/runtime/test_presence.py
+++ b/tests/runtime/test_presence.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
+
+from band_sdk_core import RoomMembership
 
 from band.runtime.presence import RoomPresence
 
@@ -17,6 +20,8 @@ from tests.conftest import (
     make_room_deleted_event,
     make_room_removed_event,
 )
+from tests.platform.conftest import cancelled_mid_await
+from tests.runtime.conftest import admit_room
 
 
 @pytest.fixture
@@ -122,9 +127,27 @@ class TestRoomPresenceStart:
         presence = presences(auto_subscribe_existing=True)
         await presence.start()
 
-        assert "room-1" in presence.rooms
-        assert "room-2" in presence.rooms
+        assert presence.roster.room_membership("room-1") is RoomMembership.Admitted
+        assert presence.roster.room_membership("room-2") is RoomMembership.Admitted
         assert mock_link.subscribe_room.call_count == 2
+
+    async def test_start_while_running_raises_without_orphaning_the_task(
+        self, mock_link, presences
+    ):
+        """A second start() call while the event task is still running must
+        raise, not silently overwrite ``_event_task`` and orphan the first
+        one (stop() would then only ever cancel the second)."""
+        presence = presences(auto_subscribe_existing=False)
+        await presence.start()
+        first_task = presence._event_task
+
+        with pytest.raises(RuntimeError):
+            await presence.start()
+
+        assert presence._event_task is first_task
+
+        await presence.stop()
+        assert first_task.done()
 
 
 class TestRoomPresenceStop:
@@ -133,18 +156,18 @@ class TestRoomPresenceStop:
     async def test_stop_clears_rooms(self, mock_link, presences):
         """stop() should clear tracked rooms."""
         presence = presences(auto_subscribe_existing=False)
-        presence.rooms.add("room-1")
-        presence.rooms.add("room-2")
+        admit_room(presence, "room-1")
+        admit_room(presence, "room-2")
 
         await presence.stop()
 
-        assert presence.rooms == set()
+        assert presence.roster.tracked_room_ids() == []
 
     async def test_stop_calls_on_room_left(self, mock_link, presences):
         """stop() should call on_room_left for each room."""
         presence = presences(auto_subscribe_existing=False)
-        presence.rooms.add("room-1")
-        presence.rooms.add("room-2")
+        admit_room(presence, "room-1")
+        admit_room(presence, "room-2")
 
         left_rooms = []
 
@@ -156,6 +179,20 @@ class TestRoomPresenceStop:
         await presence.stop()
 
         assert set(left_rooms) == {"room-1", "room-2"}
+
+    async def test_stop_does_not_notify_for_a_room_still_admitting(
+        self, mock_link, presences
+    ):
+        """A room that never reached Admitted was never announced as
+        joined, so stop() must not announce it as left either."""
+        presence = presences(auto_subscribe_existing=False)
+        presence.roster.begin_room_admission("room-1", passes_filter=True)
+        on_left = AsyncMock()
+        presence.on_room_left = on_left
+
+        await presence.stop()
+
+        on_left.assert_not_called()
 
 
 class TestRoomPresenceRoomAdded:
@@ -179,7 +216,7 @@ class TestRoomPresenceRoomAdded:
         )
 
         mock_link.subscribe_room.assert_called_with("room-123")
-        assert presence.rooms == {"room-123"}
+        assert presence.roster.tracked_room_ids() == ["room-123"]
         assert joined == [("room-123", ANY)]
         assert joined[0][1]["title"] == "Test", "the payload reaches the callback"
 
@@ -196,7 +233,7 @@ class TestRoomPresenceRoomAdded:
         event = make_room_added_event(room_id="room-123", type="direct")
         await presence._handle_room_added(event)
 
-        assert "room-123" not in presence.rooms
+        assert presence.roster.room_membership("room-123") is RoomMembership.Unadmitted
         mock_link.subscribe_room.assert_not_called()
 
 
@@ -272,7 +309,7 @@ class TestJoiningOnce:
 
         await presence.start()
 
-        assert presence.rooms == {"room-1"}
+        assert presence.roster.tracked_room_ids() == ["room-1"]
 
     async def test_a_room_that_never_actually_subscribed_is_untracked(
         self, mock_link, presences
@@ -281,8 +318,8 @@ class TestJoiningOnce:
         real join/rollback failure never raises up to _join_room's except
         block. is_room_subscribed() must be checked instead of assuming
         "no exception" means "subscribed" — otherwise the room stays
-        (wrongly) in self.rooms forever, treated as surviving on every
-        future reconnect."""
+        (wrongly) tracked forever, treated as surviving on every future
+        reconnect."""
         mock_link.rest.agent_api_chats.list_agent_chats = listing([chat_row("room-1")])
         mock_link.is_room_subscribed = MagicMock(return_value=False)
         joined = []
@@ -291,7 +328,7 @@ class TestJoiningOnce:
 
         await presence.start()
 
-        assert presence.rooms == set()
+        assert presence.roster.room_membership("room-1") is RoomMembership.Unadmitted
         assert joined == []
 
     async def test_a_room_that_never_subscribed_is_rejoined_on_reconnect(
@@ -304,14 +341,53 @@ class TestJoiningOnce:
         mock_link.is_room_subscribed = MagicMock(return_value=False)
         presence = presences(auto_subscribe_existing=True)
         await presence.start()
-        assert presence.rooms == set()
+        assert presence.roster.room_membership("room-1") is RoomMembership.Unadmitted
 
         mock_link.is_room_subscribed = MagicMock(return_value=True)
         mock_link.rest.agent_api_chats.list_agent_chats = listing([chat_row("room-1")])
         await presence._handle_reconnect()
 
-        assert presence.rooms == {"room-1"}
+        assert presence.roster.tracked_room_ids() == ["room-1"]
         assert mock_link.subscribe_room.call_count == 2  # startup attempt + reconnect
+
+
+class TestAdmissionRaces:
+    """Regression coverage for the admission ticket's concurrency guarantees."""
+
+    async def test_cancellation_mid_subscribe_rolls_back_to_unadmitted(
+        self, mock_link, presences
+    ):
+        """Cancelling _join_room while subscribe_room() is in flight must not
+        leave the room stuck Admitting forever — record_room_admission's
+        bare finally always resolves the ticket, even on cancellation."""
+        presence = presences(auto_subscribe_existing=False)
+        await presence.start()
+
+        async with cancelled_mid_await(
+            mock_link.subscribe_room,
+            presence._join_room("room-1", {}, context="room_added"),
+        ):
+            pass
+
+        assert presence.roster.room_membership("room-1") is RoomMembership.Unadmitted
+
+    async def test_concurrent_join_room_only_one_admits(self, mock_link, presences):
+        """Two concurrent _join_room calls for the same room must not both
+        subscribe: begin_room_admission's synchronous pre-await claim makes
+        the loser a no-op, deterministically under asyncio.gather."""
+        presence = presences(auto_subscribe_existing=False)
+        await presence.start()
+        joined = []
+        presence.on_room_joined = AsyncMock(side_effect=lambda *a: joined.append(a))
+
+        results = await asyncio.gather(
+            presence._join_room("room-1", {}, context="room_added"),
+            presence._join_room("room-1", {}, context="room_added"),
+        )
+
+        assert sorted(results) == [False, True]
+        assert mock_link.subscribe_room.call_count == 1
+        assert len(joined) == 1
 
 
 class TestRoomPresenceRoomRemoved:
@@ -321,7 +397,7 @@ class TestRoomPresenceRoomRemoved:
         """room_removed should unsubscribe from room."""
         presence = presences(auto_subscribe_existing=False)
         await presence.start()
-        presence.rooms.add("room-123")
+        admit_room(presence, "room-123")
 
         event = make_room_removed_event(room_id="room-123")
         await presence._handle_room_removed(event)
@@ -329,21 +405,21 @@ class TestRoomPresenceRoomRemoved:
         mock_link.unsubscribe_room.assert_called_with("room-123")
 
     async def test_room_removed_untracks_room(self, mock_link, presences):
-        """room_removed should remove from presence.rooms."""
+        """room_removed should untrack the room from presence.roster."""
         presence = presences(auto_subscribe_existing=False)
         await presence.start()
-        presence.rooms.add("room-123")
+        admit_room(presence, "room-123")
 
         event = make_room_removed_event(room_id="room-123")
         await presence._handle_room_removed(event)
 
-        assert "room-123" not in presence.rooms
+        assert presence.roster.room_membership("room-123") is RoomMembership.Unadmitted
 
     async def test_room_removed_calls_callback(self, mock_link, presences):
         """room_removed should call on_room_left callback."""
         presence = presences(auto_subscribe_existing=False)
         await presence.start()
-        presence.rooms.add("room-123")
+        admit_room(presence, "room-123")
 
         left_rooms = []
 
@@ -363,19 +439,19 @@ class TestRoomPresenceRoomRemoved:
         """room_deleted should reuse room cleanup behavior."""
         presence = presences(auto_subscribe_existing=False)
         await presence.start()
-        presence.rooms.add("room-123")
+        admit_room(presence, "room-123")
 
         event = make_room_deleted_event(room_id="room-123")
         await presence._on_platform_event(event)
 
         mock_link.unsubscribe_room.assert_called_with("room-123")
-        assert "room-123" not in presence.rooms
+        assert presence.roster.room_membership("room-123") is RoomMembership.Unadmitted
 
     async def test_room_deleted_calls_callback(self, mock_link, presences):
         """room_deleted should call on_room_left callback once."""
         presence = presences(auto_subscribe_existing=False)
         await presence.start()
-        presence.rooms.add("room-123")
+        admit_room(presence, "room-123")
 
         left_rooms = []
 
@@ -389,63 +465,64 @@ class TestRoomPresenceRoomRemoved:
 
         assert left_rooms == ["room-123"]
 
+    async def test_room_removed_for_a_never_admitted_room_does_not_notify(
+        self, mock_link, presences
+    ):
+        """A room_removed/room_deleted for a room we never actually admitted
+        must not fire on_room_left — record_room_removed's was_tracked
+        return exists specifically to gate this."""
+        presence = presences(auto_subscribe_existing=False)
+        await presence.start()
+        on_left = AsyncMock()
+        presence.on_room_left = on_left
+
+        event = make_room_removed_event(room_id="room-never-joined")
+        await presence._handle_room_removed(event)
+
+        on_left.assert_not_called()
+        mock_link.unsubscribe_room.assert_called_once_with("room-never-joined")
+
 
 class TestRoomPresenceReconnect:
     """Test reconnect reconciliation behavior."""
 
     async def test_reconnect_unsubscribes_gone_rooms(self, mock_link, presences):
         """Reconnect should unsubscribe rooms missing from the API."""
-        room = MagicMock()
-        room.id = "room-2"
-        room.model_dump.return_value = {"id": "room-2"}
-        mock_link.rest.agent_api_chats.list_agent_chats.return_value = MagicMock(
-            data=[room],
-            metadata=MagicMock(total_pages=1),
+        mock_link.rest.agent_api_chats.list_agent_chats = listing(
+            [chat_row("room-1"), chat_row("room-2")]
         )
-
         presence = presences(auto_subscribe_existing=True)
         await presence.start()
         mock_link.subscribe_room.reset_mock()
-        presence.rooms = {"room-1", "room-2"}
 
+        mock_link.rest.agent_api_chats.list_agent_chats = listing([chat_row("room-2")])
         event = ReconnectedEvent()
         await presence._on_platform_event(event)
 
         mock_link.unsubscribe_room.assert_called_once_with("room-1")
-        assert presence.rooms == {"room-2"}
+        assert presence.roster.tracked_room_ids() == ["room-2"]
 
     async def test_reconnect_subscribes_only_new_rooms(self, mock_link, presences):
         """Reconnect should only join rooms that are new from the API."""
-        room1 = MagicMock()
-        room1.id = "room-1"
-        room1.model_dump.return_value = {"id": "room-1"}
-        room2 = MagicMock()
-        room2.id = "room-2"
-        room2.model_dump.return_value = {"id": "room-2"}
-        mock_link.rest.agent_api_chats.list_agent_chats.return_value = MagicMock(
-            data=[room1, room2],
-            metadata=MagicMock(total_pages=1),
-        )
-
+        mock_link.rest.agent_api_chats.list_agent_chats = listing([chat_row("room-1")])
         presence = presences(auto_subscribe_existing=True)
         await presence.start()
         mock_link.subscribe_room.reset_mock()
         mock_link.unsubscribe_room.reset_mock()
-        presence.rooms = {"room-1"}
 
+        mock_link.rest.agent_api_chats.list_agent_chats = listing(
+            [chat_row("room-1"), chat_row("room-2")]
+        )
         event = ReconnectedEvent()
         await presence._on_platform_event(event)
 
         mock_link.subscribe_room.assert_called_once_with("room-2")
         mock_link.unsubscribe_room.assert_not_called()
-        assert presence.rooms == {"room-1", "room-2"}
+        assert set(presence.roster.tracked_room_ids()) == {"room-1", "room-2"}
 
     async def test_reconnect_notifies_left_for_gone_rooms(self, mock_link, presences):
         """Reconnect should fire on_room_left for rooms removed while offline."""
-        mock_link.rest.agent_api_chats.list_agent_chats.return_value = MagicMock(
-            data=[],
-            metadata=MagicMock(total_pages=1),
-        )
+        mock_link.rest.agent_api_chats.list_agent_chats = listing([chat_row("room-1")])
         left_rooms = []
 
         async def on_left(room_id):
@@ -454,27 +531,21 @@ class TestRoomPresenceReconnect:
         presence = presences(auto_subscribe_existing=True)
         presence.on_room_left = on_left
         await presence.start()
-        presence.rooms = {"room-1"}
         mock_link.unsubscribe_room.reset_mock()
 
+        mock_link.rest.agent_api_chats.list_agent_chats = listing([])
         event = ReconnectedEvent()
         await presence._on_platform_event(event)
 
         assert left_rooms == ["room-1"]
         mock_link.unsubscribe_room.assert_called_once_with("room-1")
-        assert presence.rooms == set()
+        assert presence.roster.tracked_room_ids() == []
 
     async def test_reconnect_forwards_event_to_surviving_rooms(
         self, mock_link, presences
     ):
         """Reconnect should notify surviving rooms even when no rooms are newly joined."""
-        room = MagicMock()
-        room.id = "room-1"
-        room.model_dump.return_value = {"id": "room-1"}
-        mock_link.rest.agent_api_chats.list_agent_chats.return_value = MagicMock(
-            data=[room],
-            metadata=MagicMock(total_pages=1),
-        )
+        mock_link.rest.agent_api_chats.list_agent_chats = listing([chat_row("room-1")])
         received = []
 
         async def on_event(room_id, event):
@@ -485,8 +556,8 @@ class TestRoomPresenceReconnect:
         await presence.start()
         mock_link.subscribe_room.reset_mock()
         mock_link.unsubscribe_room.reset_mock()
-        presence.rooms = {"room-1"}
 
+        mock_link.rest.agent_api_chats.list_agent_chats = listing([chat_row("room-1")])
         await presence._on_platform_event(ReconnectedEvent())
 
         assert mock_link.subscribe_room.call_count == 0
@@ -494,6 +565,87 @@ class TestRoomPresenceReconnect:
         assert len(received) == 1
         assert received[0][0] == "room-1"
         assert isinstance(received[0][1], ReconnectedEvent)
+
+    async def test_a_failed_reconnect_admission_is_not_tracked_or_resynced(
+        self, mock_link, presences
+    ):
+        """An admitting-list entry whose subscribe fails during reconnect
+        must not end up tracked, and must not receive an on_room_event
+        resync — it never became Admitted."""
+        mock_link.rest.agent_api_chats.list_agent_chats = listing([chat_row("room-1")])
+        mock_link.is_room_subscribed = MagicMock(return_value=False)
+        received = []
+
+        async def on_event(room_id, event):
+            received.append(room_id)
+
+        presence = presences(auto_subscribe_existing=True)
+        presence.on_room_event = on_event
+        await presence.start()
+
+        await presence._handle_reconnect()
+
+        assert presence.roster.tracked_room_ids() == []
+        assert received == []
+
+    async def test_a_stale_room_added_after_reconnect_admission_is_a_noop(
+        self, mock_link, presences
+    ):
+        """A room_added delivered after reconcile() already admitted the
+        same room via its own admitting list must be a harmless no-op — not
+        a second subscribe or announce. Proves the TOCTOU self-healing the
+        design doc calls out for reconnect's atomic admission claim; the
+        single event-consumer task invariant is what makes this the only
+        reachable interleaving (a room-scoped event can't be dequeued
+        mid-admission of that same room)."""
+        mock_link.rest.agent_api_chats.list_agent_chats = listing([])
+        joined = []
+        presence = presences(auto_subscribe_existing=True)
+        presence.on_room_joined = AsyncMock(side_effect=lambda *a: joined.append(a))
+        await presence.start()
+        assert presence.roster.tracked_room_ids() == []
+
+        mock_link.rest.agent_api_chats.list_agent_chats = listing(
+            [chat_row("room-new")]
+        )
+        await presence._handle_reconnect()
+
+        assert mock_link.subscribe_room.call_count == 1
+        assert len(joined) == 1
+
+        await presence._handle_room_added(make_room_added_event(room_id="room-new"))
+
+        assert mock_link.subscribe_room.call_count == 1
+        assert len(joined) == 1
+
+    async def test_auto_subscribe_false_leaves_a_new_reconnect_room_unadmitted(
+        self, mock_link, presences
+    ):
+        """With auto_subscribe_existing=False, a reconnect snapshot naming a
+        room never seen before must leave it Unadmitted, not stuck
+        Admitting forever: reconcile() atomically claims a ticket for every
+        Unadmitted room it's given, with no partial-apply to undo that
+        claim afterward, so the snapshot must exclude the room up front."""
+        mock_link.rest.agent_api_chats.list_agent_chats = listing(
+            [chat_row("room-new")]
+        )
+        presence = presences(auto_subscribe_existing=False)
+        await presence.start()
+
+        await presence._handle_reconnect()
+
+        assert presence.roster.room_membership("room-new") is RoomMembership.Unadmitted
+        mock_link.subscribe_room.assert_not_called()
+
+        # A real room_added for it afterward must succeed normally, not
+        # silently no-op as if a ticket were already claimed.
+        joined = []
+        presence.on_room_joined = AsyncMock(side_effect=lambda *a: joined.append(a))
+        await presence._handle_room_added(make_room_added_event(room_id="room-new"))
+
+        assert presence.roster.room_membership("room-new") is RoomMembership.Admitted
+        mock_link.subscribe_room.assert_called_once_with("room-new")
+        assert len(joined) == 1
 
 
 class TestRoomPresenceRoomEvents:
@@ -503,7 +655,7 @@ class TestRoomPresenceRoomEvents:
         """Room events should be forwarded to on_room_event."""
         presence = presences(auto_subscribe_existing=False)
         await presence.start()
-        presence.rooms.add("room-123")
+        admit_room(presence, "room-123")
 
         received_events = []
 
@@ -549,24 +701,24 @@ class TestRoomPresenceEventRouting:
         event = make_room_added_event(room_id="room-123")
         await presence._on_platform_event(event)
 
-        assert "room-123" in presence.rooms
+        assert presence.roster.room_membership("room-123") is RoomMembership.Admitted
 
     async def test_routes_room_removed(self, mock_link, presences):
         """Should route room_removed events correctly."""
         presence = presences(auto_subscribe_existing=False)
         await presence.start()
-        presence.rooms.add("room-123")
+        admit_room(presence, "room-123")
 
         event = make_room_removed_event(room_id="room-123")
         await presence._on_platform_event(event)
 
-        assert "room-123" not in presence.rooms
+        assert presence.roster.room_membership("room-123") is RoomMembership.Unadmitted
 
     async def test_routes_message_to_room_event(self, mock_link, presences):
         """Should route message events to on_room_event."""
         presence = presences(auto_subscribe_existing=False)
         await presence.start()
-        presence.rooms.add("room-123")
+        admit_room(presence, "room-123")
 
         received = []
 

--- a/tests/runtime/test_presence.py
+++ b/tests/runtime/test_presence.py
@@ -216,6 +216,32 @@ class TestRoomPresenceStop:
 
         on_left.assert_not_called()
 
+    async def test_stop_waits_for_an_in_progress_start_before_tearing_down(
+        self, mock_link, presences
+    ):
+        """stop() racing an in-flight start() must not return before the
+        instance is actually stopped: it has to wait for start() to finish
+        creating _event_task and then tear it down, rather than finding
+        nothing to cancel and returning while start() is still running."""
+        side_effect, started, release = gated_coroutine()
+        mock_link.connect.side_effect = side_effect
+        mock_link.is_connected = False
+        presence = presences(auto_subscribe_existing=False)
+
+        start_task = asyncio.create_task(presence.start())
+        await started.wait()
+
+        stop_task = asyncio.create_task(presence.stop())
+        await asyncio.sleep(0)
+        assert not stop_task.done()
+
+        release.set()
+        await start_task
+        await stop_task
+
+        assert presence._event_task is not None
+        assert presence._event_task.done()
+
 
 class TestRoomPresenceRoomAdded:
     """Test room_added event handling."""

--- a/tests/runtime/test_presence.py
+++ b/tests/runtime/test_presence.py
@@ -318,6 +318,22 @@ class TestJoiningOnce:
         assert joined == ["room-1"], "the callback ran again for a room already joined"
         assert mock_link.subscribe_room.call_count == 1
 
+    async def test_subscribe_rooms_skips_a_room_already_admitted(
+        self, mock_link, presences
+    ):
+        """A room a concurrent room_added event already admitted before
+        _subscribe_rooms ran must be skipped, not re-attempted and counted
+        as a failed admission -- _join_room's own no-op for an already-
+        admitted room would otherwise misreport an already-successful join
+        as a failure in the admission-results log."""
+        presence = presences(auto_subscribe_existing=False)
+        await presence.start()
+        admit_room(presence, "room-1")
+
+        await presence._subscribe_rooms({"room-1": {}}, context="startup")
+
+        mock_link.subscribe_room.assert_not_called()
+
     async def test_a_room_on_two_pages_of_one_snapshot_joins_once(
         self, mock_link, presences
     ):
@@ -399,7 +415,11 @@ class TestAdmissionRaces:
     ):
         """Cancelling _join_room while subscribe_room() is in flight must not
         leave the room stuck Admitting forever — record_room_admission's
-        bare finally always resolves the ticket, even on cancellation."""
+        bare finally always resolves the ticket, even on cancellation. The
+        join may have already reached the server by the time the
+        cancellation lands, so this must also attempt a best-effort
+        unsubscribe rather than leave a transport subscription nothing in
+        the roster will ever target for cleanup."""
         presence = presences(auto_subscribe_existing=False)
         await presence.start()
 
@@ -410,6 +430,7 @@ class TestAdmissionRaces:
             pass
 
         assert presence.roster.room_membership("room-1") is RoomMembership.Unadmitted
+        mock_link.unsubscribe_room.assert_called_once_with("room-1")
 
     async def test_concurrent_join_room_only_one_admits(self, mock_link, presences):
         """Two concurrent _join_room calls for the same room must not both

--- a/tests/runtime/test_presence_contacts.py
+++ b/tests/runtime/test_presence_contacts.py
@@ -22,6 +22,8 @@ from band.client.streaming import (
 )
 from band.runtime.presence import RoomPresence
 
+from tests.runtime.conftest import admit_room
+
 
 @pytest.fixture
 def mock_link():
@@ -131,7 +133,7 @@ class TestContactEventRouting:
         presence.on_contact_event = AsyncMock()  # Set up contact handler
 
         # Add a room to track
-        presence.rooms.add("room-123")
+        admit_room(presence, "room-123")
 
         # Process contact event
         await presence._on_platform_event(sample_contact_added_event)
@@ -153,7 +155,7 @@ class TestContactEventRouting:
         presence.on_contact_event = contact_callback
 
         # Add room to track for message events
-        presence.rooms.add("room-123")
+        admit_room(presence, "room-123")
 
         # Process room added event
         await presence._on_platform_event(sample_room_added_event)

--- a/tests/runtime/test_presence_real_wire.py
+++ b/tests/runtime/test_presence_real_wire.py
@@ -21,6 +21,8 @@ from band.platform.link import BandLink
 from band.runtime.presence import RoomPresence
 from band.testing import fake_phoenix_server
 
+from tests.runtime.conftest import chat_row
+
 
 def make_link(server_url: str) -> BandLink:
     return BandLink(
@@ -29,14 +31,6 @@ def make_link(server_url: str) -> BandLink:
         ws_url=server_url,
         rest_url="https://test.invalid",
     )
-
-
-def chat_row(room_id: str) -> MagicMock:
-    """One room as the chats listing returns it."""
-    room = MagicMock()
-    room.id = room_id
-    room.model_dump.return_value = {"id": room_id}
-    return room
 
 
 def listing(*room_ids: str) -> AsyncMock:

--- a/tests/runtime/test_presence_real_wire.py
+++ b/tests/runtime/test_presence_real_wire.py
@@ -1,0 +1,114 @@
+"""RoomPresence behavior proven against a real (fake-server-backed) wire, not
+mocks calling each other -- mirrors tests/platform/test_link_real_wire.py one
+layer up.
+
+Every existing reconnect test in test_presence.py calls
+``presence._handle_reconnect()`` directly, bypassing a real drop/reconnect
+entirely. This file closes that gap: a real severed connection triggers
+BandLink's own reconnect supervisor, which fires a real ``ReconnectedEvent``
+through the real event queue, which RoomPresence's real event-consumer task
+dispatches to ``_handle_reconnect`` -- the one seam a fully mocked suite
+cannot exercise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+from band.platform.link import BandLink
+from band.runtime.presence import RoomPresence
+from band.testing import fake_phoenix_server
+
+
+def make_link(server_url: str) -> BandLink:
+    return BandLink(
+        agent_id="agent-123",
+        api_key="test-key",
+        ws_url=server_url,
+        rest_url="https://test.invalid",
+    )
+
+
+def chat_row(room_id: str) -> MagicMock:
+    """One room as the chats listing returns it."""
+    room = MagicMock()
+    room.id = room_id
+    room.model_dump.return_value = {"id": room_id}
+    return room
+
+
+def listing(*room_ids: str) -> AsyncMock:
+    """Stub ``list_agent_chats`` returning one page naming ``room_ids``."""
+    return AsyncMock(
+        return_value=MagicMock(
+            data=[chat_row(room_id) for room_id in room_ids],
+            metadata=MagicMock(total_pages=1),
+        )
+    )
+
+
+@asynccontextmanager
+async def running_presence(link: BandLink):
+    """Tear down every real resource (event-consumer task, room
+    subscriptions, WS connection) even if an assertion in between raises.
+    ``presence.stop()`` only reaches room-level state -- the connection is
+    ``link``'s own, so it needs its own explicit close."""
+    presence = RoomPresence(link)
+    try:
+        yield presence
+    finally:
+        await presence.stop()
+        await link.disconnect()
+
+
+async def test_reconnect_reconciles_room_membership_over_a_real_socket_drop() -> None:
+    """A real severed connection must trigger BandLink's actual reconnect
+    supervisor, which fires a real ReconnectedEvent through the real event
+    queue -- not a direct ``_handle_reconnect()`` call -- and RoomPresence's
+    reconciliation against the (drifted) REST snapshot must land correctly:
+    a room dropped from the snapshot leaves, a newly-added one joins, and the
+    true survivor gets resynced (not unioned with the newly-admitted room)."""
+    async with fake_phoenix_server() as server:
+        link = make_link(server.url)
+        link.rest.agent_api_chats.list_agent_chats = listing("room-1", "room-2")
+
+        async with running_presence(link) as presence:
+            joined: list[str] = []
+            left: list[str] = []
+            resynced: list[str] = []
+            reconnected = asyncio.Event()
+
+            presence.on_room_joined = AsyncMock(
+                side_effect=lambda room_id, payload: joined.append(room_id)
+            )
+            presence.on_room_left = AsyncMock(
+                side_effect=lambda room_id: left.append(room_id)
+            )
+
+            async def on_event(room_id: str, event) -> None:
+                resynced.append(room_id)
+
+            presence.on_room_event = on_event
+
+            async def on_reconnected() -> None:
+                reconnected.set()
+
+            presence.on_reconnected = on_reconnected
+
+            await presence.start()
+            assert set(presence.roster.tracked_room_ids()) == {"room-1", "room-2"}
+            joined.clear()
+
+            # Membership drifts while "disconnected": room-1 drops, room-3
+            # appears, room-2 survives.
+            link.rest.agent_api_chats.list_agent_chats = listing("room-2", "room-3")
+
+            await server.abort_connection()
+            await asyncio.wait_for(reconnected.wait(), timeout=10)
+
+            assert left == ["room-1"]
+            assert joined == ["room-3"]
+            assert resynced == ["room-2"]
+            assert set(presence.roster.tracked_room_ids()) == {"room-2", "room-3"}

--- a/tests/runtime/test_resync.py
+++ b/tests/runtime/test_resync.py
@@ -24,6 +24,8 @@ from band.runtime.presence import RoomPresence
 from band.runtime.runtime import AgentRuntime
 from band.runtime.types import PlatformMessage, SessionConfig
 
+from tests.runtime.conftest import admit_room
+
 
 async def wait_for_condition(
     predicate, *, timeout: float = 1.0, interval: float = 0.01
@@ -461,7 +463,7 @@ class TestPresenceReconnectOnReconnectedCallback:
         )
 
         presence = RoomPresence(mock_presence_link, auto_subscribe_existing=True)
-        presence.rooms = {"room-old"}
+        admit_room(presence, "room-old")
         presence.on_reconnected = on_reconnected
 
         await presence._handle_reconnect()


### PR DESCRIPTION
## Summary

Replaces `RoomPresence`'s hand-rolled room-lifecycle tracking (`self.rooms: Set[str]`, the early-claim dedup in `_join_room`, the reconnect set-diffing in `_handle_reconnect`) with `band_sdk_core.RoomRoster` — an explicit `Unadmitted`/`Admitting`/`Admitted` state machine with ticket-based admission claims and a `reconcile()` call that replaces the manual `old_rooms & current_room_ids` set diffing.

Not a pure lift-and-shift — three deliberate corrections land alongside it:

- **`_handle_room_left` no longer fires `on_room_left` for a room that was never actually admitted.** `record_room_removed`'s `was_tracked` return gates the notification.
- **`auto_subscribe_existing=False` no longer leaks an admission ticket on reconnect.** `reconcile()` atomically claims a ticket for every `Unadmitted` room it's given, with no way to undo that claim afterward — so the reconnect snapshot is now pre-filtered by `auto_subscribe_existing` before it ever reaches `reconcile()`, instead of gating only what happens with the result.
- **`start()` now rejects a concurrent/repeated call** instead of silently overwriting `self._event_task` and orphaning the previous one (a second call previously leaked a background task that `stop()` could never cancel).

Also fixes a latent bug: `_join_room` is split into a synchronous claim (`_join_room`) and an async resolve (`_complete_room_admission`), so a cancelled or failed `subscribe_room()` call now always rolls the ticket back to `Unadmitted` via a bare `finally` — previously, cancellation during `subscribe_room()` left the room stuck "joined" in `self.rooms` forever.

Six near-duplicate "invoke an optional callback, log-and-swallow on failure" call sites (inconsistent log levels between copies) are consolidated into one `_notify` helper with an explicit level/`exc_info` per call site.

Refs INT-1302.

## Addressed review feedback (amit-gazal-band)

- `_complete_room_admission` now catches `CancelledError` specifically around the `subscribe_room` await and attempts a best-effort unsubscribe before re-raising — a join cancelled after reaching the server previously left a live transport subscription with nothing in the roster to ever clean it up. Strengthened the existing cancellation regression test to assert the unsubscribe actually happens, not just the roster state.
- `_subscribe_rooms` pre-filters rooms a concurrent `room_added` event already admitted, instead of counting `_join_room`'s benign no-op as a failed admission in the results log.
- Pushed back on collapsing `stop()`'s `tracked_room_ids()` + `clear()` into just `clear()`'s return value: `clear()` includes every tracked room regardless of membership (an in-flight `Admitting` one too), which broke `test_stop_does_not_notify_for_a_room_still_admitting` — left as two calls with a comment explaining why.

All 3 review threads resolved.

## Test plan

- [x] `uv sync --extra dev --all-packages`
- [x] `uv run pytest tests/runtime/test_presence.py tests/runtime/test_presence_real_wire.py tests/runtime/test_presence_contacts.py tests/runtime/test_resync.py -v` — 63 passed
- [x] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/ -v` — 5181 passed, 122 skipped
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run pyrefly check` — 0 errors
- [x] New `tests/runtime/test_presence_real_wire.py`: one test proves the one seam a fully-mocked suite can't — a real severed WebSocket connection triggering `BandLink`'s actual reconnect supervisor, firing a real `ReconnectedEvent` through the real event queue, dispatched by `RoomPresence`'s real event-consumer task (every prior reconnect test called `_handle_reconnect()` directly)
- [x] New regression coverage for: cancellation-mid-subscribe rollback (now also asserting the best-effort unsubscribe fires), concurrent double-claim on one room, never-admitted room_removed no-op, `stop()` mid-admission no-op, failed reconnect admission not tracked, stale `room_added` after reconnect admission is a no-op, `auto_subscribe_existing=False` ticket-leak fix, `start()` concurrent-call guard, `_subscribe_rooms` skipping an already-admitted room

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QPgnbSx6F19CiHZ1XsaE5
