### PR TITLE
feat(websocket): add heartbeat dead-threshold watchdog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ classifiers = [
 
 dependencies = [
     "band-client-rest==0.0.27",
-    "band-sdk-core==0.7.2",
-    "phoenix-channels-python-client>=0.2.2",
+    "band-sdk-core==2.0.0",
+    "phoenix-channels-python-client>=0.3.0",
     "python-dotenv>=1.2.2",
     "pydantic>=2.0",
     "pydantic-settings>=2.0.0",
@@ -353,6 +353,14 @@ markers = [
 # workspace members that aren't root dependencies — every dev-loop command
 # here and in CLAUDE.md uses `--all-packages`.
 members = ["packages/*"]
+
+[tool.uv.sources]
+# TEMPORARY (INT-1323): phoenix-channels-python-client's on_heartbeat_ack
+# callback and close_connection method are not on PyPI yet -- they ship in
+# https://github.com/band-ai/phoenix-channels-python-client/pull/53, still
+# open. Remove this table and the >=0.3.0 pin above once that PR merges and
+# releases; PyPI's next release is what 0.3.0 should resolve to.
+phoenix-channels-python-client = { git = "https://github.com/AlexanderZ-Band/phoenix-channels-python-client", branch = "int-1323-add-shared-heartbeat-interval-dead-threshold-policy-to-band" }
 
 [tool.uv]
 # google-adk pulls opentelemetry-resourcedetector-gcp transitively, whose 1.13.0 is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "band-client-rest==0.0.27",
     "band-sdk-core==2.0.0",
-    "phoenix-channels-python-client>=0.3.0",
+    "phoenix-channels-python-client>=0.2.4",
     "python-dotenv>=1.2.2",
     "pydantic>=2.0",
     "pydantic-settings>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -355,11 +355,11 @@ markers = [
 members = ["packages/*"]
 
 [tool.uv.sources]
-# TEMPORARY (INT-1323): phoenix-channels-python-client's on_heartbeat_ack
-# callback and close_connection method are not on PyPI yet -- they ship in
-# https://github.com/band-ai/phoenix-channels-python-client/pull/53, still
-# open. Remove this table and the >=0.3.0 pin above once that PR merges and
-# releases; PyPI's next release is what 0.3.0 should resolve to.
+# TEMPORARY (INT-1323): on_heartbeat_ack/close_connection aren't released yet
+# (github.com/band-ai/phoenix-channels-python-client/pull/53). The >=0.3.0
+# floor above is a placeholder, not a real version -- don't lower it to
+# resolve to 0.2.3, which lacks these methods and would crash at runtime.
+# Remove this table and set the real floor once PR #53 releases.
 phoenix-channels-python-client = { git = "https://github.com/AlexanderZ-Band/phoenix-channels-python-client", branch = "int-1323-add-shared-heartbeat-interval-dead-threshold-policy-to-band" }
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -354,14 +354,6 @@ markers = [
 # here and in CLAUDE.md uses `--all-packages`.
 members = ["packages/*"]
 
-[tool.uv.sources]
-# TEMPORARY (INT-1323): on_heartbeat_ack/close_connection aren't released yet
-# (github.com/band-ai/phoenix-channels-python-client/pull/54). The >=0.3.0
-# floor above is a placeholder, not a real version -- don't lower it to
-# resolve to 0.2.3, which lacks these methods and would crash at runtime.
-# Remove this table and set the real floor once PR #54 releases.
-phoenix-channels-python-client = { git = "https://github.com/band-ai/phoenix-channels-python-client", branch = "int-1323-add-shared-heartbeat-interval-dead-threshold-policy-to-band" }
-
 [tool.uv]
 # google-adk pulls opentelemetry-resourcedetector-gcp transitively, whose 1.13.0 is
 # yanked and whose only newer release is a pre-release. Steering that resolution is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -356,11 +356,11 @@ members = ["packages/*"]
 
 [tool.uv.sources]
 # TEMPORARY (INT-1323): on_heartbeat_ack/close_connection aren't released yet
-# (github.com/band-ai/phoenix-channels-python-client/pull/53). The >=0.3.0
+# (github.com/band-ai/phoenix-channels-python-client/pull/54). The >=0.3.0
 # floor above is a placeholder, not a real version -- don't lower it to
 # resolve to 0.2.3, which lacks these methods and would crash at runtime.
-# Remove this table and set the real floor once PR #53 releases.
-phoenix-channels-python-client = { git = "https://github.com/AlexanderZ-Band/phoenix-channels-python-client", branch = "int-1323-add-shared-heartbeat-interval-dead-threshold-policy-to-band" }
+# Remove this table and set the real floor once PR #54 releases.
+phoenix-channels-python-client = { git = "https://github.com/band-ai/phoenix-channels-python-client", branch = "int-1323-add-shared-heartbeat-interval-dead-threshold-policy-to-band" }
 
 [tool.uv]
 # google-adk pulls opentelemetry-resourcedetector-gcp transitively, whose 1.13.0 is

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from enum import StrEnum
@@ -18,6 +17,7 @@ from phoenix_channels_python_client.client_types import ReconnectPolicy
 from phoenix_channels_python_client.exceptions import PHXConnectionError
 from phoenix_channels_python_client.phx_messages import PHXMessage
 from band.client.streaming.errors import classify_initial_upgrade_error
+from band.client.streaming.watchdog import HeartbeatWatchdog
 from band.client.streaming.wire import WirePayload
 from band.logging_config import core_issues, trace_context_extra
 
@@ -346,9 +346,7 @@ class WebSocketClient:
         self._on_disconnect = on_disconnect
         self._validation_error_count: int = 0
         self._last_disconnect_reason: WebSocketDisconnectReason | None = None
-        self._session_policy = session_policy or SessionPolicy.default()
-        self._watchdog_task: asyncio.Task[None] | None = None
-        self._watchdog_deadline: float = 0.0
+        self._watchdog = HeartbeatWatchdog(session_policy or SessionPolicy.default())
 
     @property
     def validation_error_count(self) -> int:
@@ -374,11 +372,6 @@ class WebSocketClient:
             raise RuntimeError("WebSocket client is not connected")
         return self.client
 
-    def _reset_watchdog_deadline(self) -> None:
-        self._watchdog_deadline = (
-            asyncio.get_running_loop().time() + self._session_policy.dead_threshold_s
-        )
-
     async def _handle_reconnect(self) -> None:
         """Reset the watchdog deadline on reconnect, then forward to the
         caller's own on_reconnect callback (if any).
@@ -387,59 +380,9 @@ class WebSocketClient:
         socket existed and expire before its first heartbeat_interval_s
         cycle completes, force-closing a healthy connection.
         """
-        self._reset_watchdog_deadline()
+        self._watchdog.reset_deadline()
         if self._on_reconnect is not None:
             await self._on_reconnect()
-
-    async def _watchdog_loop(self, client: PHXChannelsClient) -> None:
-        """Force-close ``client`` once dead_threshold_s passes with no ack.
-
-        Takes the specific `PHXChannelsClient` this task watches as an
-        argument (rather than reading ``self.client``) so a stale watchdog
-        left over from a superseded initial-connect attempt can never act on
-        whatever instance `self.client` has since been reassigned to.
-        """
-        while True:
-            await self._sleep_until_watchdog_deadline()
-            await self._force_close_if_stale(client)
-
-    async def _sleep_until_watchdog_deadline(self) -> None:
-        """Sleep until ``self._watchdog_deadline``, re-reading it after each
-        wake so an ack (which pushes it forward via `_reset_watchdog_deadline`)
-        reschedules the sleep instead of firing early."""
-        while True:
-            remaining = self._watchdog_deadline - asyncio.get_running_loop().time()
-            if remaining <= 0:
-                return
-            await asyncio.sleep(remaining)
-
-    async def _force_close_if_stale(self, client: PHXChannelsClient) -> None:
-        """Force-close ``client`` if it still has a live connection.
-
-        ``close_connection`` failures are caught and logged -- this is the
-        only watchdog for the rest of `client`'s lifetime, so it must not
-        die silently on one bad close.
-        """
-        self._reset_watchdog_deadline()
-        if client.connection is None:
-            # Already disconnected (e.g. mid initial-connect or backoff);
-            # nothing to force-close, and nothing to warn about.
-            return
-        logger.warning(
-            "[WebSocket] No heartbeat ack within %.2fs; forcing reconnect",
-            self._session_policy.dead_threshold_s,
-        )
-        try:
-            await client.close_connection("Heartbeat dead-threshold exceeded")
-        except Exception:
-            logger.exception("[WebSocket] Failed to force-close dead connection")
-
-    async def _cancel_watchdog(self) -> None:
-        if self._watchdog_task is not None and not self._watchdog_task.done():
-            self._watchdog_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._watchdog_task
-        self._watchdog_task = None
 
     async def __aenter__(self):
         """Create and enter the PHXChannelsClient context"""
@@ -450,10 +393,10 @@ class WebSocketClient:
                 self.api_key,
                 protocol_version=PhoenixChannelsProtocolVersion.V2,
                 auto_reconnect=False,
-                heartbeat_interval_s=self._session_policy.heartbeat_interval_s,
+                heartbeat_interval_s=self._watchdog.policy.heartbeat_interval_s,
                 on_reconnect=self._handle_reconnect,
                 on_disconnect=self._on_disconnect,
-                on_heartbeat_ack=self._reset_watchdog_deadline,
+                on_heartbeat_ack=self._watchdog.reset_deadline,
                 # Also send the key as an x-api-key handshake header. Under
                 # proxy-managed sandbox custody the host-side proxy replaces the
                 # sentinel in this header (it can't touch the URL query), and the
@@ -485,17 +428,14 @@ class WebSocketClient:
                 await asyncio.sleep(delay)
             else:
                 self.client.auto_reconnect = True
-                self._reset_watchdog_deadline()
-                self._watchdog_task = asyncio.create_task(
-                    self._watchdog_loop(self.client)
-                )
+                self._watchdog.start(self.client)
                 return self
 
         raise RuntimeError("WebSocket client failed to connect")
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Exit the PHXChannelsClient context"""
-        await self._cancel_watchdog()
+        await self._watchdog.stop()
         if self.client:
             await self.client.__aexit__(exc_type, exc_val, exc_tb)
 

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -8,6 +8,7 @@ import logging
 import random
 from typing import Any, Literal
 
+from band_sdk_core import SessionPolicy
 from phoenix_channels_python_client.client import (
     PHXChannelsClient,
     PhoenixChannelsProtocolVersion,
@@ -334,6 +335,7 @@ class WebSocketClient:
         agent_id: str | None = None,
         on_reconnect: Callable[[], Awaitable[None]] | None = None,
         on_disconnect: Callable[[Exception | None], Awaitable[None]] | None = None,
+        session_policy: SessionPolicy | None = None,
     ):
         self.ws_url = ws_url
         self.api_key = api_key
@@ -343,6 +345,9 @@ class WebSocketClient:
         self._on_disconnect = on_disconnect
         self._validation_error_count: int = 0
         self._last_disconnect_reason: WebSocketDisconnectReason | None = None
+        self._session_policy = session_policy or SessionPolicy.default()
+        self._watchdog_task: asyncio.Task[None] | None = None
+        self._watchdog_deadline: float = 0.0
 
     @property
     def validation_error_count(self) -> int:
@@ -368,6 +373,50 @@ class WebSocketClient:
             raise RuntimeError("WebSocket client is not connected")
         return self.client
 
+    def _reset_watchdog_deadline(self) -> None:
+        self._watchdog_deadline = (
+            asyncio.get_running_loop().time() + self._session_policy.dead_threshold_s
+        )
+
+    def _on_heartbeat_ack(self) -> None:
+        self._reset_watchdog_deadline()
+
+    async def _watchdog_loop(self, client: PHXChannelsClient) -> None:
+        """Force-close ``client`` once dead_threshold_s passes with no ack.
+
+        Takes the specific `PHXChannelsClient` this task watches as an
+        argument (rather than reading ``self.client``) so a stale watchdog
+        left over from a superseded initial-connect attempt can never act on
+        whatever instance `self.client` has since been reassigned to.
+
+        Reads ``self._watchdog_deadline`` fresh each iteration so an ack
+        (which pushes it forward from `_on_heartbeat_ack`) reschedules the
+        sleep instead of firing early.
+        """
+        while True:
+            deadline = self._watchdog_deadline
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+                continue
+            if self._watchdog_deadline != deadline:
+                continue
+            logger.warning(
+                "[WebSocket] No heartbeat ack within %.2fs; forcing reconnect",
+                self._session_policy.dead_threshold_s,
+            )
+            self._reset_watchdog_deadline()
+            await client.close_connection("Heartbeat dead-threshold exceeded")
+
+    async def _cancel_watchdog(self) -> None:
+        if self._watchdog_task is not None and not self._watchdog_task.done():
+            self._watchdog_task.cancel()
+            try:
+                await self._watchdog_task
+            except asyncio.CancelledError:
+                pass
+        self._watchdog_task = None
+
     async def __aenter__(self):
         """Create and enter the PHXChannelsClient context"""
         policy = ReconnectPolicy()
@@ -377,8 +426,10 @@ class WebSocketClient:
                 self.api_key,
                 protocol_version=PhoenixChannelsProtocolVersion.V2,
                 auto_reconnect=False,
+                heartbeat_interval_s=self._session_policy.heartbeat_interval_s,
                 on_reconnect=self._on_reconnect,
                 on_disconnect=self._on_disconnect,
+                on_heartbeat_ack=self._on_heartbeat_ack,
                 # Also send the key as an x-api-key handshake header. Under
                 # proxy-managed sandbox custody the host-side proxy replaces the
                 # sentinel in this header (it can't touch the URL query), and the
@@ -389,9 +440,12 @@ class WebSocketClient:
             )
             if self.agent_id:
                 self.client.channel_socket_url += f"&agent_id={self.agent_id}"
+            self._reset_watchdog_deadline()
+            self._watchdog_task = asyncio.create_task(self._watchdog_loop(self.client))
             try:
                 await self.client.__aenter__()
             except Exception as exc:
+                await self._cancel_watchdog()
                 upgrade_error = await classify_initial_upgrade_error(
                     exc, self.client.channel_socket_url
                 )
@@ -416,6 +470,7 @@ class WebSocketClient:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Exit the PHXChannelsClient context"""
+        await self._cancel_watchdog()
         if self.client:
             await self.client.__aexit__(exc_type, exc_val, exc_tb)
 

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -379,6 +379,18 @@ class WebSocketClient:
             asyncio.get_running_loop().time() + self._session_policy.dead_threshold_s
         )
 
+    async def _handle_reconnect(self) -> None:
+        """Reset the watchdog deadline on reconnect, then forward to the
+        caller's own on_reconnect callback (if any).
+
+        Without this, a reconnect can inherit a deadline set before the new
+        socket existed and expire before its first heartbeat_interval_s
+        cycle completes, force-closing a healthy connection.
+        """
+        self._reset_watchdog_deadline()
+        if self._on_reconnect is not None:
+            await self._on_reconnect()
+
     async def _watchdog_loop(self, client: PHXChannelsClient) -> None:
         """Force-close ``client`` once dead_threshold_s passes with no ack.
 
@@ -439,7 +451,7 @@ class WebSocketClient:
                 protocol_version=PhoenixChannelsProtocolVersion.V2,
                 auto_reconnect=False,
                 heartbeat_interval_s=self._session_policy.heartbeat_interval_s,
-                on_reconnect=self._on_reconnect,
+                on_reconnect=self._handle_reconnect,
                 on_disconnect=self._on_disconnect,
                 on_heartbeat_ack=self._reset_watchdog_deadline,
                 # Also send the key as an x-api-key handshake header. Under

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -391,22 +391,28 @@ class WebSocketClient:
 
         Reads ``self._watchdog_deadline`` fresh each iteration so an ack
         (which pushes it forward from `_on_heartbeat_ack`) reschedules the
-        sleep instead of firing early.
+        sleep instead of firing early. ``close_connection`` failures are
+        caught and logged -- this loop is the only watchdog for the rest of
+        `client`'s lifetime, so it must not die silently on one bad close.
         """
         while True:
-            deadline = self._watchdog_deadline
-            remaining = deadline - asyncio.get_running_loop().time()
+            remaining = self._watchdog_deadline - asyncio.get_running_loop().time()
             if remaining > 0:
                 await asyncio.sleep(remaining)
                 continue
-            if self._watchdog_deadline != deadline:
+            self._reset_watchdog_deadline()
+            if client.connection is None:
+                # Already disconnected (e.g. mid initial-connect or backoff);
+                # nothing to force-close, and nothing to warn about.
                 continue
             logger.warning(
                 "[WebSocket] No heartbeat ack within %.2fs; forcing reconnect",
                 self._session_policy.dead_threshold_s,
             )
-            self._reset_watchdog_deadline()
-            await client.close_connection("Heartbeat dead-threshold exceeded")
+            try:
+                await client.close_connection("Heartbeat dead-threshold exceeded")
+            except Exception:
+                logger.exception("[WebSocket] Failed to force-close dead connection")
 
     async def _cancel_watchdog(self) -> None:
         if self._watchdog_task is not None and not self._watchdog_task.done():

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from enum import StrEnum
@@ -378,9 +379,6 @@ class WebSocketClient:
             asyncio.get_running_loop().time() + self._session_policy.dead_threshold_s
         )
 
-    def _on_heartbeat_ack(self) -> None:
-        self._reset_watchdog_deadline()
-
     async def _watchdog_loop(self, client: PHXChannelsClient) -> None:
         """Force-close ``client`` once dead_threshold_s passes with no ack.
 
@@ -388,39 +386,47 @@ class WebSocketClient:
         argument (rather than reading ``self.client``) so a stale watchdog
         left over from a superseded initial-connect attempt can never act on
         whatever instance `self.client` has since been reassigned to.
-
-        Reads ``self._watchdog_deadline`` fresh each iteration so an ack
-        (which pushes it forward from `_on_heartbeat_ack`) reschedules the
-        sleep instead of firing early. ``close_connection`` failures are
-        caught and logged -- this loop is the only watchdog for the rest of
-        `client`'s lifetime, so it must not die silently on one bad close.
         """
         while True:
+            await self._sleep_until_watchdog_deadline()
+            await self._force_close_if_stale(client)
+
+    async def _sleep_until_watchdog_deadline(self) -> None:
+        """Sleep until ``self._watchdog_deadline``, re-reading it after each
+        wake so an ack (which pushes it forward via `_reset_watchdog_deadline`)
+        reschedules the sleep instead of firing early."""
+        while True:
             remaining = self._watchdog_deadline - asyncio.get_running_loop().time()
-            if remaining > 0:
-                await asyncio.sleep(remaining)
-                continue
-            self._reset_watchdog_deadline()
-            if client.connection is None:
-                # Already disconnected (e.g. mid initial-connect or backoff);
-                # nothing to force-close, and nothing to warn about.
-                continue
-            logger.warning(
-                "[WebSocket] No heartbeat ack within %.2fs; forcing reconnect",
-                self._session_policy.dead_threshold_s,
-            )
-            try:
-                await client.close_connection("Heartbeat dead-threshold exceeded")
-            except Exception:
-                logger.exception("[WebSocket] Failed to force-close dead connection")
+            if remaining <= 0:
+                return
+            await asyncio.sleep(remaining)
+
+    async def _force_close_if_stale(self, client: PHXChannelsClient) -> None:
+        """Force-close ``client`` if it still has a live connection.
+
+        ``close_connection`` failures are caught and logged -- this is the
+        only watchdog for the rest of `client`'s lifetime, so it must not
+        die silently on one bad close.
+        """
+        self._reset_watchdog_deadline()
+        if client.connection is None:
+            # Already disconnected (e.g. mid initial-connect or backoff);
+            # nothing to force-close, and nothing to warn about.
+            return
+        logger.warning(
+            "[WebSocket] No heartbeat ack within %.2fs; forcing reconnect",
+            self._session_policy.dead_threshold_s,
+        )
+        try:
+            await client.close_connection("Heartbeat dead-threshold exceeded")
+        except Exception:
+            logger.exception("[WebSocket] Failed to force-close dead connection")
 
     async def _cancel_watchdog(self) -> None:
         if self._watchdog_task is not None and not self._watchdog_task.done():
             self._watchdog_task.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 await self._watchdog_task
-            except asyncio.CancelledError:
-                pass
         self._watchdog_task = None
 
     async def __aenter__(self):
@@ -435,7 +441,7 @@ class WebSocketClient:
                 heartbeat_interval_s=self._session_policy.heartbeat_interval_s,
                 on_reconnect=self._on_reconnect,
                 on_disconnect=self._on_disconnect,
-                on_heartbeat_ack=self._on_heartbeat_ack,
+                on_heartbeat_ack=self._reset_watchdog_deadline,
                 # Also send the key as an x-api-key handshake header. Under
                 # proxy-managed sandbox custody the host-side proxy replaces the
                 # sentinel in this header (it can't touch the URL query), and the
@@ -446,12 +452,9 @@ class WebSocketClient:
             )
             if self.agent_id:
                 self.client.channel_socket_url += f"&agent_id={self.agent_id}"
-            self._reset_watchdog_deadline()
-            self._watchdog_task = asyncio.create_task(self._watchdog_loop(self.client))
             try:
                 await self.client.__aenter__()
             except Exception as exc:
-                await self._cancel_watchdog()
                 upgrade_error = await classify_initial_upgrade_error(
                     exc, self.client.channel_socket_url
                 )
@@ -470,6 +473,10 @@ class WebSocketClient:
                 await asyncio.sleep(delay)
             else:
                 self.client.auto_reconnect = True
+                self._reset_watchdog_deadline()
+                self._watchdog_task = asyncio.create_task(
+                    self._watchdog_loop(self.client)
+                )
                 return self
 
         raise RuntimeError("WebSocket client failed to connect")

--- a/src/band/client/streaming/watchdog.py
+++ b/src/band/client/streaming/watchdog.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+
+from band_sdk_core import SessionPolicy
+from phoenix_channels_python_client.client import PHXChannelsClient
+
+logger = logging.getLogger(__name__)
+
+
+class HeartbeatWatchdog:
+    """Force-closes a connection once dead_threshold_s passes with no
+    heartbeat ack, so a silently dead socket gets reconnected instead of
+    sitting idle."""
+
+    def __init__(self, policy: SessionPolicy) -> None:
+        self.policy = policy
+        self._deadline: float = 0.0
+        self._task: asyncio.Task[None] | None = None
+
+    def reset_deadline(self) -> None:
+        self._deadline = (
+            asyncio.get_running_loop().time() + self.policy.dead_threshold_s
+        )
+
+    def start(self, client: PHXChannelsClient) -> None:
+        """Begin watching `client`. Takes it as an argument (rather than
+        reading it from the caller later) so a stale watchdog left over
+        from a superseded initial-connect attempt can never act on
+        whatever instance the caller has since moved on to."""
+        self.reset_deadline()
+        self._task = asyncio.create_task(self._loop(client))
+
+    async def stop(self) -> None:
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+        self._task = None
+
+    async def _loop(self, client: PHXChannelsClient) -> None:
+        while True:
+            await self._sleep_until_deadline()
+            await self._force_close_if_stale(client)
+
+    async def _sleep_until_deadline(self) -> None:
+        """Sleep until ``self._deadline``, re-reading it after each wake so
+        an ack (which pushes it forward via `reset_deadline`) reschedules
+        the sleep instead of firing early."""
+        while True:
+            remaining = self._deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                return
+            await asyncio.sleep(remaining)
+
+    async def _force_close_if_stale(self, client: PHXChannelsClient) -> None:
+        """Force-close ``client`` if it still has a live connection.
+
+        ``close_connection`` failures are caught and logged -- this is the
+        only watchdog for the rest of `client`'s lifetime, so it must not
+        die silently on one bad close.
+        """
+        self.reset_deadline()
+        if client.connection is None:
+            # Already disconnected (e.g. mid initial-connect or backoff);
+            # nothing to force-close, and nothing to warn about.
+            return
+        logger.warning(
+            "[WebSocket] No heartbeat ack within %.2fs; forcing reconnect",
+            self.policy.dead_threshold_s,
+        )
+        try:
+            await client.close_connection("Heartbeat dead-threshold exceeded")
+        except Exception:
+            logger.exception("[WebSocket] Failed to force-close dead connection")

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -1125,6 +1125,7 @@ async def test_stale_watchdog_cannot_close_a_superseded_connection():
 
     class FakePHXClient:
         def __init__(self) -> None:
+            self.connection = object()  # watchdog only closes a live connection
             self.close_calls: list[str] = []
 
         async def close_connection(self, reason: str) -> None:
@@ -1153,3 +1154,63 @@ async def test_stale_watchdog_cannot_close_a_superseded_connection():
         reason == "Heartbeat dead-threshold exceeded" for reason in first.close_calls
     )
     assert second.close_calls == []
+
+
+async def test_watchdog_survives_a_close_connection_failure():
+    """A `close_connection` failure must not kill the watchdog task -- it is
+    the only monitor for the rest of this client's lifetime, so one bad
+    close must not silently disable dead-threshold enforcement forever."""
+
+    class FlakyThenFakePHXClient:
+        def __init__(self) -> None:
+            self.connection = object()
+            self.close_calls: list[str] = []
+
+        async def close_connection(self, reason: str) -> None:
+            self.close_calls.append(reason)
+            if len(self.close_calls) == 1:
+                raise RuntimeError("close boom")
+
+    policy = _fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
+    client = WebSocketClient(
+        "ws://localhost", "test-key", "agent-123", session_policy=policy
+    )
+    fake = FlakyThenFakePHXClient()
+    client._reset_watchdog_deadline()
+    watchdog = asyncio.create_task(client._watchdog_loop(fake))
+
+    await asyncio.sleep(0.2)  # comfortably past two dead_threshold_s windows
+    watchdog.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await watchdog
+
+    assert len(fake.close_calls) >= 2
+
+
+async def test_watchdog_does_not_warn_or_close_while_already_disconnected():
+    """No live connection to force-close means nothing to warn about either
+    -- an extended reconnect backoff must not spam misleading 'forcing
+    reconnect' warnings for a connection that's already down."""
+
+    class DisconnectedFakePHXClient:
+        def __init__(self) -> None:
+            self.connection = None
+            self.close_calls: list[str] = []
+
+        async def close_connection(self, reason: str) -> None:
+            self.close_calls.append(reason)
+
+    policy = _fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
+    client = WebSocketClient(
+        "ws://localhost", "test-key", "agent-123", session_policy=policy
+    )
+    fake = DisconnectedFakePHXClient()
+    client._reset_watchdog_deadline()
+    watchdog = asyncio.create_task(client._watchdog_loop(fake))
+
+    await asyncio.sleep(0.15)
+    watchdog.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await watchdog
+
+    assert fake.close_calls == []

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -8,6 +8,8 @@ errors and skipping malformed events, rather than crashing the connection.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import json
 import logging
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
@@ -16,6 +18,7 @@ from unittest.mock import AsyncMock
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
+from band_sdk_core import SessionPolicy
 from opentelemetry.sdk.trace import TracerProvider
 from phoenix_channels_python_client.exceptions import PHXConnectionError
 from websockets.asyncio.server import ServerConnection, serve
@@ -984,3 +987,169 @@ async def test_cancelled_error_propagates_through_callback():
         await client._handle_events(
             MockMessage(), {"message_created": cancelling_callback}
         )
+
+
+# --- Heartbeat dead-threshold watchdog tests (INT-1323) ---
+
+
+def _fast_session_policy(
+    *, heartbeat_interval_s: float, dead_threshold_s: float
+) -> SessionPolicy:
+    """A SessionPolicy with real reconnect-backoff defaults (mirroring
+    SessionPolicy.default()) but a fast heartbeat/dead-threshold pair, so
+    watchdog tests run in real fractional seconds instead of production's
+    30s/60s."""
+    return SessionPolicy(
+        {
+            "base_delay_s": 1.0,
+            "factor": 2.0,
+            "max_delay_s": 30.0,
+            "stable_reset_s": 60.0,
+            "rapid_disconnect_uptime_s": 10.0,
+            "rapid_window_s": 300.0,
+            "rapid_first_min_delay_s": 1.0,
+            "rapid_second_min_delay_s": 5.0,
+            "rapid_cooldown_base_s": 10.0,
+            "rapid_cooldown_step_s": 10.0,
+            "rapid_cooldown_max_s": 60.0,
+            "rapid_threshold": 10,
+            "heartbeat_interval_s": heartbeat_interval_s,
+            "dead_threshold_s": dead_threshold_s,
+        }
+    )
+
+
+@asynccontextmanager
+async def phoenix_peer(*, ack_heartbeats: bool = True):
+    """In-process peer that completes the WS upgrade and, when
+    ack_heartbeats, replies to every V2 heartbeat frame (topic "phoenix")
+    with a matching phx_reply -- a real wire heartbeat round-trip drives
+    on_heartbeat_ack, nothing about it is mocked. Yields ``(ws_url,
+    connected)``, where ``connected`` resolves with the first accepted
+    ServerConnection.
+    """
+    connected: asyncio.Future[ServerConnection] = (
+        asyncio.get_running_loop().create_future()
+    )
+
+    async def handler(conn: ServerConnection) -> None:
+        if not connected.done():
+            connected.set_result(conn)
+        async for raw in conn:
+            if not ack_heartbeats:
+                continue
+            join_ref, ref, topic, _event, _payload = json.loads(raw)
+            if topic == "phoenix":
+                await conn.send(
+                    json.dumps(
+                        [
+                            join_ref,
+                            ref,
+                            "phoenix",
+                            "phx_reply",
+                            {"status": "ok", "response": {}},
+                        ]
+                    )
+                )
+
+    async with serve(handler, "127.0.0.1", 0) as server:
+        port = next(iter(server.sockets)).getsockname()[1]
+        yield f"ws://127.0.0.1:{port}/socket/websocket", connected
+
+
+async def test_watchdog_ack_keeps_connection_alive_across_heartbeat_cycles():
+    """A real heartbeat/ack round-trip resets the watchdog deadline each
+    cycle, so the connection survives well past a single dead_threshold_s
+    window without the watchdog ever tripping."""
+    policy = _fast_session_policy(heartbeat_interval_s=0.05, dead_threshold_s=0.15)
+    async with phoenix_peer() as (ws_url, connected):
+        async with WebSocketClient(
+            ws_url, "test-key", "agent-123", session_policy=policy
+        ) as client:
+            await asyncio.wait_for(connected, timeout=5)
+            await asyncio.sleep(0.4)
+            assert client.client is not None
+            assert client.client.connection is not None
+            assert client.client.connection.close_code is None
+
+
+async def test_watchdog_forces_close_and_reconnect_when_ack_withheld():
+    """A withheld ack forces close_connection at (approximately)
+    dead_threshold_s, and the forced close flows into the client's own
+    reconnect path -- on_reconnect fires once the new connection lands."""
+    policy = _fast_session_policy(heartbeat_interval_s=0.05, dead_threshold_s=0.15)
+    reconnected = asyncio.Event()
+
+    async def on_reconnect() -> None:
+        reconnected.set()
+
+    async with phoenix_peer(ack_heartbeats=False) as (ws_url, connected):
+        async with WebSocketClient(
+            ws_url,
+            "test-key",
+            "agent-123",
+            on_reconnect=on_reconnect,
+            session_policy=policy,
+        ):
+            await asyncio.wait_for(connected, timeout=5)
+            start = asyncio.get_running_loop().time()
+            await asyncio.wait_for(reconnected.wait(), timeout=5)
+            elapsed = asyncio.get_running_loop().time() - start
+
+    assert elapsed >= policy.dead_threshold_s * 0.5
+
+
+async def test_watchdog_task_cancelled_cleanly_on_aexit():
+    """__aexit__ cancels the watchdog task -- no dangling task survives
+    shutdown."""
+    policy = _fast_session_policy(heartbeat_interval_s=0.05, dead_threshold_s=5.0)
+    async with phoenix_peer() as (ws_url, connected):
+        client = WebSocketClient(ws_url, "test-key", "agent-123", session_policy=policy)
+        async with client:
+            await asyncio.wait_for(connected, timeout=5)
+            watchdog_task = client._watchdog_task
+            assert watchdog_task is not None
+            assert not watchdog_task.done()
+
+    assert watchdog_task.done()
+    assert watchdog_task.cancelled()
+    assert client._watchdog_task is None
+
+
+async def test_stale_watchdog_cannot_close_a_superseded_connection():
+    """A watchdog task stays bound to the specific PHXChannelsClient it was
+    created for. If it fires late -- after `self.client` has already moved
+    on to a newer instance, as happens when an initial-connect attempt is
+    superseded by the next one in `__aenter__`'s retry loop -- it must only
+    ever act on its own (stale) instance, never the replacement."""
+
+    class FakePHXClient:
+        def __init__(self) -> None:
+            self.close_calls: list[str] = []
+
+        async def close_connection(self, reason: str) -> None:
+            self.close_calls.append(reason)
+
+    policy = _fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
+    client = WebSocketClient(
+        "ws://localhost", "test-key", "agent-123", session_policy=policy
+    )
+    first, second = FakePHXClient(), FakePHXClient()
+
+    client.client = first
+    client._reset_watchdog_deadline()
+    watchdog = asyncio.create_task(client._watchdog_loop(first))
+    client.client = second  # the retry loop moving on to the next attempt
+
+    await asyncio.sleep(
+        0.2
+    )  # comfortably past dead_threshold_s (may trip more than once)
+    watchdog.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await watchdog
+
+    assert first.close_calls
+    assert all(
+        reason == "Heartbeat dead-threshold exceeded" for reason in first.close_calls
+    )
+    assert second.close_calls == []

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -1061,13 +1061,13 @@ async def test_watchdog_ack_keeps_connection_alive_across_heartbeat_cycles():
     """A real heartbeat/ack round-trip resets the watchdog deadline each
     cycle, so the connection survives well past a single dead_threshold_s
     window without the watchdog ever tripping."""
-    policy = _fast_session_policy(heartbeat_interval_s=0.05, dead_threshold_s=0.15)
+    policy = _fast_session_policy(heartbeat_interval_s=0.15, dead_threshold_s=0.4)
     async with phoenix_peer() as (ws_url, connected):
         async with WebSocketClient(
             ws_url, "test-key", "agent-123", session_policy=policy
         ) as client:
             await asyncio.wait_for(connected, timeout=5)
-            await asyncio.sleep(0.4)
+            await asyncio.sleep(1.0)
             assert client.client is not None
             assert client.client.connection is not None
             assert client.client.connection.close_code is None
@@ -1077,7 +1077,7 @@ async def test_watchdog_forces_close_and_reconnect_when_ack_withheld():
     """A withheld ack forces close_connection at (approximately)
     dead_threshold_s, and the forced close flows into the client's own
     reconnect path -- on_reconnect fires once the new connection lands."""
-    policy = _fast_session_policy(heartbeat_interval_s=0.05, dead_threshold_s=0.15)
+    policy = _fast_session_policy(heartbeat_interval_s=0.15, dead_threshold_s=0.4)
     reconnected = asyncio.Event()
 
     async def on_reconnect() -> None:
@@ -1209,6 +1209,45 @@ async def test_watchdog_does_not_warn_or_close_while_already_disconnected():
     watchdog = asyncio.create_task(client._watchdog_loop(fake))
 
     await asyncio.sleep(0.15)
+    watchdog.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await watchdog
+
+    assert fake.close_calls == []
+
+
+async def test_reconnect_resets_watchdog_deadline_so_a_fresh_socket_survives():
+    """A reconnect must reset the watchdog deadline immediately -- otherwise
+    it can inherit a stale deadline (from the disconnected-state polling
+    above) that expires before the fresh socket's first heartbeat cycle,
+    force-closing a healthy connection."""
+
+    class FakePHXClient:
+        def __init__(self) -> None:
+            self.connection = object()
+            self.close_calls: list[str] = []
+
+        async def close_connection(self, reason: str) -> None:
+            self.close_calls.append(reason)
+
+    policy = _fast_session_policy(heartbeat_interval_s=0.1, dead_threshold_s=0.12)
+    client = WebSocketClient(
+        "ws://localhost", "test-key", "agent-123", session_policy=policy
+    )
+    fake = FakePHXClient()
+
+    # The disconnected-state watchdog polling has already scheduled a trip
+    # unrelated to when reconnect actually completes.
+    client._reset_watchdog_deadline()
+    await asyncio.sleep(policy.dead_threshold_s * 0.8)
+
+    # Reconnect completes just before that already-scheduled deadline.
+    await client._handle_reconnect()
+
+    watchdog = asyncio.create_task(client._watchdog_loop(fake))
+    # Wait less than heartbeat_interval_s: the fresh connection hasn't had
+    # time to send or ack its first heartbeat yet.
+    await asyncio.sleep(policy.heartbeat_interval_s * 0.5)
     watchdog.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await watchdog

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -401,6 +401,9 @@ async def test_aenter_retries_unclassified_initial_connection_errors(monkeypatch
                 raise PHXConnectionError("temporary network failure")
             return self
 
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
     async def no_upgrade_error(exc, websocket_url):
         return None
 
@@ -422,6 +425,10 @@ async def test_aenter_retries_unclassified_initial_connection_errors(monkeypatch
     assert attempts == 3
     assert len(sleep_delays) == 2
     assert client.client.auto_reconnect is True
+
+    # fake_sleep never advances the clock; an un-stopped watchdog's
+    # deadline-check loop would spin on it with no real yield point.
+    await client.__aexit__(None, None, None)
 
 
 async def test_aenter_reraises_unrecognized_upgrade_error(monkeypatch):

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -374,6 +374,9 @@ async def test_aenter_restores_reconnect_after_successful_initial_connect(monkey
         async def __aenter__(self):
             return self
 
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
     monkeypatch.setattr(
         "band.client.streaming.client.PHXChannelsClient", SuccessfulPHXClient
     )
@@ -383,6 +386,11 @@ async def test_aenter_restores_reconnect_after_successful_initial_connect(monkey
 
     assert init_kwargs["auto_reconnect"] is False
     assert client.client.auto_reconnect is True
+
+    # A successful __aenter__ starts the watchdog against this double, which
+    # has no real `.connection` -- __aexit__ stops it before returning so it
+    # can never fire `_force_close_if_stale` against a torn-down test.
+    await client.__aexit__(None, None, None)
 
 
 async def test_aenter_retries_unclassified_initial_connection_errors(monkeypatch):

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -8,7 +8,6 @@ errors and skipping malformed events, rather than crashing the connection.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import logging
 from contextlib import asynccontextmanager
@@ -1100,156 +1099,20 @@ async def test_watchdog_forces_close_and_reconnect_when_ack_withheld():
 
 
 async def test_watchdog_task_cancelled_cleanly_on_aexit():
-    """__aexit__ cancels the watchdog task -- no dangling task survives
-    shutdown."""
+    """__aexit__ stops the watchdog -- no dangling task survives shutdown.
+
+    (HeartbeatWatchdog's own cancellation behavior is covered directly in
+    test_watchdog.py; this test only checks WebSocketClient wires __aexit__
+    to it.)"""
     policy = _fast_session_policy(heartbeat_interval_s=0.05, dead_threshold_s=5.0)
     async with phoenix_peer() as (ws_url, connected):
         client = WebSocketClient(ws_url, "test-key", "agent-123", session_policy=policy)
         async with client:
             await asyncio.wait_for(connected, timeout=5)
-            watchdog_task = client._watchdog_task
+            watchdog_task = client._watchdog._task
             assert watchdog_task is not None
             assert not watchdog_task.done()
 
     assert watchdog_task.done()
     assert watchdog_task.cancelled()
-    assert client._watchdog_task is None
-
-
-async def test_stale_watchdog_cannot_close_a_superseded_connection():
-    """A watchdog task stays bound to the specific PHXChannelsClient it was
-    created for. If it fires late -- after `self.client` has already moved
-    on to a newer instance, as happens when an initial-connect attempt is
-    superseded by the next one in `__aenter__`'s retry loop -- it must only
-    ever act on its own (stale) instance, never the replacement."""
-
-    class FakePHXClient:
-        def __init__(self) -> None:
-            self.connection = object()  # watchdog only closes a live connection
-            self.close_calls: list[str] = []
-
-        async def close_connection(self, reason: str) -> None:
-            self.close_calls.append(reason)
-
-    policy = _fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
-    client = WebSocketClient(
-        "ws://localhost", "test-key", "agent-123", session_policy=policy
-    )
-    first, second = FakePHXClient(), FakePHXClient()
-
-    client.client = first
-    client._reset_watchdog_deadline()
-    watchdog = asyncio.create_task(client._watchdog_loop(first))
-    client.client = second  # the retry loop moving on to the next attempt
-
-    await asyncio.sleep(
-        0.2
-    )  # comfortably past dead_threshold_s (may trip more than once)
-    watchdog.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await watchdog
-
-    assert first.close_calls
-    assert all(
-        reason == "Heartbeat dead-threshold exceeded" for reason in first.close_calls
-    )
-    assert second.close_calls == []
-
-
-async def test_watchdog_survives_a_close_connection_failure():
-    """A `close_connection` failure must not kill the watchdog task -- it is
-    the only monitor for the rest of this client's lifetime, so one bad
-    close must not silently disable dead-threshold enforcement forever."""
-
-    class FlakyThenFakePHXClient:
-        def __init__(self) -> None:
-            self.connection = object()
-            self.close_calls: list[str] = []
-
-        async def close_connection(self, reason: str) -> None:
-            self.close_calls.append(reason)
-            if len(self.close_calls) == 1:
-                raise RuntimeError("close boom")
-
-    policy = _fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
-    client = WebSocketClient(
-        "ws://localhost", "test-key", "agent-123", session_policy=policy
-    )
-    fake = FlakyThenFakePHXClient()
-    client._reset_watchdog_deadline()
-    watchdog = asyncio.create_task(client._watchdog_loop(fake))
-
-    await asyncio.sleep(0.2)  # comfortably past two dead_threshold_s windows
-    watchdog.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await watchdog
-
-    assert len(fake.close_calls) >= 2
-
-
-async def test_watchdog_does_not_warn_or_close_while_already_disconnected():
-    """No live connection to force-close means nothing to warn about either
-    -- an extended reconnect backoff must not spam misleading 'forcing
-    reconnect' warnings for a connection that's already down."""
-
-    class DisconnectedFakePHXClient:
-        def __init__(self) -> None:
-            self.connection = None
-            self.close_calls: list[str] = []
-
-        async def close_connection(self, reason: str) -> None:
-            self.close_calls.append(reason)
-
-    policy = _fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
-    client = WebSocketClient(
-        "ws://localhost", "test-key", "agent-123", session_policy=policy
-    )
-    fake = DisconnectedFakePHXClient()
-    client._reset_watchdog_deadline()
-    watchdog = asyncio.create_task(client._watchdog_loop(fake))
-
-    await asyncio.sleep(0.15)
-    watchdog.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await watchdog
-
-    assert fake.close_calls == []
-
-
-async def test_reconnect_resets_watchdog_deadline_so_a_fresh_socket_survives():
-    """A reconnect must reset the watchdog deadline immediately -- otherwise
-    it can inherit a stale deadline (from the disconnected-state polling
-    above) that expires before the fresh socket's first heartbeat cycle,
-    force-closing a healthy connection."""
-
-    class FakePHXClient:
-        def __init__(self) -> None:
-            self.connection = object()
-            self.close_calls: list[str] = []
-
-        async def close_connection(self, reason: str) -> None:
-            self.close_calls.append(reason)
-
-    policy = _fast_session_policy(heartbeat_interval_s=0.1, dead_threshold_s=0.12)
-    client = WebSocketClient(
-        "ws://localhost", "test-key", "agent-123", session_policy=policy
-    )
-    fake = FakePHXClient()
-
-    # The disconnected-state watchdog polling has already scheduled a trip
-    # unrelated to when reconnect actually completes.
-    client._reset_watchdog_deadline()
-    await asyncio.sleep(policy.dead_threshold_s * 0.8)
-
-    # Reconnect completes just before that already-scheduled deadline.
-    await client._handle_reconnect()
-
-    watchdog = asyncio.create_task(client._watchdog_loop(fake))
-    # Wait less than heartbeat_interval_s: the fresh connection hasn't had
-    # time to send or ack its first heartbeat yet.
-    await asyncio.sleep(policy.heartbeat_interval_s * 0.5)
-    watchdog.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await watchdog
-
-    assert fake.close_calls == []
+    assert client._watchdog._task is None

--- a/tests/websocket/test_watchdog.py
+++ b/tests/websocket/test_watchdog.py
@@ -1,0 +1,157 @@
+"""Tests for HeartbeatWatchdog in isolation (no real socket needed -- the
+wiring between it and WebSocketClient/PHXChannelsClient is covered by the
+real-wire tests in test_client.py)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from band_sdk_core import SessionPolicy
+
+from band.client.streaming.watchdog import HeartbeatWatchdog
+
+
+def _fast_session_policy(
+    *, heartbeat_interval_s: float, dead_threshold_s: float
+) -> SessionPolicy:
+    """A SessionPolicy with real reconnect-backoff defaults (mirroring
+    SessionPolicy.default()) but a fast heartbeat/dead-threshold pair, so
+    watchdog tests run in real fractional seconds instead of production's
+    30s/60s."""
+    return SessionPolicy(
+        {
+            "base_delay_s": 1.0,
+            "factor": 2.0,
+            "max_delay_s": 30.0,
+            "stable_reset_s": 60.0,
+            "rapid_disconnect_uptime_s": 10.0,
+            "rapid_window_s": 300.0,
+            "rapid_first_min_delay_s": 1.0,
+            "rapid_second_min_delay_s": 5.0,
+            "rapid_cooldown_base_s": 10.0,
+            "rapid_cooldown_step_s": 10.0,
+            "rapid_cooldown_max_s": 60.0,
+            "rapid_threshold": 10,
+            "heartbeat_interval_s": heartbeat_interval_s,
+            "dead_threshold_s": dead_threshold_s,
+        }
+    )
+
+
+class FakePHXClient:
+    def __init__(self, connection: object | None = object()) -> None:
+        self.connection = connection
+        self.close_calls: list[str] = []
+
+    async def close_connection(self, reason: str) -> None:
+        self.close_calls.append(reason)
+
+
+async def test_start_cancelled_cleanly_on_stop():
+    """stop() cancels the watchdog task cleanly -- no dangling task
+    survives shutdown."""
+    policy = _fast_session_policy(heartbeat_interval_s=0.05, dead_threshold_s=5.0)
+    watchdog = HeartbeatWatchdog(policy)
+    watchdog.start(FakePHXClient())
+
+    task = watchdog._task
+    assert task is not None
+    assert not task.done()
+
+    await watchdog.stop()
+
+    assert task.done()
+    assert task.cancelled()
+    assert watchdog._task is None
+
+
+async def test_stale_watchdog_cannot_close_a_superseded_connection():
+    """A watchdog task stays bound to the specific PHXChannelsClient it was
+    started with. If it fires late -- after the caller has already moved on
+    to a newer instance, as happens when an initial-connect attempt is
+    superseded by the next one in `WebSocketClient.__aenter__`'s retry loop
+    -- it must only ever act on its own (stale) instance, never the
+    replacement."""
+    policy = _fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
+    watchdog = HeartbeatWatchdog(policy)
+    first, second = FakePHXClient(), FakePHXClient()
+
+    watchdog.start(first)
+    # The retry loop moving on to the next attempt: nothing re-points this
+    # watchdog at `second` -- a fresh HeartbeatWatchdog would be started for
+    # attempt 2, so this instance stays bound to `first`.
+
+    await asyncio.sleep(
+        0.2
+    )  # comfortably past dead_threshold_s (may trip more than once)
+    await watchdog.stop()
+
+    assert first.close_calls
+    assert all(
+        reason == "Heartbeat dead-threshold exceeded" for reason in first.close_calls
+    )
+    assert second.close_calls == []
+
+
+async def test_survives_a_close_connection_failure():
+    """A `close_connection` failure must not kill the watchdog task -- it is
+    the only monitor for the rest of this client's lifetime, so one bad
+    close must not silently disable dead-threshold enforcement forever."""
+
+    class FlakyThenFakePHXClient(FakePHXClient):
+        async def close_connection(self, reason: str) -> None:
+            self.close_calls.append(reason)
+            if len(self.close_calls) == 1:
+                raise RuntimeError("close boom")
+
+    policy = _fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
+    watchdog = HeartbeatWatchdog(policy)
+    fake = FlakyThenFakePHXClient()
+    watchdog.start(fake)
+
+    await asyncio.sleep(0.2)  # comfortably past two dead_threshold_s windows
+    await watchdog.stop()
+
+    assert len(fake.close_calls) >= 2
+
+
+async def test_does_not_warn_or_close_while_already_disconnected():
+    """No live connection to force-close means nothing to warn about either
+    -- an extended reconnect backoff must not spam misleading 'forcing
+    reconnect' warnings for a connection that's already down."""
+    policy = _fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
+    watchdog = HeartbeatWatchdog(policy)
+    fake = FakePHXClient(connection=None)
+    watchdog.start(fake)
+
+    await asyncio.sleep(0.15)
+    await watchdog.stop()
+
+    assert fake.close_calls == []
+
+
+async def test_reset_deadline_lets_a_fresh_socket_survive_a_reconnect():
+    """A reconnect must reset the watchdog deadline immediately -- otherwise
+    it can inherit a stale deadline (from the disconnected-state polling
+    above) that expires before the fresh socket's first heartbeat cycle,
+    force-closing a healthy connection."""
+    policy = _fast_session_policy(heartbeat_interval_s=0.1, dead_threshold_s=0.12)
+    watchdog = HeartbeatWatchdog(policy)
+    fake = FakePHXClient()
+
+    # The disconnected-state watchdog polling has already scheduled a trip
+    # unrelated to when reconnect actually completes.
+    watchdog.reset_deadline()
+    await asyncio.sleep(policy.dead_threshold_s * 0.8)
+
+    # Reconnect completes just before that already-scheduled deadline (what
+    # WebSocketClient._handle_reconnect does on a real reconnect).
+    watchdog.reset_deadline()
+
+    watchdog.start(fake)
+    # Wait less than heartbeat_interval_s: the fresh connection hasn't had
+    # time to send or ack its first heartbeat yet.
+    await asyncio.sleep(policy.heartbeat_interval_s * 0.5)
+    await watchdog.stop()
+
+    assert fake.close_calls == []

--- a/uv.lock
+++ b/uv.lock
@@ -762,7 +762,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'dev-crewai'", specifier = ">=0.75.0" },
     { name = "anthropic", marker = "extra == 'dev-parlant'", specifier = ">=0.75.0" },
     { name = "band-client-rest", specifier = "==0.0.27" },
-    { name = "band-sdk-core", specifier = "==0.7.2" },
+    { name = "band-sdk-core", specifier = "==2.0.0" },
     { name = "band-testing-python", marker = "extra == 'dev'", specifier = "==0.1.4" },
     { name = "band-testing-python", marker = "extra == 'dev-crewai'", specifier = "==0.1.4" },
     { name = "band-testing-python", marker = "extra == 'dev-parlant'", specifier = "==0.1.4" },
@@ -830,7 +830,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", marker = "extra == 'dev'", specifier = ">=1.44.0" },
     { name = "parlant", marker = "extra == 'dev-parlant'", specifier = ">=3.3.2" },
     { name = "parlant", marker = "extra == 'parlant'", specifier = ">=3.3.2" },
-    { name = "phoenix-channels-python-client", specifier = ">=0.2.2" },
+    { name = "phoenix-channels-python-client", git = "https://github.com/AlexanderZ-Band/phoenix-channels-python-client?branch=int-1323-add-shared-heartbeat-interval-dead-threshold-policy-to-band" },
     { name = "pillow", marker = "extra == 'crewai'", specifier = ">=12.1.1" },
     { name = "pillow", marker = "extra == 'dev-crewai'", specifier = ">=12.1.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
@@ -905,17 +905,17 @@ provides-extras = ["logging", "desktop", "codex", "opencode", "letta", "pydantic
 
 [[package]]
 name = "band-sdk-core"
-version = "0.7.2"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/67/e8292ca46080dfe45192c03f236e8953acd897b21e084b4f228e540307de/band_sdk_core-0.7.2-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:574b41b37a79c0b8d436be9ef84b386dbb36711035018098188827d417814c8e", size = 446441, upload-time = "2026-08-26T10:19:06.993Z" },
-    { url = "https://files.pythonhosted.org/packages/08/c1/2d4a5be20ee26ff54b20f65038e06eba999b7441396cf1630aa7701cb471/band_sdk_core-0.7.2-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:f99e4559df394be3837b2b1221612d41382e1252aa3118ac8a0f0ef4b293390e", size = 448481, upload-time = "2026-08-26T10:19:08.675Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/07/f749efd4d62ce8eb6059716a0f9f59c20c2ee4b7996a24d4ccf2b740cfe9/band_sdk_core-0.7.2-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:782be8e9f4a41f1c22c36c0f31b7c9c2a885c2abfabe7a2c7c9edfb28b4369cb", size = 495430, upload-time = "2026-08-26T10:19:10.119Z" },
-    { url = "https://files.pythonhosted.org/packages/59/33/a3a09d817c0ed5a938cf0485fe822a7885c8dd8267a6d99f7cccdc7114c8/band_sdk_core-0.7.2-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:5f67adad762a763a58d294b1e31460df1cf28600509d602bb7b837523f9cbf7b", size = 497801, upload-time = "2026-08-26T10:19:11.539Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/52/d4b587bcdde4bcc38bad702b60f98881aa1a76f900218b09ae5400b1ca64/band_sdk_core-0.7.2-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:64890438f1b094516d249d1795af3b6b278a781c7e46b5e2fea486c4226c3608", size = 673968, upload-time = "2026-08-26T10:19:12.747Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/e0/44d753e3cd7b38ea768cb3fcd61c23770660894c7b249d854560defb404d/band_sdk_core-0.7.2-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:eed8262d67ff65f14d2a57216c7023573e043dbe809fc3e02de828f16f9dbac3", size = 709013, upload-time = "2026-08-26T10:19:14.02Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/58/59eb4a562f7b344b1ffc21693d3e254974febb30cd1328167526282f1458/band_sdk_core-0.7.2-cp311-abi3-win_amd64.whl", hash = "sha256:bde0d8c5cf424df6832d5cf8be14108fb588892f7e6957a0a8af2e0d083db92e", size = 321106, upload-time = "2026-08-26T10:19:15.267Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/5a/a94d50108611fe917e7b74c71b9d0b1d95aa1d6915ac8c3676dc90ce6c89/band_sdk_core-0.7.2-cp311-abi3-win_arm64.whl", hash = "sha256:a346cddbe44578532f8a518c6d58138a174e662d9a70bc9fee10a6fe333b3bea", size = 306578, upload-time = "2026-08-26T10:19:16.437Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b0/c0450d0df122aa46ffaf11aabacd5dcf27b81e35ff1f5b08639c0cfa1457/band_sdk_core-2.0.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7db8f08f4dc4616ecee2aa5e8a7bd61d846d959a309a6b25da598e649d4ac278", size = 457389, upload-time = "2026-08-29T12:00:47.019Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/99/12d8e5a5fb4ef42e684117de2687cbb7bf8df0b706eeb65587caa9867b49/band_sdk_core-2.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:556f420711b7026b0b3dbb9abf0a2dcdd6f7126f2c09ec40ca281c081229851c", size = 458700, upload-time = "2026-08-29T12:00:48.396Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c3/a894dd0a873a80184bdf443e770917c2ec85e671a8c72f4c8400584692e9/band_sdk_core-2.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:19e58438cf932bb0324c0358a8c332437eade63bb253e6f7cddbfa02c928051e", size = 509782, upload-time = "2026-08-29T12:00:49.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/95/18d976f8a12d24819e3788a2c880ec7d07945673c6a34b68fd7653142ee8/band_sdk_core-2.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9f581c2173967e44a219d86f124a65650fc915c8c99a1f9ddf69c0e98612253f", size = 510429, upload-time = "2026-08-29T12:00:50.849Z" },
+    { url = "https://files.pythonhosted.org/packages/67/87/1eef985931ddddf2f2ff9623622f15bab460d4d943aa7dc96d1da8227d37/band_sdk_core-2.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:430fb51e32080fa58a1c84f8d2342c443865c85a05f8ad727288063e5bdb425a", size = 687161, upload-time = "2026-08-29T12:00:51.987Z" },
+    { url = "https://files.pythonhosted.org/packages/08/8d/61d49368320438ad8ee7ebfc689cfc62163cdb9a5d7592e8d48a3438aae4/band_sdk_core-2.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3606b58f5a3d9ff006fcd9db425cc4ac47c4482380146a282e23299ca6f0fcab", size = 724455, upload-time = "2026-08-29T12:00:53.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/17/c795774be4b1b1c96633c68b5a8f2966bfd0752004835920f6f0a676153a/band_sdk_core-2.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:8ac8e95b466e8110f4e3dd99afaa4520f825c294e2b731d04c246efe1edd7685", size = 331961, upload-time = "2026-08-29T12:00:54.47Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/93/aa331d33db1d8436dba57df83d4592c6534223ffc11bf94c1eb5090714cc/band_sdk_core-2.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:d802cb5a411afa5b7e6089962cdc3b4573ad6d43048fc2b28a8a9079a247aa0b", size = 314808, upload-time = "2026-08-29T12:00:55.707Z" },
 ]
 
 [[package]]
@@ -5885,14 +5885,10 @@ wheels = [
 
 [[package]]
 name = "phoenix-channels-python-client"
-version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
+version = "0.2.3"
+source = { git = "https://github.com/AlexanderZ-Band/phoenix-channels-python-client?branch=int-1323-add-shared-heartbeat-interval-dead-threshold-policy-to-band#9e4ab250bcd293295f5a2a0b16f2e37c93a71bb2" }
 dependencies = [
     { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/4a/3fad1bc7724c874b9224878af9e6f7062e295c448b325da4fdd9b7745176/phoenix_channels_python_client-0.2.2.tar.gz", hash = "sha256:b610e54b56ecfa238aa8568b33dba4c9ae9a7f5362a0f3c66fdec013ae38f728", size = 29491, upload-time = "2026-07-20T14:10:55.912Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/e9/47ac73a5a8bc6b8dec339fbb2b89f325bf2270fa68c81dfe1f2495a7e7a6/phoenix_channels_python_client-0.2.2-py3-none-any.whl", hash = "sha256:ebbf468a15b3ffaa8bc463ddd0132811e94a2fcd5bc20f507ee76109e45b8b14", size = 24197, upload-time = "2026-07-20T14:10:54.799Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -830,7 +830,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", marker = "extra == 'dev'", specifier = ">=1.44.0" },
     { name = "parlant", marker = "extra == 'dev-parlant'", specifier = ">=3.3.2" },
     { name = "parlant", marker = "extra == 'parlant'", specifier = ">=3.3.2" },
-    { name = "phoenix-channels-python-client", git = "https://github.com/AlexanderZ-Band/phoenix-channels-python-client?branch=int-1323-add-shared-heartbeat-interval-dead-threshold-policy-to-band" },
+    { name = "phoenix-channels-python-client", git = "https://github.com/band-ai/phoenix-channels-python-client?branch=int-1323-add-shared-heartbeat-interval-dead-threshold-policy-to-band" },
     { name = "pillow", marker = "extra == 'crewai'", specifier = ">=12.1.1" },
     { name = "pillow", marker = "extra == 'dev-crewai'", specifier = ">=12.1.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
@@ -5886,7 +5886,7 @@ wheels = [
 [[package]]
 name = "phoenix-channels-python-client"
 version = "0.2.3"
-source = { git = "https://github.com/AlexanderZ-Band/phoenix-channels-python-client?branch=int-1323-add-shared-heartbeat-interval-dead-threshold-policy-to-band#9e4ab250bcd293295f5a2a0b16f2e37c93a71bb2" }
+source = { git = "https://github.com/band-ai/phoenix-channels-python-client?branch=int-1323-add-shared-heartbeat-interval-dead-threshold-policy-to-band#2b1fe6d58aa1cd75065afda08ed0d42dc3005b8c" }
 dependencies = [
     { name = "websockets" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -830,7 +830,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", marker = "extra == 'dev'", specifier = ">=1.44.0" },
     { name = "parlant", marker = "extra == 'dev-parlant'", specifier = ">=3.3.2" },
     { name = "parlant", marker = "extra == 'parlant'", specifier = ">=3.3.2" },
-    { name = "phoenix-channels-python-client", git = "https://github.com/band-ai/phoenix-channels-python-client?branch=int-1323-add-shared-heartbeat-interval-dead-threshold-policy-to-band" },
+    { name = "phoenix-channels-python-client", specifier = ">=0.2.4" },
     { name = "pillow", marker = "extra == 'crewai'", specifier = ">=12.1.1" },
     { name = "pillow", marker = "extra == 'dev-crewai'", specifier = ">=12.1.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
@@ -5885,10 +5885,14 @@ wheels = [
 
 [[package]]
 name = "phoenix-channels-python-client"
-version = "0.2.3"
-source = { git = "https://github.com/band-ai/phoenix-channels-python-client?branch=int-1323-add-shared-heartbeat-interval-dead-threshold-policy-to-band#2b1fe6d58aa1cd75065afda08ed0d42dc3005b8c" }
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/7a/c8545746a7055205a86be4b02aa545e1ed1cfdc57c797226f3cd581f7002/phoenix_channels_python_client-0.2.4.tar.gz", hash = "sha256:7b9c7f27ccbaecdecbf89fd975e9c18ce493df1dfec792d13364d385eed58395", size = 31301, upload-time = "2026-08-30T06:25:46.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/32/5e1a22892562857d1535a676947df174c32ee39a27c56ae7d8c92908e2a4/phoenix_channels_python_client-0.2.4-py3-none-any.whl", hash = "sha256:9f18a51ce33f3edb25d2896194c415096ef5952b896276931a98096e9ddeb3ce", size = 25372, upload-time = "2026-08-30T06:25:44.58Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Part of [INT-1323](https://linear.app/thenvoi/issue/INT-1323): wires `WebSocketClient` up to `band-sdk-core`'s shared `SessionPolicy` heartbeat/dead-threshold policy (band-ai/band-sdk-core#60, released as v2.0.0) and `phoenix-channels-python-client`'s new `on_heartbeat_ack`/`close_connection` surface (band-ai/phoenix-channels-python-client#53).

Dead-connection detection lives in a new `band.client.streaming.watchdog.HeartbeatWatchdog` class, not inline in `WebSocketClient`:

- `HeartbeatWatchdog` owns the deadline, the watchdog task, and the force-close decision. `WebSocketClient` holds one `self._watchdog` and delegates `start`/`stop`/`reset_deadline` to it.
- `heartbeat_interval_s` (from `SessionPolicy`, default or an injected override) is passed to `PHXChannelsClient`; `on_heartbeat_ack` and `on_reconnect` are wired to reset the watchdog's deadline.
- `HeartbeatWatchdog.start(client)` takes the specific `PHXChannelsClient` instance as an argument (not read dynamically later), so a stale watchdog from a superseded initial-connect attempt can never act on a later instance.
- A force-close, once `dead_threshold_s` passes with no ack, flows into the client's own existing reconnect path — no new disconnect-handling branch.
- Reconnects reset the deadline immediately (not just acks and the initial connect) — otherwise a reconnect can inherit a stale deadline from disconnected-state polling and get force-closed before its first heartbeat cycle completes.
- The watchdog task is started only once, on a successful connect, and stopped cleanly in `__aexit__`.
- A `close_connection` failure is caught and logged rather than killing the watchdog task, and the watchdog skips warning/closing when there's no live connection to avoid misleading log spam during backoff.

## Dependency floor: resolved

`phoenix-channels-python-client` PR #53 has since released as a real PyPI version (`0.2.4`) containing `on_heartbeat_ack`/`close_connection`. `dependencies` pins `phoenix-channels-python-client>=0.2.4` — a real, verified floor — and there is no `[tool.uv.sources]` git override. This PR is mergeable/releasable; the `packaging` job's "Install from wheel" step passes.

## Addressed review feedback (amit-gazal-band)

- `test_aenter_restores_reconnect_after_successful_initial_connect` called `__aenter__` without a matching `__aexit__`, leaking a watchdog task against a test double with no real `.connection` — once `dead_threshold_s` elapsed, `_force_close_if_stale` would raise `AttributeError` inside that fire-and-forget task on the session-scoped event loop, polluting whichever test ran when it fired. Gave the double a no-op `__aexit__` and added the matching cleanup call, same shape as the sibling retry-backoff test's own earlier fix. Checked every other bare `__aenter__()` call in the file: the rest all raise before reaching the watchdog-start line, so this was the only actual leak.

Review thread resolved.

## Test plan

- [x] `tests/websocket/test_watchdog.py` — 5 tests against `HeartbeatWatchdog` directly, no real socket needed: task cancels cleanly on `stop()`; a stale watchdog from a superseded attempt cannot close a newer connection; survives a `close_connection` failure and keeps enforcing the threshold; neither warns nor closes while already disconnected; a reset deadline lets a fresh socket survive a reconnect that lands late in a disconnected-state polling window.
- [x] `tests/websocket/test_client.py` — real-wire tests against an in-process Phoenix-protocol peer, covering the actual wiring: ack keeps the connection alive across several heartbeat cycles; a withheld ack forces close + reconnect at ~`dead_threshold_s`; `__aexit__` stops the watchdog; the successful-initial-connect test no longer leaks a watchdog task (`-W error` clean).
- [x] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/ --all-packages` — 5175 passed, 122 skipped.
- [x] `uv run pyrefly check` (project-wide, matching CI) — 0 errors.
- [x] `uv run ruff check` / `ruff format --check` — clean.
- [x] Merged `main` to pick up an unrelated `band-sdk-core`/lockfile drift; resolved keeping this PR's `band-sdk-core==2.0.0` and `phoenix-channels-python-client>=0.2.4`. Full CI green (20/20 checks) as of the merge commit, including `packaging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EuhCwwdkV3gYphyNFkw9Y
