### PR TITLE
refactor(websocket): consume band-sdk-core topic-naming (AgentTopicKind)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "band-client-rest==0.0.27",
-    "band-sdk-core==1.1.0",
+    "band-sdk-core==1.2.0",
     "phoenix-channels-python-client>=0.2.2",
     "python-dotenv>=1.2.2",
     "pydantic>=2.0",

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -18,6 +18,7 @@ from phoenix_channels_python_client.phx_messages import PHXMessage
 from band.client.streaming.errors import classify_initial_upgrade_error
 from band.client.streaming.wire import WirePayload
 from band.logging_config import core_issues, trace_context_extra
+from band_sdk_core import AgentTopicKind, chat_room_topic, room_participants_topic
 
 logger = logging.getLogger(__name__)
 
@@ -317,30 +318,6 @@ _PAYLOAD_MODELS: dict[WireEvent, type[WirePayload]] = {
 KNOWN_UNHANDLED_EVENTS = frozenset({WireEvent.EVENT_CREATED})
 
 
-# Single source of truth for the two single-topic agent-channel kinds: every
-# site that builds a topic string (agent_*_topic) or parses one back apart
-# (BandLink._drain_agent_topic_reconciliation) reads these, so a typo in one
-# can't silently diverge from the other.
-AGENT_ROOMS_KIND = "agent_rooms"
-AGENT_CONTACTS_KIND = "agent_contacts"
-
-
-def agent_rooms_topic(agent_id: str) -> str:
-    return f"{AGENT_ROOMS_KIND}:{agent_id}"
-
-
-def agent_contacts_topic(agent_id: str) -> str:
-    return f"{AGENT_CONTACTS_KIND}:{agent_id}"
-
-
-def chat_room_topic(chat_room_id: str) -> str:
-    return f"chat_room:{chat_room_id}"
-
-
-def room_participants_topic(chat_room_id: str) -> str:
-    return f"room_participants:{chat_room_id}"
-
-
 def _initial_reconnect_delay(policy: ReconnectPolicy, attempt: int) -> float:
     delay = min(
         policy.max_delay_s, policy.base_delay_s * (policy.factor ** max(attempt, 0))
@@ -562,7 +539,7 @@ class WebSocketClient:
         Handles terminal ``supersede`` events and, when ``on_control`` is
         provided, ``agent.control`` interrupt/stop/play signals.
         """
-        topic = f"agent_control:{agent_id}"
+        topic = AgentTopicKind.Control.topic(agent_id)
         logger.info("[WebSocket] Subscribing to topic: %s", topic)
 
         handlers: dict[str, Callable[..., Awaitable[None]]] = {
@@ -585,7 +562,7 @@ class WebSocketClient:
         on_room_removed: Callable[[RoomRemovedPayload], Awaitable[None]],
     ):
         """Subscribe to agent rooms topic with async callbacks"""
-        topic = agent_rooms_topic(agent_id)
+        topic = AgentTopicKind.Rooms.topic(agent_id)
         logger.info("[WebSocket] Subscribing to topic: %s", topic)
 
         async def message_handler(message):
@@ -695,13 +672,13 @@ class WebSocketClient:
 
     async def leave_agent_control_channel(self, agent_id: str):
         """Unsubscribe from agent control topic"""
-        topic = f"agent_control:{agent_id}"
+        topic = AgentTopicKind.Control.topic(agent_id)
         logger.info("[WebSocket] Unsubscribing from topic: %s", topic)
         return await self._require_client().unsubscribe_from_topic(topic)
 
     async def leave_agent_rooms_channel(self, agent_id: str):
         """Unsubscribe from agent rooms topic"""
-        topic = agent_rooms_topic(agent_id)
+        topic = AgentTopicKind.Rooms.topic(agent_id)
         logger.info("[WebSocket] Unsubscribing from topic: %s", topic)
         return await self._require_client().unsubscribe_from_topic(topic)
 
@@ -740,7 +717,7 @@ class WebSocketClient:
         on_contact_removed: Callable[[ContactRemovedPayload], Awaitable[None]],
     ):
         """Subscribe to agent contacts topic with async callbacks."""
-        topic = agent_contacts_topic(agent_id)
+        topic = AgentTopicKind.Contacts.topic(agent_id)
         logger.info("[WebSocket] Subscribing to topic: %s", topic)
 
         async def message_handler(message):
@@ -760,7 +737,7 @@ class WebSocketClient:
 
     async def leave_agent_contacts_channel(self, agent_id: str):
         """Unsubscribe from agent contacts topic."""
-        topic = agent_contacts_topic(agent_id)
+        topic = AgentTopicKind.Contacts.topic(agent_id)
         logger.info("[WebSocket] Unsubscribing from topic: %s", topic)
         return await self._require_client().unsubscribe_from_topic(topic)
 

--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -15,17 +15,17 @@ from typing import TYPE_CHECKING
 from band.client.rest import AsyncRestClient
 from band.config.settings import DEFAULT_REST_URL, DEFAULT_WS_URL
 from band.client.streaming import WebSocketClient, WebSocketDisconnectReason
-from band.client.streaming.client import (
-    AGENT_ROOMS_KIND,
-    agent_contacts_topic,
-    agent_rooms_topic,
-    chat_room_topic,
-    room_participants_topic,
-)
 from band.core.types import PlatformConnection
 from band.platform.message_lifecycle import MessageLifecycle
 from band.runtime.types import PlatformMessage
-from band_sdk_core import LeaveOutcome, RoomSubscribeResult, SubscriptionTracker
+from band_sdk_core import (
+    AgentTopicKind,
+    LeaveOutcome,
+    RoomSubscribeResult,
+    SubscriptionTracker,
+    chat_room_topic,
+    room_participants_topic,
+)
 
 from band.platform.event import (
     MessageEvent,
@@ -287,7 +287,7 @@ class BandLink:
         ws = self._ws
 
         await self._subscribe_agent_topic(
-            agent_rooms_topic(agent_id),
+            AgentTopicKind.Rooms.topic(agent_id),
             lambda: ws.join_agent_rooms_channel(
                 agent_id,
                 on_room_added=self._on_room_added,
@@ -409,7 +409,7 @@ class BandLink:
         ws = self._ws
 
         await self._subscribe_agent_topic(
-            agent_contacts_topic(agent_id),
+            AgentTopicKind.Contacts.topic(agent_id),
             lambda: ws.join_agent_contacts_channel(
                 agent_id,
                 on_contact_request_received=self._on_contact_request_received,
@@ -517,7 +517,7 @@ class BandLink:
         ws = self._ws
 
         await self._leave_agent_topic(
-            agent_contacts_topic(self.agent_id),
+            AgentTopicKind.Contacts.topic(self.agent_id),
             lambda: ws.leave_agent_contacts_channel(self.agent_id),
             ws,
         )
@@ -681,7 +681,7 @@ class BandLink:
             kind, _, agent_id = topic.partition(":")
             leave = (
                 ws.leave_agent_rooms_channel
-                if kind == AGENT_ROOMS_KIND
+                if AgentTopicKind.from_wire_name(kind) == AgentTopicKind.Rooms
                 else ws.leave_agent_contacts_channel
             )
             await self._leave_channel(

--- a/uv.lock
+++ b/uv.lock
@@ -762,7 +762,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'dev-crewai'", specifier = ">=0.75.0" },
     { name = "anthropic", marker = "extra == 'dev-parlant'", specifier = ">=0.75.0" },
     { name = "band-client-rest", specifier = "==0.0.27" },
-    { name = "band-sdk-core", specifier = "==1.1.0" },
+    { name = "band-sdk-core", specifier = "==1.2.0" },
     { name = "band-testing-python", marker = "extra == 'dev'", specifier = "==0.1.4" },
     { name = "band-testing-python", marker = "extra == 'dev-crewai'", specifier = "==0.1.4" },
     { name = "band-testing-python", marker = "extra == 'dev-parlant'", specifier = "==0.1.4" },
@@ -905,17 +905,17 @@ provides-extras = ["logging", "desktop", "codex", "opencode", "letta", "pydantic
 
 [[package]]
 name = "band-sdk-core"
-version = "1.1.0"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/99/4123513ce7f45db97abe122069503621ce941de11036d94dbfe0c5f594aa/band_sdk_core-1.1.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:075494b2313a8d31ec99e1d8e1113c55545b11d0bddfa89d5eb24ef7131b2021", size = 451466, upload-time = "2026-08-28T18:01:31.056Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/04/9f905a3bd37812c795bdd7436150eb99ea933d1d7e3c430d64ed58c3ae71/band_sdk_core-1.1.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:cae91469197d0b0efe04a51e61bf15cd1102dc6cacb953329137678f437fc10f", size = 453738, upload-time = "2026-08-28T18:01:32.997Z" },
-    { url = "https://files.pythonhosted.org/packages/77/08/7ca2e2fa9a60ab8a5f985839e47243dc5e78359b40728a44fc9209097aac/band_sdk_core-1.1.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:903e13ac0765a10ec836f060744b309011196812d2257f26c935492c2da44fef", size = 500923, upload-time = "2026-08-28T18:01:34.763Z" },
-    { url = "https://files.pythonhosted.org/packages/82/0d/38a556608c6b9e7fa944ddb07e6976b70d32df6eb87d9a725ced7c18104e/band_sdk_core-1.1.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:eab495e235b9eae07e60d2c64a5c535e67bb1eabc5e7f1d2b0860292922ac266", size = 502903, upload-time = "2026-08-28T18:01:36.268Z" },
-    { url = "https://files.pythonhosted.org/packages/18/06/12d8c7da89e075131abdbe1a0e220213e3adbcfb2a9d06ec13de2a5068bd/band_sdk_core-1.1.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:287e6d316ec661890a8a0bc2abf55aacbe1471717eef74115010fde706a748ae", size = 678478, upload-time = "2026-08-28T18:01:38.093Z" },
-    { url = "https://files.pythonhosted.org/packages/98/ae/7710fd4fbf5eb77ed4e7bafc04c78db313ae6ac806108d8b523f4e2e3797/band_sdk_core-1.1.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:304b2e24608a8085dcae469c914ee812ded944b260884aae2f104d23a7500f94", size = 714831, upload-time = "2026-08-28T18:01:39.973Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/a9/3953748101b972ddec47a8257b874665379c04e13edc07eb26fcb1d51e68/band_sdk_core-1.1.0-cp311-abi3-win_amd64.whl", hash = "sha256:569cb97813ab6459645e544d558a0fab1a29fd796d8f8e8a7f4367c7f09abb2f", size = 325681, upload-time = "2026-08-28T18:01:41.65Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ea/b45c9332d093bca398879297e515f2c01beaaafe9552265cb2292ef99719/band_sdk_core-1.1.0-cp311-abi3-win_arm64.whl", hash = "sha256:711f06c87fd7b4a76291d39032101cdb5bea59ab64c923f8abed227a22d14fad", size = 310511, upload-time = "2026-08-28T18:01:43.063Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fb/479d7e12da34b88b1914452679a9df4d711823450f8ab2e964ee6ab1a54b/band_sdk_core-1.2.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c4068b7778f04c4f40faab8b777d8f553275ca0bec26de58d9105920017a93b2", size = 455236, upload-time = "2026-08-29T04:11:55.347Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0b/ed32223ce6ebc2ee2ce60b8cc18d9860de869223b4b361d3ac516d963d37/band_sdk_core-1.2.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:7ea3b6898b14d971302d1f7293d92a57eb884c78f67624f33936b4c5f3f548bb", size = 457236, upload-time = "2026-08-29T04:11:57.095Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c3/239894bacec18ef8495e70e056f1477299b8ca6919f0821ad30380725090/band_sdk_core-1.2.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f5c07edd23a89de9917f37b1d06614e0230f09c0c70c57422fbcec1c662cf4d", size = 504398, upload-time = "2026-08-29T04:11:58.441Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/b3/217b9f54e17563a9545dd14431d69d092369446b134b9ff038f55c1297be/band_sdk_core-1.2.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:118383385aed43a20009ae66fb3e59058b881dc40cc3ea69aa2ab876619ebd83", size = 505033, upload-time = "2026-08-29T04:11:59.619Z" },
+    { url = "https://files.pythonhosted.org/packages/10/09/64647db0bcfc6da17fe6fc87238b636fe26a51ad2b1eb1adb39fb58ac8d2/band_sdk_core-1.2.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6a4528124b77d478c3ac9a4fab80189df55daafe708ecf26329e83cc917e32f6", size = 681177, upload-time = "2026-08-29T04:12:00.912Z" },
+    { url = "https://files.pythonhosted.org/packages/83/1d/7676f5bd1b8322206e3319142aa8b1a66d25442194a1b2e29cb502a64ce4/band_sdk_core-1.2.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:75930e92a6d660ca35ec740c2b49a91d0c171fd0ee606d091b4e2f7fbb304999", size = 718804, upload-time = "2026-08-29T04:12:02.292Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/86a621527421739c36b49478bafc94afd922305d153e2c6c94d93679ad4e/band_sdk_core-1.2.0-cp311-abi3-win_amd64.whl", hash = "sha256:fa3bbbb58cc8eb32793b0c7ca8573094bed6e0269c2e782cf23a14fc55eb3d81", size = 326813, upload-time = "2026-08-29T04:12:03.728Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b5/5bf5c73fe6c40d3f69852c3ca8f686bb32d4bb81681544cc83032da99c17/band_sdk_core-1.2.0-cp311-abi3-win_arm64.whl", hash = "sha256:95db0836a3cd57a9d23687cd7c03f794edc7cf01f7f64efc26b68eac27718714", size = 310941, upload-time = "2026-08-29T04:12:05.016Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `band-sdk-core` to 1.2.0.
- Replaces `client.py`'s local topic-string builders (`chat_room_topic`, `room_participants_topic`, `agent_rooms_topic`, `agent_contacts_topic`, `AGENT_ROOMS_KIND`) and the two inline `agent_control` topic strings with `band_sdk_core.AgentTopicKind` / `chat_room_topic` / `room_participants_topic`.
- Updates `link.py`'s reconciliation-drain kind comparison to `AgentTopicKind.from_wire_name(kind) == AgentTopicKind.Rooms`.

Stacked on #593 (INT-1326) — this branch is based on that one since it centralized the topic-building functions this PR now replaces. Base will retarget to `main` once #593 merges.

Linear: INT-1336 (step 2/3 — band-sdk-typescript's consumption is step 3, tracked separately).

## Test plan
- [x] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/ -q` — 5169 passed, 122 skipped
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run pyrefly check` — 0 errors