### PR TITLE
feat: Capability.FILES support across every adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
           tests/integrations/test_crewai_flow_real_sdk.py \
           tests/integrations/test_crewai_real_tools.py \
           tests/test_capability_gating_e2e.py \
+          tests/framework_conformance/test_files_image_passthrough_matrix.py \
           tests/framework_conformance/ -k crewai
 
     - name: Pyrefly check (crewai sources)

--- a/docs/capability-negotiation.md
+++ b/docs/capability-negotiation.md
@@ -83,17 +83,22 @@ platform tool, so each grew three new hand-written wrappers instead.
 Real image vision passthrough for `band_read_room_file` (a small
 previewable image reaches the model as actual image content instead of a
 `json.dumps`'d text block) is verified for `claude_sdk`, `anthropic`,
-`opencode` (and the ACP client adapter / published `band-mcp` CLI, which
-share its MCP-engine fix), `gemini`, `langgraph`, `agno`, `strands`,
-`copilot_sdk`, `codex`, `pydantic_ai`, and `crewai`/`crewai_flow` — see
+`opencode`, `gemini`, `langgraph`, `agno`, `strands`, `copilot_sdk`,
+`codex`, `pydantic_ai`, and `crewai`/`crewai_flow` — see
 `IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS` in
 `tests/framework_conformance/test_adapter_conformance.py` for the
-up-to-date list and per-adapter mechanism citations. `google_adk` and
+up-to-date list and per-adapter mechanism citations. Three adapters are
+excluded from that list, for two different reasons. `google_adk` and
 `parlant` are confirmed **not** supportable: `google_adk` because
 installed google-adk's own tool-response builder drops multimodal content
 before it reaches the model (an upstream framework limitation), `parlant`
 because its `ToolResult` has no multimodal field and its own MCP
-integration discards image content blocks the same way.
+integration discards image content blocks the same way. `letta` and
+`copilot_acp` (which wraps the ACP client adapter) are excluded for an
+unrelated reason: both route tool execution through the shared MCP
+engine rather than calling `execute_tool_call` directly, so they inherit
+`opencode`'s fix transitively and have no adapter-local code path to
+probe — not unsupportable, just unverifiable in isolation.
 
 `AgentTools.get_tool_schemas`/`get_anthropic_tool_schemas`/
 `get_openai_tool_schemas` and `iter_tool_definitions` take a single

--- a/docs/capability-negotiation.md
+++ b/docs/capability-negotiation.md
@@ -71,39 +71,30 @@ anyway. `SlackAdapter` overrides it to also delegate into the wrapped inner
 adapter, since its own `_resolve_features()` only mirrors features into the
 inner adapter once, at construction.
 
-**Every registered adapter now declares `Capability.FILES`** —
-`claude_sdk`, `anthropic`, `langgraph`, `gemini`, `google_adk`, `agno`,
-`strands`, `codex`, `copilot_sdk`, `opencode`, the ACP client adapter,
-`letta`, `parlant`, `pydantic_ai`, `crewai`, and `crewai_flow`. The
-registry-driven ones (schemas built generically from
-`iter_tool_definitions`) needed only the declaration; `parlant`,
-`pydantic_ai`, and `crewai`/`crewai_flow` hand-roll one wrapper per
-platform tool, so each grew three new hand-written wrappers instead.
+Every registered adapter declares `Capability.FILES`. Registry-driven
+adapters (schemas built generically from `iter_tool_definitions`) need
+only the declaration; `parlant`, `pydantic_ai`, and `crewai`/`crewai_flow`
+hand-roll one wrapper per platform tool, so each carries its own
+hand-written wrapper for the three file tools.
 
 Real image vision passthrough for `band_read_room_file` (a small
 previewable image reaches the model as actual image content instead of a
-`json.dumps`'d text block) is verified for `claude_sdk`, `anthropic`,
-`opencode`, `gemini`, `langgraph`, `agno`, `strands`, `copilot_sdk`,
-`codex`, `pydantic_ai`, and `crewai`/`crewai_flow` — see
-`IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS` in
-`tests/framework_conformance/test_adapter_conformance.py` for the
-up-to-date list and per-adapter mechanism citations. Three adapters are
-excluded from that list, for two different reasons. `google_adk` and
-`parlant` are confirmed **not** supportable: `google_adk` because
-installed google-adk's own tool-response builder drops multimodal content
-before it reaches the model (an upstream framework limitation), `parlant`
-because its `ToolResult` has no multimodal field and its own MCP
-integration discards image content blocks the same way. `letta` and
-`copilot_acp` (which wraps the ACP client adapter) are excluded for an
-unrelated reason: both route tool execution through the shared MCP
-engine rather than calling `execute_tool_call` directly, so they inherit
-`opencode`'s fix transitively and have no adapter-local code path to
-probe — not unsupportable, just unverifiable in isolation.
+`json.dumps`'d text block) is supported by every adapter except
+`google_adk` and `parlant`, which cannot carry multimodal tool-result
+content at all: `google_adk`'s own tool-response builder drops it before
+it reaches the model (an upstream framework limitation), `parlant`'s
+`ToolResult` has no multimodal field and its own MCP integration discards
+image content blocks the same way. `letta` and `copilot_acp` (which wraps
+the ACP client adapter) get the fix transitively — both route tool
+execution through the shared MCP engine rather than calling
+`execute_tool_call` directly — so they have no adapter-local code path to
+probe in isolation, but are not excluded from support. See
+`IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS`/`IMAGE_PASSTHROUGH_EXCLUSIONS`
+in `tests/framework_conformance/test_adapter_conformance.py` for the
+enforced, always-current per-adapter list and mechanism citations.
 
 `AgentTools.get_tool_schemas`/`get_anthropic_tool_schemas`/
 `get_openai_tool_schemas` and `iter_tool_definitions` take a single
-`capabilities: frozenset[Capability] | None` parameter — the boolean
-`include_memory`/`include_contacts` pair they used to take is gone
-(breaking change, no back-compat shim). `None` resolves to the pre-existing
-default (contacts only); the hub-room execution path still unions
+`capabilities: frozenset[Capability] | None` parameter. `None` resolves to
+contacts-only; the hub-room execution path always unions
 `Capability.CONTACTS` in regardless of what was requested.

--- a/docs/capability-negotiation.md
+++ b/docs/capability-negotiation.md
@@ -63,20 +63,37 @@ adapter is a `SimpleAdapter` (a bare `FrameworkAdapter` has no
 place). `apply_effective_features` is a `SimpleAdapter` hook whose default
 body just reassigns `self.features`; an adapter that caches something
 derived from capabilities at construction time (`OpencodeAdapter`,
-`ACPClientAdapter`, `LettaAdapter`) would need to override it to rebuild that
-cache too — none do yet, since none of them declare `Capability.FILES`.
-`SlackAdapter` overrides it to also delegate into the wrapped inner adapter,
-since its own `_resolve_features()` only mirrors features into the inner
-adapter once, at construction.
+`ACPClientAdapter`, `LettaAdapter` — each builds its MCP tool registration
+from `self.features.capabilities` at `__init__` time) overrides it to
+rebuild that cache from the negotiated features too — otherwise a
+deployment that negotiates FILES *off* would keep serving the file tools
+anyway. `SlackAdapter` overrides it to also delegate into the wrapped inner
+adapter, since its own `_resolve_features()` only mirrors features into the
+inner adapter once, at construction.
 
-**First (and only) adapter wired to `Capability.FILES`: `claude_sdk`.** It's
-also the only adapter with the vision-passthrough fix that lets
-`band_read_room_file`'s image branch reach the model as real vision input
-(`{"content": [{"type": "image", ...}]}`) instead of being `json.dumps`'d
-into a text block — see `_is_mcp_content_result`/`_make_result` in
-`src/band/integrations/claude_sdk/tools.py`. Every other adapter, and the
-published `band-mcp` CLI (whose `--tools` vocabulary has no `files` group),
-stays out of scope until a later pass gives it the same treatment.
+**Every registered adapter now declares `Capability.FILES`** —
+`claude_sdk`, `anthropic`, `langgraph`, `gemini`, `google_adk`, `agno`,
+`strands`, `codex`, `copilot_sdk`, `opencode`, the ACP client adapter,
+`letta`, `parlant`, `pydantic_ai`, `crewai`, and `crewai_flow`. The
+registry-driven ones (schemas built generically from
+`iter_tool_definitions`) needed only the declaration; `parlant`,
+`pydantic_ai`, and `crewai`/`crewai_flow` hand-roll one wrapper per
+platform tool, so each grew three new hand-written wrappers instead.
+
+Real image vision passthrough for `band_read_room_file` (a small
+previewable image reaches the model as actual image content instead of a
+`json.dumps`'d text block) is verified for `claude_sdk`, `anthropic`,
+`opencode` (and the ACP client adapter / published `band-mcp` CLI, which
+share its MCP-engine fix), `gemini`, `langgraph`, `agno`, `strands`,
+`copilot_sdk`, `codex`, `pydantic_ai`, and `crewai`/`crewai_flow` — see
+`IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS` in
+`tests/framework_conformance/test_adapter_conformance.py` for the
+up-to-date list and per-adapter mechanism citations. `google_adk` and
+`parlant` are confirmed **not** supportable: `google_adk` because
+installed google-adk's own tool-response builder drops multimodal content
+before it reaches the model (an upstream framework limitation), `parlant`
+because its `ToolResult` has no multimodal field and its own MCP
+integration discards image content blocks the same way.
 
 `AgentTools.get_tool_schemas`/`get_anthropic_tool_schemas`/
 `get_openai_tool_schemas` and `iter_tool_definitions` take a single

--- a/packages/band-mcp/src/band_mcp/shared.py
+++ b/packages/band-mcp/src/band_mcp/shared.py
@@ -19,7 +19,7 @@ from band.config.logs import LogSettings
 from band.integrations.mcp.engine import dispatch_tool
 from band.logging_config import LogStream
 from band.runtime.tools import (
-    SEND_MESSAGE_TOOL_NAME,
+    BandTool,
     AgentTools,
     HumanTools,
     Surface,
@@ -29,7 +29,7 @@ from band.runtime.tools import (
 
 from band_mcp.config import Config, Scope, resolve_credential_for_scope, settings
 
-SEND_MESSAGE_METHOD_NAME = TOOL_DEFINITIONS[SEND_MESSAGE_TOOL_NAME].method_name
+SEND_MESSAGE_METHOD_NAME = TOOL_DEFINITIONS[BandTool.SEND_MESSAGE].method_name
 """The one thing that needs to stay in sync with :func:`_invoke_agent`'s
 pre-flight participant refresh below -- read off the registry directly so a
 future rename can't silently drift out of sync with a hand-typed sibling."""

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -33,6 +33,7 @@ from band.runtime.tools import (
     READ_ROOM_FILE_TOOL_NAME,
     SEND_MESSAGE_TOOL_NAME,
     get_band_tool_category,
+    image_block_placeholder,
     is_mcp_content_result,
 )
 
@@ -111,7 +112,7 @@ def _make_band_entrypoint(tool_name: str) -> Callable[..., Awaitable[Any]]:
                 for block in result["content"]
             ]
             return ToolResult(
-                content=f"<{len(images)} image content block(s)>", images=images
+                content=image_block_placeholder(len(images)), images=images
             )
         return result if isinstance(result, str) else json.dumps(result, default=str)
 

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -30,6 +30,7 @@ from band.converters.agno import AgnoHistoryConverter, AgnoMessages
 from band.runtime.capabilities import with_hub_room_contacts
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
+    READ_ROOM_FILE_TOOL_NAME,
     SEND_MESSAGE_TOOL_NAME,
     get_band_tool_category,
     is_mcp_content_result,
@@ -101,7 +102,7 @@ def _make_band_entrypoint(tool_name: str) -> Callable[..., Awaitable[Any]]:
         if active is None:
             return f"Error: no active Band context for tool {tool_name}"
         result = await active.execute_tool_call(tool_name, kwargs)
-        if tool_name == "band_read_room_file" and is_mcp_content_result(result):
+        if tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(result):
             images = [
                 Image(
                     content=base64.b64decode(block["data"]),

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import warnings
@@ -10,6 +11,8 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from agno.media import Image
+from agno.tools.function import ToolResult
 from typing_extensions import Unpack
 
 from band.core.protocols import AgentToolsProtocol
@@ -26,7 +29,11 @@ from band.core.types import (
 from band.converters.agno import AgnoHistoryConverter, AgnoMessages
 from band.runtime.capabilities import with_hub_room_contacts
 from band.runtime.prompts import render_system_prompt
-from band.runtime.tools import SEND_MESSAGE_TOOL_NAME, get_band_tool_category
+from band.runtime.tools import (
+    SEND_MESSAGE_TOOL_NAME,
+    get_band_tool_category,
+    is_mcp_content_result,
+)
 
 try:
     from agno.models.message import Message
@@ -88,12 +95,23 @@ def _tool_name(execution: Any) -> str:
     return getattr(execution, "tool_name", None) or ""
 
 
-def _make_band_entrypoint(tool_name: str) -> Callable[..., Awaitable[str]]:
-    async def _entrypoint(**kwargs: Any) -> str:
+def _make_band_entrypoint(tool_name: str) -> Callable[..., Awaitable[Any]]:
+    async def _entrypoint(**kwargs: Any) -> Any:
         active = _current_tools.get()
         if active is None:
             return f"Error: no active Band context for tool {tool_name}"
         result = await active.execute_tool_call(tool_name, kwargs)
+        if tool_name == "band_read_room_file" and is_mcp_content_result(result):
+            images = [
+                Image(
+                    content=base64.b64decode(block["data"]),
+                    mime_type=block["mimeType"],
+                )
+                for block in result["content"]
+            ]
+            return ToolResult(
+                content=f"<{len(images)} image content block(s)>", images=images
+            )
         return result if isinstance(result, str) else json.dumps(result, default=str)
 
     _entrypoint.__name__ = tool_name

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -29,8 +29,7 @@ from band.converters.agno import AgnoHistoryConverter, AgnoMessages
 from band.runtime.capabilities import with_hub_room_contacts
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
-    READ_ROOM_FILE_TOOL_NAME,
-    SEND_MESSAGE_TOOL_NAME,
+    BandTool,
     decode_image_block,
     get_band_tool_category,
     image_block_placeholder,
@@ -103,7 +102,7 @@ def _make_band_entrypoint(tool_name: str) -> Callable[..., Awaitable[str | ToolR
         if active is None:
             return f"Error: no active Band context for tool {tool_name}"
         result = await active.execute_tool_call(tool_name, kwargs)
-        if tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(result):
+        if tool_name == BandTool.READ_ROOM_FILE and is_mcp_content_result(result):
             images = [
                 Image(content=data, mime_type=mime_type)
                 for data, mime_type in (
@@ -349,7 +348,7 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
         self._persist_turn(room_id, response)
 
         if not any(
-            _tool_name(execution) == SEND_MESSAGE_TOOL_NAME
+            _tool_name(execution) == BandTool.SEND_MESSAGE
             for execution in _tool_executions(response)
         ):
             logger.debug(

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -97,8 +97,8 @@ def _tool_name(execution: Any) -> str:
     return getattr(execution, "tool_name", None) or ""
 
 
-def _make_band_entrypoint(tool_name: str) -> Callable[..., Awaitable[Any]]:
-    async def _entrypoint(**kwargs: Any) -> Any:
+def _make_band_entrypoint(tool_name: str) -> Callable[..., Awaitable[str | ToolResult]]:
+    async def _entrypoint(**kwargs: Any) -> str | ToolResult:
         active = _current_tools.get()
         if active is None:
             return f"Error: no active Band context for tool {tool_name}"

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -33,7 +33,8 @@ from band.runtime.tools import (
     decode_image_block,
     get_band_tool_category,
     image_block_placeholder,
-    is_mcp_content_result,
+    is_image_passthrough_result,
+    redact_tool_call_args,
 )
 
 try:
@@ -102,13 +103,20 @@ def _make_band_entrypoint(tool_name: str) -> Callable[..., Awaitable[str | ToolR
         if active is None:
             return f"Error: no active Band context for tool {tool_name}"
         result = await active.execute_tool_call(tool_name, kwargs)
-        if tool_name == BandTool.READ_ROOM_FILE and is_mcp_content_result(result):
-            images = [
-                Image(content=data, mime_type=mime_type)
-                for data, mime_type in (
-                    decode_image_block(block) for block in result["content"]
-                )
-            ]
+        if is_image_passthrough_result(tool_name, result):
+            try:
+                images = [
+                    Image(content=data, mime_type=mime_type)
+                    for data, mime_type in (
+                        decode_image_block(block) for block in result["content"]
+                    )
+                ]
+            except Exception as error:
+                # A malformed or future-extended image block (see
+                # is_mcp_content_result's docstring) must degrade to the
+                # adapter's usual error string, not raise uncaught out of
+                # the tool entrypoint Agno invokes directly.
+                return f"Error reading room file: {error}"
             return ToolResult(
                 content=image_block_placeholder(len(images)), images=images
             )
@@ -753,7 +761,9 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
                 "tool_call",
                 {
                     ToolEventKey.NAME: ex.tool_name or "",
-                    ToolEventKey.ARGS: ex.tool_args or {},
+                    ToolEventKey.ARGS: redact_tool_call_args(
+                        ex.tool_name or "", ex.tool_args or {}
+                    ),
                     ToolEventKey.TOOL_CALL_ID: ex.tool_call_id or "",
                 },
                 room_id=room_id,

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import base64
 import json
 import logging
 import warnings
@@ -32,6 +31,7 @@ from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     READ_ROOM_FILE_TOOL_NAME,
     SEND_MESSAGE_TOOL_NAME,
+    decode_image_block,
     get_band_tool_category,
     image_block_placeholder,
     is_mcp_content_result,
@@ -105,11 +105,10 @@ def _make_band_entrypoint(tool_name: str) -> Callable[..., Awaitable[str | ToolR
         result = await active.execute_tool_call(tool_name, kwargs)
         if tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(result):
             images = [
-                Image(
-                    content=base64.b64decode(block["data"]),
-                    mime_type=block["mimeType"],
+                Image(content=data, mime_type=mime_type)
+                for data, mime_type in (
+                    decode_image_block(block) for block in result["content"]
                 )
-                for block in result["content"]
             ]
             return ToolResult(
                 content=image_block_placeholder(len(images)), images=images

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -132,7 +132,7 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
         {Emit.TOOL_CALLS, Emit.THOUGHTS, Emit.USAGE}
     )
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -57,7 +57,7 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.TOOL_CALLS, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -35,9 +35,9 @@ from band.runtime.custom_tools import (
 )
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
-    BandTool,
     image_block_placeholder,
-    is_mcp_content_result,
+    is_image_passthrough_result,
+    redact_tool_call_args,
 )
 
 logger = logging.getLogger(__name__)
@@ -450,7 +450,9 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
                         content=json.dumps(
                             {
                                 ToolEventKey.NAME: tool_name,
-                                ToolEventKey.ARGS: tool_input,
+                                ToolEventKey.ARGS: redact_tool_call_args(
+                                    tool_name, tool_input
+                                ),
                                 ToolEventKey.TOOL_CALL_ID: tool_use_id,
                             }
                         ),
@@ -469,9 +471,7 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
                     result = await execute_custom_tool(custom_tool, tool_input)
                 else:
                     result = await tools.execute_tool_call(tool_name, tool_input)
-                if tool_name == BandTool.READ_ROOM_FILE and is_mcp_content_result(
-                    result
-                ):
+                if is_image_passthrough_result(tool_name, result):
                     content = _image_tool_result_content(result)
                     result_str = image_block_placeholder(len(content))
                 else:

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -35,7 +35,7 @@ from band.runtime.custom_tools import (
 )
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
-    READ_ROOM_FILE_TOOL_NAME,
+    BandTool,
     image_block_placeholder,
     is_mcp_content_result,
 )
@@ -44,13 +44,10 @@ logger = logging.getLogger(__name__)
 
 
 def _image_tool_result_content(result: dict[str, Any]) -> list[dict[str, Any]]:
-    """Convert an MCP-content-shaped ``band_read_room_file`` result into
-    Anthropic ``ImageBlockParam`` dicts for a ``tool_result``'s content list.
+    """An image tool result as Anthropic ``ImageBlockParam`` dicts.
 
-    Anthropic's ``media_type`` (jpeg/png/gif/webp) is exactly
-    ``PREVIEWABLE_IMAGE_CONTENT_TYPES`` -- the only content types
-    ``AgentTools.read_room_file`` ever inlines as an image -- so every
-    ``mimeType`` this sees is already a valid ``media_type``.
+    No media_type validation: Anthropic's accepted set is exactly
+    ``PREVIEWABLE_IMAGE_CONTENT_TYPES``, the only types read_room_file inlines.
     """
     return [
         {
@@ -472,7 +469,7 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
                     result = await execute_custom_tool(custom_tool, tool_input)
                 else:
                     result = await tools.execute_tool_call(tool_name, tool_input)
-                if tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(
+                if tool_name == BandTool.READ_ROOM_FILE and is_mcp_content_result(
                     result
                 ):
                     content = _image_tool_result_content(result)

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -34,7 +34,11 @@ from band.runtime.custom_tools import (
     find_custom_tool,
 )
 from band.runtime.prompts import render_system_prompt
-from band.runtime.tools import READ_ROOM_FILE_TOOL_NAME, is_mcp_content_result
+from band.runtime.tools import (
+    READ_ROOM_FILE_TOOL_NAME,
+    image_block_placeholder,
+    is_mcp_content_result,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -472,7 +476,7 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
                     result
                 ):
                     content = _image_tool_result_content(result)
-                    result_str = f"<{len(content)} image content block(s)>"
+                    result_str = image_block_placeholder(len(content))
                 else:
                     content = result_str = (
                         json.dumps(result, default=str)

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -34,8 +34,31 @@ from band.runtime.custom_tools import (
     find_custom_tool,
 )
 from band.runtime.prompts import render_system_prompt
+from band.runtime.tools import is_mcp_content_result
 
 logger = logging.getLogger(__name__)
+
+
+def _image_tool_result_content(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Convert an MCP-content-shaped ``band_read_room_file`` result into
+    Anthropic ``ImageBlockParam`` dicts for a ``tool_result``'s content list.
+
+    Anthropic's ``media_type`` (jpeg/png/gif/webp) is exactly
+    ``PREVIEWABLE_IMAGE_CONTENT_TYPES`` -- the only content types
+    ``AgentTools.read_room_file`` ever inlines as an image -- so every
+    ``mimeType`` this sees is already a valid ``media_type``.
+    """
+    return [
+        {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": block["mimeType"],
+                "data": block["data"],
+            },
+        }
+        for block in result["content"]
+    ]
 
 
 class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
@@ -445,14 +468,18 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
                     result = await execute_custom_tool(custom_tool, tool_input)
                 else:
                     result = await tools.execute_tool_call(tool_name, tool_input)
-                result_str = (
-                    json.dumps(result, default=str)
-                    if not isinstance(result, str)
-                    else result
-                )
+                if tool_name == "band_read_room_file" and is_mcp_content_result(result):
+                    content = _image_tool_result_content(result)
+                    result_str = f"<{len(content)} image content block(s)>"
+                else:
+                    content = result_str = (
+                        json.dumps(result, default=str)
+                        if not isinstance(result, str)
+                        else result
+                    )
                 is_error = False
             except Exception as e:
-                result_str = f"Error: {e}"
+                content = result_str = f"Error: {e}"
                 is_error = True
                 logger.error("Tool %s failed: %s", tool_name, e)
 
@@ -480,7 +507,7 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
                 {
                     "type": "tool_result",
                     "tool_use_id": tool_use_id,
-                    "content": result_str,
+                    "content": content,
                     "is_error": is_error,
                 }
             )

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -34,7 +34,7 @@ from band.runtime.custom_tools import (
     find_custom_tool,
 )
 from band.runtime.prompts import render_system_prompt
-from band.runtime.tools import is_mcp_content_result
+from band.runtime.tools import READ_ROOM_FILE_TOOL_NAME, is_mcp_content_result
 
 logger = logging.getLogger(__name__)
 
@@ -468,7 +468,9 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
                     result = await execute_custom_tool(custom_tool, tool_input)
                 else:
                     result = await tools.execute_tool_call(tool_name, tool_input)
-                if tool_name == "band_read_room_file" and is_mcp_content_result(result):
+                if tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(
+                    result
+                ):
                     content = _image_tool_result_content(result)
                     result_str = f"<{len(content)} image content block(s)>"
                 else:

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -54,7 +54,7 @@ from band.runtime.custom_tools import (
 )
 from band.runtime.formatters import strip_leading_mentions
 from band.runtime.tools import (
-    READ_ROOM_FILE_TOOL_NAME,
+    BandTool,
     image_block_placeholder,
     is_mcp_content_result,
     is_room_posting_tool,
@@ -65,11 +65,11 @@ logger = logging.getLogger(__name__)
 
 
 def _image_content_items(result: dict[str, Any]) -> list[dict[str, Any]]:
-    """Convert an MCP-content-shaped band_read_room_file result into Codex
-    app-server ``inputImage`` content items, via a data: URI -- the protocol's
-    ``imageUrl`` field is a bare string with no inline-data-vs-http distinction
-    documented in its JSON schema, but data: URIs are the standard way to embed
-    inline image bytes in a URL field."""
+    """An image tool result as Codex app-server ``inputImage`` content items.
+
+    Inlined as a data: URI -- the protocol's ``imageUrl`` is a bare string with
+    no documented inline-vs-http distinction.
+    """
     return [
         {
             "type": "inputImage",
@@ -1401,7 +1401,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     success = outcome.ok
                 if (
                     success
-                    and tool_name == READ_ROOM_FILE_TOOL_NAME
+                    and tool_name == BandTool.READ_ROOM_FILE
                     and is_mcp_content_result(result)
                 ):
                     content_items = _image_content_items(result)

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -55,6 +55,7 @@ from band.runtime.custom_tools import (
 from band.runtime.formatters import strip_leading_mentions
 from band.runtime.tools import (
     READ_ROOM_FILE_TOOL_NAME,
+    image_block_placeholder,
     is_mcp_content_result,
     is_room_posting_tool,
 )
@@ -1402,7 +1403,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     result
                 ):
                     content_items = _image_content_items(result)
-                    text_result = f"<{len(content_items)} image content block(s)>"
+                    text_result = image_block_placeholder(len(content_items))
                 else:
                     text_result = (
                         result

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -54,10 +54,10 @@ from band.runtime.custom_tools import (
 )
 from band.runtime.formatters import strip_leading_mentions
 from band.runtime.tools import (
-    BandTool,
     image_block_placeholder,
-    is_mcp_content_result,
+    is_image_passthrough_result,
     is_room_posting_tool,
+    redact_tool_call_args,
 )
 from band.runtime.prompts import render_system_prompt
 
@@ -1378,7 +1378,9 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     content=json.dumps(
                         {
                             ToolEventKey.NAME: tool_name,
-                            ToolEventKey.ARGS: arguments,
+                            ToolEventKey.ARGS: redact_tool_call_args(
+                                tool_name, arguments
+                            ),
                             ToolEventKey.TOOL_CALL_ID: call_id,
                         }
                     ),
@@ -1399,11 +1401,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     )
                     result = outcome.value
                     success = outcome.ok
-                if (
-                    success
-                    and tool_name == BandTool.READ_ROOM_FILE
-                    and is_mcp_content_result(result)
-                ):
+                if success and is_image_passthrough_result(tool_name, result):
                     content_items = _image_content_items(result)
                     text_result = image_block_placeholder(len(content_items))
                 else:
@@ -1902,6 +1900,10 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         mcp_args = item.get("arguments", {})
         if not isinstance(mcp_args, dict):
             mcp_args = {}
+        # redact_tool_call_args compares against the bare tool name (e.g.
+        # "band_send_room_file"), not the "mcp:{server}/{tool}" display name
+        # this method returns -- redact before that prefix is applied.
+        mcp_args = redact_tool_call_args(tool, mcp_args)
         output = CodexAdapter._stringify_tool_output(
             item.get("result"),
             item.get("error"),

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -373,7 +373,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         {Emit.TOOL_CALLS, Emit.THOUGHTS, Emit.TASK_EVENTS, Emit.USAGE}
     )
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -1399,8 +1399,10 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     )
                     result = outcome.value
                     success = outcome.ok
-                if tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(
-                    result
+                if (
+                    success
+                    and tool_name == READ_ROOM_FILE_TOOL_NAME
+                    and is_mcp_content_result(result)
                 ):
                     content_items = _image_content_items(result)
                     text_result = image_block_placeholder(len(content_items))

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -53,10 +53,26 @@ from band.runtime.custom_tools import (
     format_validation_error,
 )
 from band.runtime.formatters import strip_leading_mentions
-from band.runtime.tools import is_room_posting_tool
+from band.runtime.tools import is_mcp_content_result, is_room_posting_tool
 from band.runtime.prompts import render_system_prompt
 
 logger = logging.getLogger(__name__)
+
+
+def _image_content_items(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Convert an MCP-content-shaped band_read_room_file result into Codex
+    app-server ``inputImage`` content items, via a data: URI -- the protocol's
+    ``imageUrl`` field is a bare string with no inline-data-vs-http distinction
+    documented in its JSON schema, but data: URIs are the standard way to embed
+    inline image bytes in a URL field."""
+    return [
+        {
+            "type": "inputImage",
+            "imageUrl": f"data:{block['mimeType']};base64,{block['data']}",
+        }
+        for block in result["content"]
+    ]
+
 
 TransportKind = Literal["stdio", "ws"]
 ApprovalMode = Literal["auto_accept", "auto_decline", "manual"]
@@ -1378,15 +1394,20 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     )
                     result = outcome.value
                     success = outcome.ok
-                text_result = (
-                    result
-                    if isinstance(result, str)
-                    else json.dumps(result, default=str)
-                )
+                if tool_name == "band_read_room_file" and is_mcp_content_result(result):
+                    content_items = _image_content_items(result)
+                    text_result = f"<{len(content_items)} image content block(s)>"
+                else:
+                    text_result = (
+                        result
+                        if isinstance(result, str)
+                        else json.dumps(result, default=str)
+                    )
+                    content_items = [{"type": "inputText", "text": text_result}]
                 await self._client.respond(
                     event.id,
                     {
-                        "contentItems": [{"type": "inputText", "text": text_result}],
+                        "contentItems": content_items,
                         "success": success,
                     },
                 )

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -53,7 +53,11 @@ from band.runtime.custom_tools import (
     format_validation_error,
 )
 from band.runtime.formatters import strip_leading_mentions
-from band.runtime.tools import is_mcp_content_result, is_room_posting_tool
+from band.runtime.tools import (
+    READ_ROOM_FILE_TOOL_NAME,
+    is_mcp_content_result,
+    is_room_posting_tool,
+)
 from band.runtime.prompts import render_system_prompt
 
 logger = logging.getLogger(__name__)
@@ -1394,7 +1398,9 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     )
                     result = outcome.value
                     success = outcome.ok
-                if tool_name == "band_read_room_file" and is_mcp_content_result(result):
+                if tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(
+                    result
+                ):
                     content_items = _image_content_items(result)
                     text_result = f"<{len(content_items)} image content block(s)>"
                 else:

--- a/src/band/adapters/copilot_sdk.py
+++ b/src/band/adapters/copilot_sdk.py
@@ -46,6 +46,7 @@ from band.runtime.tools import (
     CHAT_ID_FIELD_NAME,
     READ_ROOM_FILE_TOOL_NAME,
     get_band_tool_category,
+    image_block_placeholder,
     is_mcp_content_result,
     is_room_posting_tool,
 )
@@ -759,7 +760,7 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
                 )
                 for block in result["content"]
             ]
-            text_result = f"<{len(binary_results)} image content block(s)>"
+            text_result = image_block_placeholder(len(binary_results))
         else:
             text_result = (
                 result if isinstance(result, str) else json.dumps(result, default=str)

--- a/src/band/adapters/copilot_sdk.py
+++ b/src/band/adapters/copilot_sdk.py
@@ -44,7 +44,7 @@ from band.runtime.custom_tools import (
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     CHAT_ID_FIELD_NAME,
-    READ_ROOM_FILE_TOOL_NAME,
+    BandTool,
     get_band_tool_category,
     image_block_placeholder,
     is_mcp_content_result,
@@ -753,7 +753,7 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
             )
 
         binary_results: list[ToolBinaryResult] | None = None
-        if tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(result):
+        if tool_name == BandTool.READ_ROOM_FILE and is_mcp_content_result(result):
             binary_results = [
                 ToolBinaryResult(
                     data=block["data"], mime_type=block["mimeType"], type="image"

--- a/src/band/adapters/copilot_sdk.py
+++ b/src/band/adapters/copilot_sdk.py
@@ -44,11 +44,11 @@ from band.runtime.custom_tools import (
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     CHAT_ID_FIELD_NAME,
-    BandTool,
     get_band_tool_category,
     image_block_placeholder,
-    is_mcp_content_result,
+    is_image_passthrough_result,
     is_room_posting_tool,
+    redact_tool_call_args,
 )
 
 try:
@@ -753,13 +753,22 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
             )
 
         binary_results: list[ToolBinaryResult] | None = None
-        if tool_name == BandTool.READ_ROOM_FILE and is_mcp_content_result(result):
-            binary_results = [
-                ToolBinaryResult(
-                    data=block["data"], mime_type=block["mimeType"], type="image"
+        if is_image_passthrough_result(tool_name, result):
+            # Same failure path as the tool-execution try/except above: a
+            # malformed or future-extended content block must still route
+            # through _fail_tool_call, not raise uncaught past it.
+            try:
+                binary_results = [
+                    ToolBinaryResult(
+                        data=block["data"], mime_type=block["mimeType"], type="image"
+                    )
+                    for block in result["content"]
+                ]
+            except (KeyError, TypeError) as exc:
+                logger.exception("Malformed image content block for %s", tool_name)
+                return await self._fail_tool_call(
+                    room_tools, invocation, f"Error: {exc}", report=should_report
                 )
-                for block in result["content"]
-            ]
             text_result = image_block_placeholder(len(binary_results))
         else:
             text_result = (
@@ -804,7 +813,9 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
             json.dumps(
                 {
                     ToolEventKey.NAME: invocation.tool_name,
-                    ToolEventKey.ARGS: arguments,
+                    ToolEventKey.ARGS: redact_tool_call_args(
+                        invocation.tool_name, arguments
+                    ),
                     ToolEventKey.TOOL_CALL_ID: invocation.tool_call_id,
                 }
             ),

--- a/src/band/adapters/copilot_sdk.py
+++ b/src/band/adapters/copilot_sdk.py
@@ -44,6 +44,7 @@ from band.runtime.custom_tools import (
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     CHAT_ID_FIELD_NAME,
+    READ_ROOM_FILE_TOOL_NAME,
     get_band_tool_category,
     is_mcp_content_result,
     is_room_posting_tool,
@@ -751,7 +752,7 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
             )
 
         binary_results: list[ToolBinaryResult] | None = None
-        if tool_name == "band_read_room_file" and is_mcp_content_result(result):
+        if tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(result):
             binary_results = [
                 ToolBinaryResult(
                     data=block["data"], mime_type=block["mimeType"], type="image"

--- a/src/band/adapters/copilot_sdk.py
+++ b/src/band/adapters/copilot_sdk.py
@@ -45,11 +45,18 @@ from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     CHAT_ID_FIELD_NAME,
     get_band_tool_category,
+    is_mcp_content_result,
     is_room_posting_tool,
 )
 
 try:
-    from copilot import CopilotClient, PermissionHandler, Tool, ToolResult
+    from copilot import (
+        CopilotClient,
+        PermissionHandler,
+        Tool,
+        ToolBinaryResult,
+        ToolResult,
+    )
     from copilot.generated.session_events import (
         AssistantReasoningData,
         AssistantUsageData,
@@ -743,14 +750,26 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
                 room_tools, invocation, f"Error: {exc}", report=should_report
             )
 
-        text_result = (
-            result if isinstance(result, str) else json.dumps(result, default=str)
-        )
+        binary_results: list[ToolBinaryResult] | None = None
+        if tool_name == "band_read_room_file" and is_mcp_content_result(result):
+            binary_results = [
+                ToolBinaryResult(
+                    data=block["data"], mime_type=block["mimeType"], type="image"
+                )
+                for block in result["content"]
+            ]
+            text_result = f"<{len(binary_results)} image content block(s)>"
+        else:
+            text_result = (
+                result if isinstance(result, str) else json.dumps(result, default=str)
+            )
         if is_room_posting_tool(tool_name) and turn is not None:
             self._mark_replied_in_room(room_id, turn)
         if should_report:
             await self._report_tool_result(room_tools, invocation, text_result)
-        return ToolResult(text_result_for_llm=text_result)
+        return ToolResult(
+            text_result_for_llm=text_result, binary_results_for_llm=binary_results
+        )
 
     async def _fail_tool_call(
         self,

--- a/src/band/adapters/copilot_sdk.py
+++ b/src/band/adapters/copilot_sdk.py
@@ -214,7 +214,7 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
         {Emit.TOOL_CALLS, Emit.THOUGHTS, Emit.USAGE}
     )
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -105,7 +105,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.TOOL_CALLS})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(

--- a/src/band/adapters/crewai_flow.py
+++ b/src/band/adapters/crewai_flow.py
@@ -1505,7 +1505,9 @@ class CrewAIFlowAdapter(SimpleAdapter[CrewAIFlowSessionState]):
     """
 
     SUPPORTED_EMIT = frozenset({Emit.TOOL_CALLS})
-    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY, Capability.CONTACTS})
+    SUPPORTED_CAPABILITIES = frozenset(
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
+    )
 
     def __init__(
         self,

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -45,7 +45,7 @@ from band.runtime.custom_tools import (
 )
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
-    READ_ROOM_FILE_TOOL_NAME,
+    BandTool,
     decode_image_block,
     image_block_placeholder,
     is_mcp_content_result,
@@ -538,7 +538,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                     result = await execute_custom_tool(custom_tool, tool_input)
                 else:
                     result = await tools.execute_tool_call(tool_name, tool_input)
-                if tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(
+                if tool_name == BandTool.READ_ROOM_FILE and is_mcp_content_result(
                     result
                 ):
                     response_parts = _image_function_response_parts(result)

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import json
 import logging
 import warnings
@@ -47,6 +46,7 @@ from band.runtime.custom_tools import (
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     READ_ROOM_FILE_TOOL_NAME,
+    decode_image_block,
     image_block_placeholder,
     is_mcp_content_result,
 )
@@ -60,15 +60,15 @@ def _image_function_response_parts(
     """Convert an MCP-content-shaped band_read_room_file result into Gemini
     FunctionResponsePart inline_data blocks, so the model receives real image
     content instead of a JSON-stringified blob."""
-    return [
-        types.FunctionResponsePart(
-            inline_data=types.FunctionResponseBlob(
-                mime_type=block["mimeType"],
-                data=base64.b64decode(block["data"]),
+    parts: list[types.FunctionResponsePart] = []
+    for block in result["content"]:
+        data, mime_type = decode_image_block(block)
+        parts.append(
+            types.FunctionResponsePart(
+                inline_data=types.FunctionResponseBlob(mime_type=mime_type, data=data)
             )
         )
-        for block in result["content"]
-    ]
+    return parts
 
 
 class GeminiAdapter(SimpleAdapter[GeminiMessages]):

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
 import warnings
@@ -44,8 +45,26 @@ from band.runtime.custom_tools import (
     get_custom_tool_name,
 )
 from band.runtime.prompts import render_system_prompt
+from band.runtime.tools import is_mcp_content_result
 
 logger = logging.getLogger(__name__)
+
+
+def _image_function_response_parts(
+    result: dict[str, Any],
+) -> list[types.FunctionResponsePart]:
+    """Convert an MCP-content-shaped band_read_room_file result into Gemini
+    FunctionResponsePart inline_data blocks, so the model receives real image
+    content instead of a JSON-stringified blob."""
+    return [
+        types.FunctionResponsePart(
+            inline_data=types.FunctionResponseBlob(
+                mime_type=block["mimeType"],
+                data=base64.b64decode(block["data"]),
+            )
+        )
+        for block in result["content"]
+    ]
 
 
 class GeminiAdapter(SimpleAdapter[GeminiMessages]):
@@ -508,17 +527,22 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                 except Exception as e:
                     logger.warning("Failed to send tool_call event: %s", e)
 
+            response_parts: list[types.FunctionResponsePart] | None = None
             try:
                 custom_tool = find_custom_tool(self._custom_tools, tool_name)
                 if custom_tool:
                     result = await execute_custom_tool(custom_tool, tool_input)
                 else:
                     result = await tools.execute_tool_call(tool_name, tool_input)
-                result_str = (
-                    json.dumps(result, default=str)
-                    if not isinstance(result, str)
-                    else result
-                )
+                if tool_name == "band_read_room_file" and is_mcp_content_result(result):
+                    response_parts = _image_function_response_parts(result)
+                    result_str = f"<{len(response_parts)} image content block(s)>"
+                else:
+                    result_str = (
+                        json.dumps(result, default=str)
+                        if not isinstance(result, str)
+                        else result
+                    )
                 is_error = False
             except ValidationError as exc:
                 errors = format_validation_error(exc)
@@ -555,6 +579,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                         id=tool_call_id,
                         name=tool_name,
                         response=response_payload,
+                        parts=response_parts,
                     )
                 )
             )

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -45,7 +45,11 @@ from band.runtime.custom_tools import (
     get_custom_tool_name,
 )
 from band.runtime.prompts import render_system_prompt
-from band.runtime.tools import READ_ROOM_FILE_TOOL_NAME, is_mcp_content_result
+from band.runtime.tools import (
+    READ_ROOM_FILE_TOOL_NAME,
+    image_block_placeholder,
+    is_mcp_content_result,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -538,7 +542,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                     result
                 ):
                     response_parts = _image_function_response_parts(result)
-                    result_str = f"<{len(response_parts)} image content block(s)>"
+                    result_str = image_block_placeholder(len(response_parts))
                 else:
                     result_str = (
                         json.dumps(result, default=str)

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -66,7 +66,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.TOOL_CALLS, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -45,10 +45,10 @@ from band.runtime.custom_tools import (
 )
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
-    BandTool,
     decode_image_block,
     image_block_placeholder,
-    is_mcp_content_result,
+    is_image_passthrough_result,
+    redact_tool_call_args,
 )
 
 logger = logging.getLogger(__name__)
@@ -522,7 +522,9 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                         content=json.dumps(
                             {
                                 ToolEventKey.NAME: tool_name,
-                                ToolEventKey.ARGS: tool_input,
+                                ToolEventKey.ARGS: redact_tool_call_args(
+                                    tool_name, tool_input
+                                ),
                                 ToolEventKey.TOOL_CALL_ID: tool_call_id,
                             }
                         ),
@@ -538,9 +540,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                     result = await execute_custom_tool(custom_tool, tool_input)
                 else:
                     result = await tools.execute_tool_call(tool_name, tool_input)
-                if tool_name == BandTool.READ_ROOM_FILE and is_mcp_content_result(
-                    result
-                ):
+                if is_image_passthrough_result(tool_name, result):
                     response_parts = _image_function_response_parts(result)
                     result_str = image_block_placeholder(len(response_parts))
                 else:

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -45,7 +45,7 @@ from band.runtime.custom_tools import (
     get_custom_tool_name,
 )
 from band.runtime.prompts import render_system_prompt
-from band.runtime.tools import is_mcp_content_result
+from band.runtime.tools import READ_ROOM_FILE_TOOL_NAME, is_mcp_content_result
 
 logger = logging.getLogger(__name__)
 
@@ -534,7 +534,9 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                     result = await execute_custom_tool(custom_tool, tool_input)
                 else:
                     result = await tools.execute_tool_call(tool_name, tool_input)
-                if tool_name == "band_read_room_file" and is_mcp_content_result(result):
+                if tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(
+                    result
+                ):
                     response_parts = _image_function_response_parts(result)
                     result_str = f"<{len(response_parts)} image content block(s)>"
                 else:

--- a/src/band/adapters/google_adk.py
+++ b/src/band/adapters/google_adk.py
@@ -288,7 +288,7 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.TOOL_CALLS, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(

--- a/src/band/adapters/google_adk.py
+++ b/src/band/adapters/google_adk.py
@@ -37,6 +37,12 @@ from band.runtime.custom_tools import (
     find_custom_tool,
 )
 from band.runtime.prompts import render_system_prompt
+from band.runtime.tools import (
+    BandTool,
+    image_block_placeholder,
+    is_image_passthrough_result,
+    redact_tool_call_args,
+)
 
 if TYPE_CHECKING:
     from google.adk.runners import InMemoryRunner
@@ -55,6 +61,32 @@ _DECLARATION_CANDIDATES: tuple[str, ...] = (
     "_get_declaration",  # google-adk 1.x (current internal API)
     "get_declaration",  # likely public rename candidate
 )
+
+
+def _redacted_function_response_output(tool_name: str, response: Any) -> str:
+    """The text a tool_result event reports for one ADK function response.
+
+    ``run_async`` always ``json.dumps`` a non-str tool result before
+    returning it (ADK requires a plain string or dict return); ADK's own
+    ``__build_response_event`` then wraps a non-dict result as
+    ``{"result": <that json string>}`` since its spec requires a dict.
+    ``str()``ing that wrapper for ``band_read_room_file``'s image branch
+    would embed the full base64 payload, so unwrap and check it first.
+    """
+    if not response:
+        return ""
+    if tool_name == BandTool.READ_ROOM_FILE and isinstance(response, dict):
+        wrapped = response.get("result")
+        if isinstance(wrapped, str):
+            try:
+                parsed = json.loads(wrapped)
+            except (TypeError, ValueError):
+                parsed = None
+            if isinstance(parsed, dict) and is_image_passthrough_result(
+                tool_name, parsed
+            ):
+                return image_block_placeholder(len(parsed["content"]))
+    return str(response)
 
 
 def _sanitize_adk_agent_name(agent_name: str) -> str:
@@ -653,6 +685,7 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
         if function_calls:
             for fc in function_calls:
                 try:
+                    tool_name = getattr(fc, "name", "unknown")
                     try:
                         args = dict(fc.args) if fc.args else {}
                     except (TypeError, ValueError):
@@ -660,8 +693,10 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
                     await tools.send_event(
                         content=json.dumps(
                             {
-                                ToolEventKey.NAME: getattr(fc, "name", "unknown"),
-                                ToolEventKey.ARGS: args,
+                                ToolEventKey.NAME: tool_name,
+                                ToolEventKey.ARGS: redact_tool_call_args(
+                                    tool_name, args
+                                ),
                                 ToolEventKey.TOOL_CALL_ID: getattr(fc, "id", ""),
                             }
                         ),
@@ -674,13 +709,14 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
         if function_responses:
             for fr in function_responses:
                 try:
+                    tool_name = getattr(fr, "name", "unknown")
                     await tools.send_event(
                         content=json.dumps(
                             {
-                                ToolEventKey.NAME: getattr(fr, "name", "unknown"),
-                                ToolEventKey.OUTPUT: str(fr.response)
-                                if getattr(fr, "response", None)
-                                else "",
+                                ToolEventKey.NAME: tool_name,
+                                ToolEventKey.OUTPUT: _redacted_function_response_output(
+                                    tool_name, getattr(fr, "response", None)
+                                ),
                                 ToolEventKey.TOOL_CALL_ID: getattr(fr, "id", ""),
                             }
                         ),

--- a/src/band/adapters/langgraph.py
+++ b/src/band/adapters/langgraph.py
@@ -80,7 +80,7 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.TOOL_CALLS, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(

--- a/src/band/adapters/langgraph.py
+++ b/src/band/adapters/langgraph.py
@@ -23,6 +23,11 @@ from band.core.types import (
 )
 from band.converters.langchain import LangChainHistoryConverter, LangChainMessages
 from band.runtime.prompts import render_system_prompt
+from band.runtime.tools import (
+    BandTool,
+    image_block_placeholder,
+    redact_tool_call_args,
+)
 
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
@@ -32,6 +37,35 @@ logger = logging.getLogger(__name__)
 
 
 _BOOTSTRAP_TRACKING_WARN_THRESHOLD = 1000
+
+
+def _redacted_tool_end_output(tool_name: str, data: dict[str, Any]) -> Any:
+    """The value a tool_result event reports for one on_tool_end/on_tool_error.
+
+    ``data["output"]`` may be a langchain ``ToolMessage`` whose ``.content``
+    is the ``list[ImageContentBlock]`` that ``langchain_tools.py``'s
+    ``execute_definition`` builds for ``band_read_room_file``'s image branch
+    (a *different* shape than the platform's own MCP content blocks --
+    ``mime_type``/``base64`` keys, not ``mimeType``/``data``). That object
+    isn't JSON-serializable, so ``json.dumps``'s ``default=str`` would
+    otherwise fall back to ``str(ToolMessage(...))``, embedding the full
+    base64 payload.
+    """
+    if data.get("error"):
+        return data["error"]
+    output = data.get("output", "")
+    if tool_name == BandTool.READ_ROOM_FILE:
+        content = getattr(output, "content", output)
+        if (
+            isinstance(content, list)
+            and content
+            and all(
+                isinstance(block, dict) and block.get("type") == "image"
+                for block in content
+            )
+        ):
+            return image_block_placeholder(len(content))
+    return output
 
 
 class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
@@ -381,7 +415,9 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
             data = event.get("data") if isinstance(event.get("data"), dict) else {}
             payload = {
                 ToolEventKey.NAME: tool_name,
-                ToolEventKey.ARGS: data.get("input", {}),
+                ToolEventKey.ARGS: redact_tool_call_args(
+                    tool_name, data.get("input", {})
+                ),
                 ToolEventKey.TOOL_CALL_ID: event.get("run_id", "unknown"),
             }
             logger.info("[STREAM] on_tool_start: %s", tool_name)
@@ -402,7 +438,7 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
             is_error = event_type == "on_tool_error" or bool(data.get("error"))
             payload = {
                 ToolEventKey.NAME: tool_name,
-                ToolEventKey.OUTPUT: data.get("error") or data.get("output", ""),
+                ToolEventKey.OUTPUT: _redacted_tool_end_output(tool_name, data),
                 ToolEventKey.TOOL_CALL_ID: event.get("run_id", "unknown"),
                 ToolEventKey.IS_ERROR: is_error,
             }

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -15,6 +15,7 @@ from band.converters.letta import LettaHistoryConverter, LettaSessionState
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
+    AdapterFeatures,
     Capability,
     Emit,
     FeatureKwargs,
@@ -139,7 +140,17 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         self._shared_agent_id: str | None = None
 
         # The Band MCP tool path: self-hosted server + Letta registration.
-        self._mcp = LettaMCPBridge(
+        self._mcp = self._build_mcp_bridge()
+
+        # Protects agent creation and MCP (re)registration only — not held
+        # during message handling, so concurrent rooms process in parallel.
+        self._rpc_lock = asyncio.Lock()
+
+        # Built during on_started
+        self._system_prompt: str = ""
+
+    def _build_mcp_bridge(self) -> LettaMCPBridge:
+        return LettaMCPBridge(
             self.config.mcp,
             tool_definitions=iter_tool_definitions(
                 capabilities=self.features.capabilities,
@@ -148,12 +159,10 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
             teardown_timeout_s=self.config.teardown_timeout_s,
         )
 
-        # Protects agent creation and MCP (re)registration only — not held
-        # during message handling, so concurrent rooms process in parallel.
-        self._rpc_lock = asyncio.Lock()
-
-        # Built during on_started
-        self._system_prompt: str = ""
+    def apply_effective_features(self, features: AdapterFeatures) -> None:
+        """Rebuild the unstarted MCP bridge with negotiated capabilities."""
+        super().apply_effective_features(features)
+        self._mcp = self._build_mcp_bridge()
 
     def _get_room_tools(self, room_id: str) -> AgentToolsProtocol | None:
         """Resolve room-scoped tools for the self-hosted MCP server."""

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -112,7 +112,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         {Emit.TOOL_CALLS, Emit.TASK_EVENTS, Emit.USAGE}
     )
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -31,7 +31,11 @@ from band.integrations.letta.config import (
 from band.integrations.letta.mcp import LettaMCPBridge, bounded_teardown
 from band.integrations.letta.prompts import render_tool_enforcement
 from band.runtime.prompts import render_system_prompt
-from band.runtime.tools import CHAT_ID_FIELD_NAME, iter_tool_definitions
+from band.runtime.tools import (
+    CHAT_ID_FIELD_NAME,
+    iter_tool_definitions,
+    redact_tool_call_args,
+)
 
 __all__ = [
     "LettaAdapter",
@@ -478,15 +482,29 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                     )
                     if tool_name == self._mcp.send_message_tool:
                         used_send_message = True
+                    # ToolCall.arguments is a JSON string (letta_client's own
+                    # wire shape); parse it so redact_tool_call_args can
+                    # replace band_send_room_file's content field -- reporting
+                    # the raw string would put real file bytes in this event.
+                    raw_arguments = (
+                        getattr(tool_call, "arguments", "{}") if tool_call else "{}"
+                    )
+                    try:
+                        parsed_arguments = json.loads(raw_arguments)
+                    except (TypeError, ValueError):
+                        parsed_arguments = raw_arguments
+                    reported_args = (
+                        redact_tool_call_args(tool_name, parsed_arguments)
+                        if isinstance(parsed_arguments, dict)
+                        else parsed_arguments
+                    )
                     await self._report_execution_event(
                         tools,
                         "tool_call",
                         tool_name,
                         {
                             ToolEventKey.NAME: tool_name,
-                            ToolEventKey.ARGS: getattr(tool_call, "arguments", "{}")
-                            if tool_call
-                            else "{}",
+                            ToolEventKey.ARGS: reported_args,
                         },
                     )
                 case "tool_return_message":

--- a/src/band/adapters/opencode/adapter.py
+++ b/src/band/adapters/opencode/adapter.py
@@ -22,6 +22,7 @@ from band.core.exceptions import BandConnectionError
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
+    AdapterFeatures,
     Capability,
     Emit,
     FeatureKwargs,
@@ -56,7 +57,6 @@ from band.runtime.custom_tools import CustomToolDef, get_custom_tool_name
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     CHAT_ID_FIELD_NAME,
-    ToolDefinition,
     is_room_posting_tool,
     iter_tool_definitions,
 )
@@ -251,15 +251,21 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         # names eagerly keeps the "is this our own band tool?" auto-approve
         # check (and room-posting detection) independent of MCP-registration
         # timing, so a second room's first turn can't race an empty set.
-        self._tool_definitions: list[ToolDefinition] = list(
-            iter_tool_definitions(
-                capabilities=self.features.capabilities,
-            )
+        self._refresh_tool_definitions()
+
+    def _refresh_tool_definitions(self) -> None:
+        self._tool_definitions = list(
+            iter_tool_definitions(capabilities=self.features.capabilities)
         )
-        self._own_tool_names: frozenset[str] = frozenset(
+        self._own_tool_names = frozenset(
             {definition.name for definition in self._tool_definitions}
             | {get_custom_tool_name(model) for model, _fn in self._custom_tools}
         )
+
+    def apply_effective_features(self, features: AdapterFeatures) -> None:
+        """Keep the MCP registration aligned with negotiated capabilities."""
+        super().apply_effective_features(features)
+        self._refresh_tool_definitions()
 
     async def on_started(self, agent_name: str, agent_description: str) -> None:
         await super().on_started(agent_name, agent_description)

--- a/src/band/adapters/opencode/adapter.py
+++ b/src/band/adapters/opencode/adapter.py
@@ -208,7 +208,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         {Emit.TOOL_CALLS, Emit.TASK_EVENTS, Emit.USAGE}
     )
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(

--- a/src/band/adapters/parlant.py
+++ b/src/band/adapters/parlant.py
@@ -98,7 +98,7 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset()
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -62,6 +62,7 @@ from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     band_tool_errored,
     decode_image_block,
+    image_block_placeholder,
     is_mcp_content_result,
     is_terminal_success,
     missing_reply_error,
@@ -833,14 +834,25 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                         ):
                             tool_executed = True
                         if Emit.TOOL_CALLS in self.features.emit:
+                            output = event.part.content
+                            if (
+                                isinstance(output, list)
+                                and output
+                                and all(
+                                    isinstance(item, BinaryContent) for item in output
+                                )
+                            ):
+                                # str() on BinaryContent embeds its raw `data`
+                                # bytes -- band_read_room_file's image result
+                                # would otherwise dump the full file into this
+                                # event instead of a bounded placeholder.
+                                output = image_block_placeholder(len(output))
                             try:
                                 await tools.send_event(
                                     content=json.dumps(
                                         {
                                             ToolEventKey.NAME: event.part.tool_name,
-                                            ToolEventKey.OUTPUT: str(
-                                                event.part.content
-                                            ),
+                                            ToolEventKey.OUTPUT: str(output),
                                             ToolEventKey.TOOL_CALL_ID: event.tool_call_id,
                                         }
                                     ),

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -67,6 +67,7 @@ from band.runtime.tools import (
     is_terminal_success,
     missing_reply_error,
     platform_tool,
+    redact_tool_call_args,
     serialize_tool_result,
 )
 
@@ -812,7 +813,10 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                                     content=json.dumps(
                                         {
                                             ToolEventKey.NAME: event.part.tool_name,
-                                            ToolEventKey.ARGS: event.part.args,
+                                            ToolEventKey.ARGS: redact_tool_call_args(
+                                                event.part.tool_name,
+                                                event.part.args_as_dict(),
+                                            ),
                                             ToolEventKey.TOOL_CALL_ID: event.part.tool_call_id,
                                         }
                                     ),

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -6,6 +6,7 @@ Extracted from band.integrations.pydantic_ai.agent.BandPydanticAgent.
 
 from __future__ import annotations
 
+import base64
 import inspect
 import json
 import logging
@@ -25,6 +26,7 @@ from pydantic_ai import (
 )
 from pydantic_ai.capabilities import Hooks, ProcessHistory
 from pydantic_ai.messages import (
+    BinaryContent,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -60,6 +62,7 @@ from band.runtime.custom_tools import (
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     band_tool_errored,
+    is_mcp_content_result,
     is_terminal_success,
     missing_reply_error,
     platform_tool,
@@ -658,9 +661,18 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             async def band_read_room_file(
                 ctx: RunContext[AgentToolsProtocol],
                 file_id: str,
-            ) -> dict[str, Any] | str:
+            ) -> dict[str, Any] | str | list[BinaryContent]:
                 try:
-                    return await ctx.deps.read_room_file(file_id)
+                    result = await ctx.deps.read_room_file(file_id)
+                    if is_mcp_content_result(result):
+                        return [
+                            BinaryContent(
+                                data=base64.b64decode(block["data"]),
+                                media_type=block["mimeType"],
+                            )
+                            for block in result["content"]
+                        ]
+                    return result
                 except Exception as e:
                     return f"Error reading room file: {e}"
 

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -6,7 +6,6 @@ Extracted from band.integrations.pydantic_ai.agent.BandPydanticAgent.
 
 from __future__ import annotations
 
-import base64
 import inspect
 import json
 import logging
@@ -62,6 +61,7 @@ from band.runtime.custom_tools import (
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     band_tool_errored,
+    decode_image_block,
     is_mcp_content_result,
     is_terminal_success,
     missing_reply_error,
@@ -666,11 +666,10 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                     result = await ctx.deps.read_room_file(file_id)
                     if is_mcp_content_result(result):
                         return [
-                            BinaryContent(
-                                data=base64.b64decode(block["data"]),
-                                media_type=block["mimeType"],
+                            BinaryContent(data=data, media_type=mime_type)
+                            for data, mime_type in (
+                                decode_image_block(block) for block in result["content"]
                             )
-                            for block in result["content"]
                         ]
                     return result
                 except Exception as e:

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -216,7 +216,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.TOOL_CALLS, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(
@@ -638,6 +638,50 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                     return f"Error archiving memory: {e}"
 
             agent.tool(band_archive_memory)
+
+        # Room-file tools (opt-in via Capability.FILES)
+        if Capability.FILES in self.features.capabilities:
+
+            @platform_tool
+            async def band_list_room_files(
+                ctx: RunContext[AgentToolsProtocol],
+                cursor: str | None = None,
+            ) -> dict[str, Any] | str:
+                try:
+                    return await ctx.deps.list_room_files(cursor)
+                except Exception as e:
+                    return f"Error listing room files: {e}"
+
+            agent.tool(band_list_room_files)
+
+            @platform_tool
+            async def band_read_room_file(
+                ctx: RunContext[AgentToolsProtocol],
+                file_id: str,
+            ) -> dict[str, Any] | str:
+                try:
+                    return await ctx.deps.read_room_file(file_id)
+                except Exception as e:
+                    return f"Error reading room file: {e}"
+
+            agent.tool(band_read_room_file)
+
+            @platform_tool
+            async def band_send_room_file(
+                ctx: RunContext[AgentToolsProtocol],
+                content: str,
+                filename: str,
+                mentions: list[str],
+                caption: str = "",
+            ) -> dict[str, Any] | str:
+                try:
+                    return await ctx.deps.send_room_file(
+                        content, filename, caption, mentions
+                    )
+                except Exception as e:
+                    return f"Error sending room file '{filename}': {e}"
+
+            agent.tool(band_send_room_file)
 
         # Register custom tools (user-provided PydanticAI-compatible functions) on
         # the path their signature calls for — pydantic-ai keeps the two apart.

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -56,7 +56,7 @@ from band.runtime.custom_tools import (
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     ALL_TOOL_NAMES,
-    READ_ROOM_FILE_TOOL_NAME,
+    BandTool,
     ToolDefinition,
     ToolCallOutcome,
     band_tool_errored,
@@ -89,7 +89,7 @@ def _tool_result(tool_use: ToolUse, *, value: object, ok: bool) -> ToolResult:
     content: list[ToolResultContent]
     if (
         ok
-        and tool_use["name"] == READ_ROOM_FILE_TOOL_NAME
+        and tool_use["name"] == BandTool.READ_ROOM_FILE
         and is_mcp_content_result(value)
     ):
         content = []

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 from collections.abc import Awaitable, Callable, Mapping
@@ -16,10 +17,12 @@ try:
     from strands.hooks.events import AfterToolCallEvent, BeforeToolCallEvent
     from strands.models import Model
     from strands.models.openai import OpenAIModel
+    from strands.types.media import ImageFormat
     from strands.types.tools import (
         AgentTool,
         ToolGenerator,
         ToolResult,
+        ToolResultContent,
         ToolSpec,
         ToolUse,
     )
@@ -58,6 +61,7 @@ from band.runtime.tools import (
     ToolCallOutcome,
     band_tool_errored,
     get_band_tool_category,
+    is_mcp_content_result,
     is_terminal_success,
     iter_tool_definitions,
     missing_reply_error,
@@ -80,10 +84,29 @@ def _format_tool_output(value: object) -> str:
 
 def _tool_result(tool_use: ToolUse, *, value: object, ok: bool) -> ToolResult:
     """Build the framework's typed result envelope at the Strands boundary."""
+    content: list[ToolResultContent]
+    if (
+        ok
+        and tool_use["name"] == "band_read_room_file"
+        and is_mcp_content_result(value)
+    ):
+        content = [
+            {
+                "image": {
+                    "format": cast(
+                        ImageFormat, block["mimeType"].removeprefix("image/")
+                    ),
+                    "source": {"bytes": base64.b64decode(block["data"])},
+                }
+            }
+            for block in cast(dict[str, Any], value)["content"]
+        ]
+    else:
+        content = [{"text": _format_tool_output(value)}]
     return {
         "toolUseId": tool_use["toolUseId"],
         "status": "success" if ok else "error",
-        "content": [{"text": _format_tool_output(value)}],
+        "content": content,
     }
 
 

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import base64
 import json
 import logging
 from collections.abc import Awaitable, Callable, Mapping
@@ -61,7 +60,9 @@ from band.runtime.tools import (
     ToolDefinition,
     ToolCallOutcome,
     band_tool_errored,
+    decode_image_block,
     get_band_tool_category,
+    image_block_placeholder,
     is_mcp_content_result,
     is_terminal_success,
     iter_tool_definitions,
@@ -91,17 +92,17 @@ def _tool_result(tool_use: ToolUse, *, value: object, ok: bool) -> ToolResult:
         and tool_use["name"] == READ_ROOM_FILE_TOOL_NAME
         and is_mcp_content_result(value)
     ):
-        content = [
-            {
-                "image": {
-                    "format": cast(
-                        ImageFormat, block["mimeType"].removeprefix("image/")
-                    ),
-                    "source": {"bytes": base64.b64decode(block["data"])},
+        content = []
+        for block in cast(dict[str, Any], value)["content"]:
+            data, mime_type = decode_image_block(block)
+            content.append(
+                {
+                    "image": {
+                        "format": cast(ImageFormat, mime_type.removeprefix("image/")),
+                        "source": {"bytes": data},
+                    }
                 }
-            }
-            for block in cast(dict[str, Any], value)["content"]
-        ]
+            )
     else:
         content = [{"text": _format_tool_output(value)}]
     return {
@@ -120,6 +121,8 @@ def _result_text(result: ToolResult) -> str:
                 parts.append(text)
             case {"json": value}:
                 parts.append(_format_tool_output(value))
+            case {"image": _}:
+                parts.append(image_block_placeholder(1))
     return "\n".join(parts)
 
 

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -56,17 +56,17 @@ from band.runtime.custom_tools import (
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     ALL_TOOL_NAMES,
-    BandTool,
     ToolDefinition,
     ToolCallOutcome,
     band_tool_errored,
     decode_image_block,
     get_band_tool_category,
     image_block_placeholder,
-    is_mcp_content_result,
+    is_image_passthrough_result,
     is_terminal_success,
     iter_tool_definitions,
     missing_reply_error,
+    redact_tool_call_args,
     serialize_tool_result,
     validate_tool_arguments,
 )
@@ -87,27 +87,40 @@ def _format_tool_output(value: object) -> str:
 def _tool_result(tool_use: ToolUse, *, value: object, ok: bool) -> ToolResult:
     """Build the framework's typed result envelope at the Strands boundary."""
     content: list[ToolResultContent]
-    if (
-        ok
-        and tool_use["name"] == BandTool.READ_ROOM_FILE
-        and is_mcp_content_result(value)
-    ):
-        content = []
-        for block in cast(dict[str, Any], value)["content"]:
-            data, mime_type = decode_image_block(block)
-            content.append(
-                {
-                    "image": {
-                        "format": cast(ImageFormat, mime_type.removeprefix("image/")),
-                        "source": {"bytes": data},
+    status = "success" if ok else "error"
+    if ok and is_image_passthrough_result(tool_use["name"], value):
+        try:
+            content = []
+            for block in cast(dict[str, Any], value)["content"]:
+                data, mime_type = decode_image_block(block)
+                content.append(
+                    {
+                        "image": {
+                            "format": cast(
+                                ImageFormat, mime_type.removeprefix("image/")
+                            ),
+                            "source": {"bytes": data},
+                        }
                     }
-                }
+                )
+        except Exception as error:
+            # A malformed or future-extended image block (see
+            # is_mcp_content_result's docstring) must degrade to the
+            # adapter's normal failure result, not raise uncaught out of
+            # stream()'s async generator -- this runs after _execute's own
+            # try/except already succeeded, so it needs its own boundary.
+            logger.error(
+                "Failed to decode image content for %s: %s",
+                tool_use["name"],
+                error,
             )
+            status = "error"
+            content = [{"text": f"Error: {error}"}]
     else:
         content = [{"text": _format_tool_output(value)}]
     return {
         "toolUseId": tool_use["toolUseId"],
-        "status": "success" if ok else "error",
+        "status": status,
         "content": content,
     }
 
@@ -333,7 +346,9 @@ class BandTurnHooks(HookProvider):
             MessageType.TOOL_CALL,
             {
                 ToolEventKey.NAME: event.tool_use["name"],
-                ToolEventKey.ARGS: event.tool_use["input"],
+                ToolEventKey.ARGS: redact_tool_call_args(
+                    event.tool_use["name"], event.tool_use["input"]
+                ),
                 ToolEventKey.TOOL_CALL_ID: event.tool_use["toolUseId"],
             },
         )

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -349,7 +349,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.TOOL_CALLS, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -115,6 +115,8 @@ def _tool_result(tool_use: ToolUse, *, value: object, ok: bool) -> ToolResult:
 def _result_text(result: ToolResult) -> str:
     """Flatten a tool result for execution events and terminal-state policy."""
     parts: list[str] = []
+    image_count = 0
+    image_index: int | None = None
     for block in result.get("content", []):
         match block:
             case {"text": str() as text}:
@@ -122,7 +124,12 @@ def _result_text(result: ToolResult) -> str:
             case {"json": value}:
                 parts.append(_format_tool_output(value))
             case {"image": _}:
-                parts.append(image_block_placeholder(1))
+                if image_index is None:
+                    image_index = len(parts)
+                    parts.append("")
+                image_count += 1
+    if image_index is not None:
+        parts[image_index] = image_block_placeholder(image_count)
     return "\n".join(parts)
 
 

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -57,6 +57,7 @@ from band.runtime.custom_tools import (
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
     ALL_TOOL_NAMES,
+    READ_ROOM_FILE_TOOL_NAME,
     ToolDefinition,
     ToolCallOutcome,
     band_tool_errored,
@@ -87,7 +88,7 @@ def _tool_result(tool_use: ToolUse, *, value: object, ok: bool) -> ToolResult:
     content: list[ToolResultContent]
     if (
         ok
-        and tool_use["name"] == "band_read_room_file"
+        and tool_use["name"] == READ_ROOM_FILE_TOOL_NAME
         and is_mcp_content_result(value)
     ):
         content = [

--- a/src/band/integrations/acp/client_adapter.py
+++ b/src/band/integrations/acp/client_adapter.py
@@ -129,7 +129,7 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset()
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY, Capability.CONTACTS}
+        {Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
     )
 
     def __init__(

--- a/src/band/integrations/acp/client_adapter.py
+++ b/src/band/integrations/acp/client_adapter.py
@@ -18,7 +18,13 @@ from band.converters.acp_client import ACPClientHistoryConverter
 from band.converters.helpers import build_replay_messages
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
-from band.core.types import Capability, Emit, FeatureKwargs, PlatformMessage
+from band.core.types import (
+    AdapterFeatures,
+    Capability,
+    Emit,
+    FeatureKwargs,
+    PlatformMessage,
+)
 from band.integrations.acp.client_profiles import ACPClientProfile
 from band.integrations.acp.client_runtime import (
     ACPConnectionProtocol,
@@ -183,6 +189,11 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
         # _band_mcp_backend None and start a fresh one that outlives shutdown
         # and is never stopped -- a real leaked server, not just a failed turn.
         self._stopped = False
+
+    def apply_effective_features(self, features: AdapterFeatures) -> None:
+        """Rebuild the lazy MCP registration after capability negotiation."""
+        super().apply_effective_features(features)
+        self._tool_definitions, self._own_tool_names = self._registered_tools()
 
     @staticmethod
     def _shape_command(command: str | list[str] | None, host: str | None) -> list[str]:

--- a/src/band/integrations/claude_sdk/tools.py
+++ b/src/band/integrations/claude_sdk/tools.py
@@ -37,6 +37,7 @@ from band.runtime.tools import (
     BASE_TOOL_NAMES,
     CHAT_ID_FIELD_NAME,
     CHAT_TOOL_NAMES,
+    READ_ROOM_FILE_TOOL_NAME,
     SEND_MESSAGE_TOOL_NAME,
     ToolDefinition,
     append_mention_handles_hint,
@@ -131,7 +132,7 @@ def _format_success_payload(
     result: Any,
 ) -> dict[str, Any]:
     """Keep tool result payloads stable across Claude integrations."""
-    if tool_name == "band_read_room_file" and is_mcp_content_result(result):
+    if tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(result):
         # Pass the image content block through bare -- wrapping it in
         # {"status": "success", **result} would bury "content" behind an
         # extra key, and _make_result would no longer recognize the shape.
@@ -232,7 +233,7 @@ def _build_builtin_sdk_tool(
             # content block (see _format_success_payload) -- pass it through
             # bare instead of json-encoding it into a text block, which is
             # what _make_result would otherwise do to any dict.
-            if definition.name == "band_read_room_file" and is_mcp_content_result(
+            if definition.name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(
                 payload
             ):
                 return payload

--- a/src/band/integrations/claude_sdk/tools.py
+++ b/src/band/integrations/claude_sdk/tools.py
@@ -40,7 +40,7 @@ from band.runtime.tools import (
     BandTool,
     ToolDefinition,
     append_mention_handles_hint,
-    is_mcp_content_result,
+    is_image_passthrough_result,
     iter_tool_definitions,
     mcp_tool_names,
     serialize_tool_result,
@@ -87,7 +87,7 @@ def _make_result(data: Any) -> dict[str, Any]:
     misfire on an unrelated custom tool whose own return value happens to
     have a "content" list of dicts each carrying a "type" key. The
     band_read_room_file passthrough is instead decided by the one caller that
-    actually needs it -- see ``is_mcp_content_result`` at the
+    actually needs it -- see ``is_image_passthrough_result`` at the
     ``_build_builtin_sdk_tool`` call site.
     """
     return {"content": [{"type": "text", "text": json.dumps(data, default=str)}]}
@@ -131,16 +131,16 @@ def _format_success_payload(
     result: Any,
 ) -> dict[str, Any]:
     """Keep tool result payloads stable across Claude integrations."""
-    if tool_name == BandTool.READ_ROOM_FILE and is_mcp_content_result(result):
+    if is_image_passthrough_result(tool_name, result):
         # Pass the image content block through bare -- wrapping it in
         # {"status": "success", **result} would bury "content" behind an
         # extra key, and _make_result would no longer recognize the shape.
         return result
-    if tool_name == "band_send_message":
+    if tool_name == BandTool.SEND_MESSAGE:
         return {"status": "success", "message": "Message sent"}
-    if tool_name == "band_send_event":
+    if tool_name == BandTool.SEND_EVENT:
         return {"status": "success", "message": "Event sent"}
-    if tool_name == "band_add_participant":
+    if tool_name == BandTool.ADD_PARTICIPANT:
         return {
             "status": "success",
             "message": (
@@ -148,13 +148,13 @@ def _format_success_payload(
             ),
             **result,
         }
-    if tool_name == "band_remove_participant":
+    if tool_name == BandTool.REMOVE_PARTICIPANT:
         return {
             "status": "success",
             "message": f"Participant '{call_args['identifier']}' removed",
             **result,
         }
-    if tool_name == "band_get_participants":
+    if tool_name == BandTool.GET_PARTICIPANTS:
         participants = result if isinstance(result, list) else []
         # Convert Fern models to dicts for JSON serialization
         serialized = [
@@ -165,7 +165,7 @@ def _format_success_payload(
             "participants": serialized,
             "count": len(serialized),
         }
-    if tool_name == "band_create_chatroom":
+    if tool_name == BandTool.CREATE_CHATROOM:
         return {
             "status": "success",
             "message": "Chat room created",
@@ -232,9 +232,7 @@ def _build_builtin_sdk_tool(
             # content block (see _format_success_payload) -- pass it through
             # bare instead of json-encoding it into a text block, which is
             # what _make_result would otherwise do to any dict.
-            if definition.name == BandTool.READ_ROOM_FILE and is_mcp_content_result(
-                payload
-            ):
+            if is_image_passthrough_result(definition.name, payload):
                 return payload
             return _make_result(payload)
         except (ValueError, BandToolError) as error:

--- a/src/band/integrations/claude_sdk/tools.py
+++ b/src/band/integrations/claude_sdk/tools.py
@@ -40,6 +40,7 @@ from band.runtime.tools import (
     SEND_MESSAGE_TOOL_NAME,
     ToolDefinition,
     append_mention_handles_hint,
+    is_mcp_content_result,
     iter_tool_definitions,
     mcp_tool_names,
     serialize_tool_result,
@@ -76,24 +77,6 @@ def __getattr__(name: str) -> Any:
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-def _is_mcp_content_result(data: Any) -> bool:
-    """True when ``data`` is already MCP-content-shaped (``{"content": [...]}``).
-
-    ``band_read_room_file``'s image branch returns exactly this shape (a real
-    MCP image content block) so ``claude_agent_sdk`` can hand it to the model
-    as vision input. Everything else this module produces (status payloads,
-    error payloads) is a plain dict that still needs json-encoding into a
-    text block.
-    """
-    return (
-        isinstance(data, dict)
-        and isinstance(data.get("content"), list)
-        and all(
-            isinstance(block, dict) and "type" in block for block in data["content"]
-        )
-    )
-
-
 def _make_result(data: Any) -> dict[str, Any]:
     """Format tool result for Claude SDK MCP responses.
 
@@ -104,7 +87,7 @@ def _make_result(data: Any) -> dict[str, Any]:
     misfire on an unrelated custom tool whose own return value happens to
     have a "content" list of dicts each carrying a "type" key. The
     band_read_room_file passthrough is instead decided by the one caller that
-    actually needs it -- see ``_is_mcp_content_result`` at the
+    actually needs it -- see ``is_mcp_content_result`` at the
     ``_build_builtin_sdk_tool`` call site.
     """
     return {"content": [{"type": "text", "text": json.dumps(data, default=str)}]}
@@ -148,7 +131,7 @@ def _format_success_payload(
     result: Any,
 ) -> dict[str, Any]:
     """Keep tool result payloads stable across Claude integrations."""
-    if tool_name == "band_read_room_file" and _is_mcp_content_result(result):
+    if tool_name == "band_read_room_file" and is_mcp_content_result(result):
         # Pass the image content block through bare -- wrapping it in
         # {"status": "success", **result} would bury "content" behind an
         # extra key, and _make_result would no longer recognize the shape.
@@ -249,7 +232,7 @@ def _build_builtin_sdk_tool(
             # content block (see _format_success_payload) -- pass it through
             # bare instead of json-encoding it into a text block, which is
             # what _make_result would otherwise do to any dict.
-            if definition.name == "band_read_room_file" and _is_mcp_content_result(
+            if definition.name == "band_read_room_file" and is_mcp_content_result(
                 payload
             ):
                 return payload

--- a/src/band/integrations/claude_sdk/tools.py
+++ b/src/band/integrations/claude_sdk/tools.py
@@ -37,8 +37,7 @@ from band.runtime.tools import (
     BASE_TOOL_NAMES,
     CHAT_ID_FIELD_NAME,
     CHAT_TOOL_NAMES,
-    READ_ROOM_FILE_TOOL_NAME,
-    SEND_MESSAGE_TOOL_NAME,
+    BandTool,
     ToolDefinition,
     append_mention_handles_hint,
     is_mcp_content_result,
@@ -132,7 +131,7 @@ def _format_success_payload(
     result: Any,
 ) -> dict[str, Any]:
     """Keep tool result payloads stable across Claude integrations."""
-    if tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(result):
+    if tool_name == BandTool.READ_ROOM_FILE and is_mcp_content_result(result):
         # Pass the image content block through bare -- wrapping it in
         # {"status": "success", **result} would bury "content" behind an
         # extra key, and _make_result would no longer recognize the shape.
@@ -233,14 +232,14 @@ def _build_builtin_sdk_tool(
             # content block (see _format_success_payload) -- pass it through
             # bare instead of json-encoding it into a text block, which is
             # what _make_result would otherwise do to any dict.
-            if definition.name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(
+            if definition.name == BandTool.READ_ROOM_FILE and is_mcp_content_result(
                 payload
             ):
                 return payload
             return _make_result(payload)
         except (ValueError, BandToolError) as error:
             if (
-                definition.name == SEND_MESSAGE_TOOL_NAME
+                definition.name == BandTool.SEND_MESSAGE
                 and get_participant_handles is not None
             ):
                 available = get_participant_handles(room_id)

--- a/src/band/integrations/crewai/catalog.py
+++ b/src/band/integrations/crewai/catalog.py
@@ -20,6 +20,7 @@ from band.core.protocols import AgentToolsProtocol
 from band.integrations.crewai.reporting import CrewAIToolReporter
 from band.runtime.tools import (
     BandTool,
+    file_content_placeholder,
     image_block_placeholder,
     is_mcp_content_result,
     platform_args_schema,
@@ -469,6 +470,7 @@ async def _read_room_file(call: Invocation, *, file_id: str = "") -> Any:
     BandTool.SEND_ROOM_FILE,
     args_schema=SEND_ROOM_FILE_ARGS_SCHEMA,
     normalize=_posted_file_args,
+    reports=False,
 )
 async def _send_room_file(
     call: Invocation,
@@ -478,7 +480,22 @@ async def _send_room_file(
     caption: str = "",
     mentions: Any = None,
 ) -> Any:
-    return await call.tools.send_room_file(content, filename, caption, mentions)
+    # reports=False: report_call's default behavior would json.dumps the raw
+    # file content into a tool_call event -- report a bounded placeholder for
+    # content instead, mirroring how _read_room_file bounds its own result.
+    await call.reporter.report_call(
+        call.tools,
+        BandTool.SEND_ROOM_FILE,
+        {
+            "content": file_content_placeholder(len(content.encode("utf-8"))),
+            "filename": filename,
+            "caption": caption,
+            "mentions": mentions,
+        },
+    )
+    result = await call.tools.send_room_file(content, filename, caption, mentions)
+    await call.reporter.report_result(call.tools, BandTool.SEND_ROOM_FILE, result)
+    return result
 
 
 if frozenset(spec.name for spec in PLATFORM_TOOLS) != frozenset(BandTool):

--- a/src/band/integrations/crewai/catalog.py
+++ b/src/band/integrations/crewai/catalog.py
@@ -1,0 +1,475 @@
+"""The Band platform tools CrewAI exposes, one ``@band_tool`` body each.
+
+``band_tool`` carries the lifecycle every tool would otherwise repeat --
+report the call, run the body, report the result, render the model-facing
+text -- so a body spells out only the platform call it makes. The decorated
+bodies collect into ``PLATFORM_TOOLS`` in declaration order, which is the
+order a crew is handed them.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, cast
+
+from pydantic import BaseModel, field_validator
+
+from band.core.protocols import AgentToolsProtocol
+from band.integrations.crewai.reporting import CrewAIToolReporter
+from band.runtime.tools import (
+    BandTool,
+    is_mcp_content_result,
+    platform_args_schema,
+    serialize_tool_result,
+    validate_tool_arguments,
+)
+
+
+# --- Rendering a tool result as the text CrewAI hands the model ---
+
+
+def serialize_success_result(result: Any) -> str:
+    """Serialize a successful tool result without losing domain status fields.
+
+    Pydantic models are converted via serialize_tool_result at the boundary.
+    Dicts that already carry a "status" key (e.g. domain status from REST
+    responses) get that field renamed to "result_status" so the wrapper's
+    own "status": "success" envelope stays unambiguous.
+    """
+    result = serialize_tool_result(result)
+    if isinstance(result, dict):
+        payload = dict(result)
+        result_status = payload.pop("status", None)
+        response: dict[str, Any] = {"status": "success", **payload}
+        if result_status is not None:
+            response["result_status"] = result_status
+        return json.dumps(response, default=str)
+    return json.dumps({"status": "success", "result": result}, default=str)
+
+
+def as_json(result: Any) -> str:
+    """Serialize an envelope the body already shaped."""
+    return json.dumps(result, default=str)
+
+
+def vision_sentinel(result: dict[str, Any]) -> str:
+    """Encode the first image block as CrewAI's ``VISION_IMAGE:`` sentinel.
+
+    StepExecutor rewrites this exact string shape into a real image content
+    block before the LLM sees it: an internal crewai protocol, verified against
+    the installed package rather than documented, so a version bump can break it.
+    """
+    block = result["content"][0]
+    return f"VISION_IMAGE:{block['mimeType']}:{block['data']}"
+
+
+def text_or_success(result: Any) -> str:
+    """Pass a body-rendered string through; wrap anything else in the envelope."""
+    return result if isinstance(result, str) else serialize_success_result(result)
+
+
+def succeeded(message: str, **fields: Any) -> dict[str, Any]:
+    """The success envelope for a tool whose result is the fact that it ran."""
+    return {"status": "success", "message": message, **fields}
+
+
+# --- Tool declaration ---
+
+
+@dataclass(frozen=True)
+class Invocation:
+    """The per-call handles a tool body runs against."""
+
+    tools: AgentToolsProtocol
+    reporter: CrewAIToolReporter
+
+
+ToolBody = Callable[..., Awaitable[Any]]
+Renderer = Callable[[Any], str]
+ArgNormalizer = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """One platform tool: what CrewAI advertises, plus the body behind it."""
+
+    name: BandTool
+    body: ToolBody
+    args_schema: type[BaseModel]
+    declared: dict[str, Any] | None
+    render: Renderer
+    reports: bool
+    normalize: ArgNormalizer | None
+
+    def arguments(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """The call's arguments: declared defaults filled in, unknown keys dropped."""
+        if self.declared is None:
+            return kwargs
+        known = {key: kwargs[key] for key in kwargs.keys() & self.declared.keys()}
+        args = {**self.declared, **known}
+        return self.normalize(args) if self.normalize else args
+
+    async def invoke(self, call: Invocation, kwargs: dict[str, Any]) -> str:
+        args = self.arguments(kwargs)
+        if self.reports:
+            await call.reporter.report_call(call.tools, self.name, args)
+        result = await self.body(call, **args)
+        if self.reports:
+            await call.reporter.report_result(call.tools, self.name, result)
+        return self.render(result)
+
+
+PLATFORM_TOOLS: list[ToolSpec] = []
+
+
+def band_tool(
+    name: BandTool,
+    *,
+    args_schema: type[BaseModel] | None = None,
+    render: Renderer = serialize_success_result,
+    reports: bool = True,
+    normalize: ArgNormalizer | None = None,
+) -> Callable[[ToolBody], ToolSpec]:
+    """Register an async body as the platform tool ``name``.
+
+    The body's keyword-only parameters and their defaults are the arguments the
+    tool accepts and reports; a body declaring ``**kwargs`` instead receives the
+    caller's arguments untouched (``band_send_event`` validates them itself).
+    ``reports=False`` hands a body full control of its own event emission.
+    """
+
+    def register(body: ToolBody) -> ToolSpec:
+        spec = ToolSpec(
+            name=name,
+            body=body,
+            args_schema=args_schema or platform_args_schema(name),
+            declared=_declared_arguments(body),
+            render=render,
+            reports=reports,
+            normalize=normalize,
+        )
+        PLATFORM_TOOLS.append(spec)
+        return spec
+
+    return register
+
+
+def _declared_arguments(body: ToolBody) -> dict[str, Any] | None:
+    """A body's keyword parameters and defaults, or None if it takes raw kwargs."""
+    params = list(inspect.signature(body).parameters.values())[1:]
+    if any(param.kind is param.VAR_KEYWORD for param in params):
+        return None
+    return {param.name: param.default for param in params}
+
+
+def without_none(**fields: Any) -> dict[str, Any]:
+    """Only the fields that carry a value — the REST layer rejects explicit nulls."""
+    return {key: value for key, value in fields.items() if value is not None}
+
+
+# --- CrewAI-specific parsing leniency ---
+
+
+def normalize_mentions_lenient(value: Any) -> list[str]:
+    """Coerce whatever CrewAI's tool layer produced into a list of handles.
+
+    Smaller models driving CrewAI emit ``mentions`` as a JSON-encoded string or
+    a bracketed list of bare handles (``"[@john/agent]"``) rather than a real
+    list. Without this the platform rejects the call for having no mentions and
+    the agent retries in a loop, so the leniency lives here rather than on the
+    master model, which every other adapter satisfies as-is.
+    """
+    if value is None or value == "":
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            pass
+        else:
+            if isinstance(decoded, list):
+                return [str(item) for item in decoded]
+        stripped = value.strip().strip("[]")
+        return [
+            token.strip().strip("'\"") for token in stripped.split(",") if token.strip()
+        ]
+    return [str(value)]
+
+
+SEND_MESSAGE_ARGS_SCHEMA: type[BaseModel] = platform_args_schema(
+    BandTool.SEND_MESSAGE,
+    validators={
+        "normalize_mentions": field_validator("mentions", mode="before")(
+            staticmethod(normalize_mentions_lenient)
+        ),
+    },
+)
+
+# band_send_room_file's mentions field is the same shape/purpose as
+# band_send_message's -- smaller models hit the same leniency need here.
+SEND_ROOM_FILE_ARGS_SCHEMA: type[BaseModel] = platform_args_schema(
+    BandTool.SEND_ROOM_FILE,
+    validators={
+        "normalize_mentions": field_validator("mentions", mode="before")(
+            staticmethod(normalize_mentions_lenient)
+        ),
+    },
+)
+
+SEND_EVENT_ARGS_SCHEMA: type[BaseModel] = platform_args_schema(BandTool.SEND_EVENT)
+
+
+def _posted_file_args(args: dict[str, Any]) -> dict[str, Any]:
+    """Apply the schema's mention/caption leniency to a directly-called ``_run``."""
+    return {
+        **args,
+        "caption": args["caption"] or "",
+        "mentions": normalize_mentions_lenient(args["mentions"]),
+    }
+
+
+# --- Chat tools ---
+
+
+@band_tool(
+    BandTool.SEND_MESSAGE,
+    args_schema=SEND_MESSAGE_ARGS_SCHEMA,
+    render=as_json,
+    reports=False,
+)
+async def _send_message(
+    call: Invocation, *, content: str = "", mentions: Any = None
+) -> Any:
+    """Post a message, unless the reporter owns delivery (and its events) itself."""
+    # Normalized here too, not just in the schema: _run is also called
+    # directly, bypassing args_schema validation.
+    mention_list = normalize_mentions_lenient(mentions)
+    delivery = getattr(call.reporter, "execute_send_message", None)
+    if callable(delivery):
+        deliver = cast(
+            Callable[[AgentToolsProtocol, str, list[str]], Awaitable[None]], delivery
+        )
+        await deliver(call.tools, content, mention_list)
+    else:
+        await call.reporter.report_call(
+            call.tools,
+            BandTool.SEND_MESSAGE,
+            {"content": content, "mentions": mention_list},
+        )
+        await call.tools.send_message(content, mention_list)
+        await call.reporter.report_result(call.tools, BandTool.SEND_MESSAGE, "success")
+    return succeeded("Message sent")
+
+
+@band_tool(
+    BandTool.SEND_EVENT,
+    args_schema=SEND_EVENT_ARGS_SCHEMA,
+    render=as_json,
+    reports=False,
+)
+async def _send_event(call: Invocation, **kwargs: Any) -> Any:
+    """Emit a raw event, reporting nothing itself to avoid meta-events."""
+    # Validated here rather than by the caller: _run is also called directly,
+    # bypassing args_schema, and _execute_tool turns the ValueError into the
+    # error result the caller expects.
+    args = validate_tool_arguments(BandTool.SEND_EVENT, SEND_EVENT_ARGS_SCHEMA, kwargs)
+    await call.tools.send_event(
+        args["content"], args["message_type"], metadata=args.get("metadata")
+    )
+    return succeeded("Event sent")
+
+
+@band_tool(BandTool.ADD_PARTICIPANT)
+async def _add_participant(
+    call: Invocation, *, identifier: str = "", role: str = "member"
+) -> Any:
+    return await call.tools.add_participant(identifier, role)
+
+
+@band_tool(BandTool.REMOVE_PARTICIPANT)
+async def _remove_participant(call: Invocation, *, identifier: str = "") -> Any:
+    return await call.tools.remove_participant(identifier)
+
+
+@band_tool(BandTool.GET_PARTICIPANTS, render=as_json)
+async def _get_participants(call: Invocation) -> Any:
+    participants = await call.tools.get_participants()
+    serialized, count = _plain_participants(participants)
+    return {"status": "success", "participants": serialized, "count": count}
+
+
+def _plain_participants(participants: Any) -> tuple[Any, int]:
+    """Participants as plain data plus their count (0 when not a list)."""
+    if not isinstance(participants, list):
+        return participants, 0
+    plain = [p.model_dump() if hasattr(p, "model_dump") else p for p in participants]
+    return plain, len(participants)
+
+
+@band_tool(BandTool.LOOKUP_PEERS)
+async def _lookup_peers(call: Invocation, *, page: int = 1, page_size: int = 50) -> Any:
+    return await call.tools.lookup_peers(page, page_size)
+
+
+@band_tool(BandTool.CREATE_CHATROOM, render=as_json)
+async def _create_chatroom(call: Invocation, *, task_id: str | None = None) -> Any:
+    room_id = await call.tools.create_chatroom(task_id)
+    return succeeded("Chat room created", room_id=room_id)
+
+
+# --- Contact tools ---
+
+
+@band_tool(BandTool.LIST_CONTACTS)
+async def _list_contacts(
+    call: Invocation, *, page: int = 1, page_size: int = 50
+) -> Any:
+    return await call.tools.list_contacts(page, page_size)
+
+
+@band_tool(BandTool.ADD_CONTACT)
+async def _add_contact(
+    call: Invocation, *, handle: str = "", message: str | None = None
+) -> Any:
+    return await call.tools.add_contact(handle, message)
+
+
+@band_tool(BandTool.REMOVE_CONTACT)
+async def _remove_contact(
+    call: Invocation, *, handle: str | None = None, contact_id: str | None = None
+) -> Any:
+    return await call.tools.remove_contact(handle, contact_id)
+
+
+@band_tool(BandTool.LIST_CONTACT_REQUESTS)
+async def _list_contact_requests(
+    call: Invocation,
+    *,
+    page: int = 1,
+    page_size: int = 50,
+    sent_status: str = "pending",
+) -> Any:
+    return await call.tools.list_contact_requests(page, page_size, sent_status)
+
+
+@band_tool(BandTool.RESPOND_CONTACT_REQUEST)
+async def _respond_contact_request(
+    call: Invocation,
+    *,
+    action: str = "",
+    handle: str | None = None,
+    request_id: str | None = None,
+) -> Any:
+    return await call.tools.respond_contact_request(action, handle, request_id)
+
+
+# --- Memory tools ---
+
+
+@band_tool(BandTool.LIST_MEMORIES)
+async def _list_memories(
+    call: Invocation,
+    *,
+    subject_id: str | None = None,
+    scope: str | None = None,
+    system: str | None = None,
+    type: str | None = None,
+    segment: str | None = None,
+    content_query: str | None = None,
+    page_size: int = 50,
+    status: str | None = None,
+) -> Any:
+    return await call.tools.list_memories(
+        page_size=page_size,
+        **without_none(
+            subject_id=subject_id,
+            scope=scope,
+            system=system,
+            type=type,
+            segment=segment,
+            content_query=content_query,
+            status=status,
+        ),
+    )
+
+
+@band_tool(BandTool.STORE_MEMORY)
+async def _store_memory(
+    call: Invocation,
+    *,
+    content: str = "",
+    system: str = "",
+    type: str = "",
+    segment: str = "",
+    thought: str = "",
+    scope: str = "",
+    subject_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Any:
+    return await call.tools.store_memory(
+        content=content,
+        system=system,
+        type=type,
+        segment=segment,
+        thought=thought,
+        scope=scope,
+        **without_none(subject_id=subject_id, metadata=metadata),
+    )
+
+
+@band_tool(BandTool.GET_MEMORY)
+async def _get_memory(call: Invocation, *, memory_id: str = "") -> Any:
+    return await call.tools.get_memory(memory_id)
+
+
+@band_tool(BandTool.SUPERSEDE_MEMORY)
+async def _supersede_memory(call: Invocation, *, memory_id: str = "") -> Any:
+    return await call.tools.supersede_memory(memory_id)
+
+
+@band_tool(BandTool.ARCHIVE_MEMORY)
+async def _archive_memory(call: Invocation, *, memory_id: str = "") -> Any:
+    return await call.tools.archive_memory(memory_id)
+
+
+# --- Room file tools ---
+
+
+@band_tool(BandTool.LIST_ROOM_FILES)
+async def _list_room_files(call: Invocation, *, cursor: str | None = None) -> Any:
+    return await call.tools.list_room_files(cursor)
+
+
+@band_tool(BandTool.READ_ROOM_FILE, render=text_or_success)
+async def _read_room_file(call: Invocation, *, file_id: str = "") -> Any:
+    result = await call.tools.read_room_file(file_id)
+    # The sentinel is reported as well as returned: a tool_result carrying the
+    # raw base64 blob is worthless to a reader and huge on the wire.
+    return vision_sentinel(result) if is_mcp_content_result(result) else result
+
+
+@band_tool(
+    BandTool.SEND_ROOM_FILE,
+    args_schema=SEND_ROOM_FILE_ARGS_SCHEMA,
+    normalize=_posted_file_args,
+)
+async def _send_room_file(
+    call: Invocation,
+    *,
+    content: str = "",
+    filename: str = "",
+    caption: str = "",
+    mentions: Any = None,
+) -> Any:
+    return await call.tools.send_room_file(content, filename, caption, mentions)
+
+
+if frozenset(spec.name for spec in PLATFORM_TOOLS) != frozenset(BandTool):
+    raise ValueError(
+        "CrewAI platform tools drifted from BandTool: "
+        f"{frozenset(spec.name for spec in PLATFORM_TOOLS) ^ frozenset(BandTool)}"
+    )

--- a/src/band/integrations/crewai/catalog.py
+++ b/src/band/integrations/crewai/catalog.py
@@ -118,6 +118,13 @@ class ToolSpec:
         if self.reports:
             await call.reporter.report_call(call.tools, self.name, args)
         result = await self.body(call, **args)
+        # Serialize once, before reporting: report_result's json.dumps has no
+        # default=str, so a body that returns a raw Pydantic/Fern model
+        # (bypassing execute_tool_call's own serialization boundary) would
+        # otherwise raise inside report_result and silently drop the
+        # tool_result event -- render() already serializes via this same
+        # helper, so reuse its output instead of serializing twice.
+        result = serialize_tool_result(result)
         if self.reports:
             await call.reporter.report_result(call.tools, self.name, result)
         return self.render(result)

--- a/src/band/integrations/crewai/catalog.py
+++ b/src/band/integrations/crewai/catalog.py
@@ -20,6 +20,7 @@ from band.core.protocols import AgentToolsProtocol
 from band.integrations.crewai.reporting import CrewAIToolReporter
 from band.runtime.tools import (
     BandTool,
+    image_block_placeholder,
     is_mcp_content_result,
     platform_args_schema,
     serialize_tool_result,
@@ -444,12 +445,24 @@ async def _list_room_files(call: Invocation, *, cursor: str | None = None) -> An
     return await call.tools.list_room_files(cursor)
 
 
-@band_tool(BandTool.READ_ROOM_FILE, render=text_or_success)
+@band_tool(BandTool.READ_ROOM_FILE, render=text_or_success, reports=False)
 async def _read_room_file(call: Invocation, *, file_id: str = "") -> Any:
+    # reports=False: an image result must still return the full VISION_IMAGE
+    # sentinel (StepExecutor needs the real base64 to build vision content),
+    # but reporting that same string would put the raw base64 blob in a
+    # tool_result event -- huge on the wire and worthless to a reader. Report
+    # a bounded placeholder instead, independent of what's returned.
+    await call.reporter.report_call(
+        call.tools, BandTool.READ_ROOM_FILE, {"file_id": file_id}
+    )
     result = await call.tools.read_room_file(file_id)
-    # The sentinel is reported as well as returned: a tool_result carrying the
-    # raw base64 blob is worthless to a reader and huge on the wire.
-    return vision_sentinel(result) if is_mcp_content_result(result) else result
+    if is_mcp_content_result(result):
+        reported: Any = image_block_placeholder(len(result["content"]))
+        sentinel = vision_sentinel(result)
+        await call.reporter.report_result(call.tools, BandTool.READ_ROOM_FILE, reported)
+        return sentinel
+    await call.reporter.report_result(call.tools, BandTool.READ_ROOM_FILE, result)
+    return result
 
 
 @band_tool(

--- a/src/band/integrations/crewai/reporting.py
+++ b/src/band/integrations/crewai/reporting.py
@@ -1,0 +1,139 @@
+"""Room context and tool-event reporting for the CrewAI integration.
+
+A reporter decides whether a tool call and its result reach the platform as
+``tool_call`` / ``tool_result`` events. Each CrewAI adapter supplies its own,
+so the tool wrappers stay unaware of how (or whether) a turn is narrated.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from band.core.protocols import AgentToolsProtocol
+from band.core.types import AdapterFeatures, Emit, ToolEventKey
+
+logger = logging.getLogger(__name__)
+
+
+# --- Shared context + reporter contracts ---
+
+
+@dataclass
+class ReplyTracker:
+    """Mutable per-turn markers shared (by reference) with the tool wrappers.
+
+    ``replied`` flips once ``band_send_message`` succeeds; ``tool_executed`` flips
+    once any terminal tool succeeds.
+    """
+
+    replied: bool = False
+    tool_executed: bool = False
+
+
+@dataclass(frozen=True)
+class CrewAIToolContext:
+    """The room a tool call belongs to, plus the tools it runs against."""
+
+    room_id: str
+    tools: AgentToolsProtocol
+    reply_tracker: ReplyTracker | None = None
+
+
+@runtime_checkable
+class CrewAIToolReporter(Protocol):
+    """Hook for tool execution event emission.
+
+    Implementations decide whether to send tool_call / tool_result events to
+    the platform. The default EmitToolCallsReporter gates emission on
+    Emit.TOOL_CALLS. NoopReporter never emits.
+
+    Both methods are best-effort: implementations must not raise on transport
+    failure. Wrappers depend on this contract.
+    """
+
+    async def report_call(
+        self,
+        tools: AgentToolsProtocol,
+        tool_name: str,
+        input_data: dict[str, Any],
+    ) -> None: ...
+
+    async def report_result(
+        self,
+        tools: AgentToolsProtocol,
+        tool_name: str,
+        result: Any,
+        is_error: bool = False,
+    ) -> None: ...
+
+
+class EmitToolCallsReporter:
+    """Reporter gated by Emit.TOOL_CALLS — matches legacy CrewAIAdapter behavior."""
+
+    def __init__(self, features: AdapterFeatures) -> None:
+        self._features = features
+
+    async def report_call(
+        self,
+        tools: AgentToolsProtocol,
+        tool_name: str,
+        input_data: dict[str, Any],
+    ) -> None:
+        if Emit.TOOL_CALLS not in self._features.emit:
+            return
+        try:
+            await tools.send_event(
+                content=json.dumps(
+                    {ToolEventKey.NAME: tool_name, ToolEventKey.ARGS: input_data}
+                ),
+                message_type="tool_call",
+            )
+        except Exception as e:
+            logger.warning("Failed to send tool_call event: %s", e)
+
+    async def report_result(
+        self,
+        tools: AgentToolsProtocol,
+        tool_name: str,
+        result: Any,
+        is_error: bool = False,
+    ) -> None:
+        if Emit.TOOL_CALLS not in self._features.emit:
+            return
+        try:
+            await tools.send_event(
+                content=json.dumps(
+                    {
+                        ToolEventKey.NAME: tool_name,
+                        ToolEventKey.OUTPUT: result,
+                        ToolEventKey.IS_ERROR: is_error,
+                    }
+                ),
+                message_type="tool_result",
+            )
+        except Exception as e:
+            logger.warning("Failed to send tool_result event: %s", e)
+
+
+class NoopReporter:
+    """Reporter that emits nothing — useful for adapters that report elsewhere."""
+
+    async def report_call(
+        self,
+        tools: AgentToolsProtocol,
+        tool_name: str,
+        input_data: dict[str, Any],
+    ) -> None:
+        return None
+
+    async def report_result(
+        self,
+        tools: AgentToolsProtocol,
+        tool_name: str,
+        result: Any,
+        is_error: bool = False,
+    ) -> None:
+        return None

--- a/src/band/integrations/crewai/tools.py
+++ b/src/band/integrations/crewai/tools.py
@@ -7,12 +7,13 @@ spawn sub-Crews inside @listen methods get platform tools without copying code.
 The builder takes three injectables:
 - get_context: callable returning the current room context (room_id + tools).
   Each adapter owns its own ContextVar and supplies its own getter.
-- reporter: CrewAIToolReporter implementation. Two ship in this module:
+- reporter: CrewAIToolReporter implementation. Two ship in this integration:
   EmitToolCallsReporter (gates by Emit.TOOL_CALLS) and NoopReporter.
 - capabilities: frozenset[Capability] — controls which tool subset is exposed.
 
-Extracted from src/band/adapters/crewai.py so both CrewAI adapters share
-one platform tool surface.
+What each tool *does* lives in ``catalog.py``; this module is how one is run
+and handed to a crew. It is also the integration's public face: the names in
+``__all__`` are re-exported here for both adapters and their tests.
 """
 
 from __future__ import annotations
@@ -20,18 +21,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from dataclasses import dataclass
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Awaitable,
-    Callable,
-    Protocol,
-    cast,
-    runtime_checkable,
-)
+from typing import TYPE_CHECKING, Any, Callable
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from crewai.tools import BaseTool
@@ -39,11 +31,20 @@ if TYPE_CHECKING:
 from band.core.exceptions import BandToolError
 from band.core.protocols import AgentToolsProtocol
 from band.core.tool_filter import filter_tool_schemas
-from band.core.types import (
-    AdapterFeatures,
-    Capability,
-    Emit,
-    ToolEventKey,
+from band.core.types import AdapterFeatures, Capability
+from band.integrations.crewai.catalog import (
+    PLATFORM_TOOLS,
+    Invocation,
+    ToolSpec,
+    serialize_success_result,
+    vision_sentinel,
+)
+from band.integrations.crewai.reporting import (
+    CrewAIToolContext,
+    CrewAIToolReporter,
+    EmitToolCallsReporter,
+    NoopReporter,
+    ReplyTracker,
 )
 from band.integrations.crewai.runtime import run_async
 from band.runtime.custom_tools import (
@@ -53,208 +54,19 @@ from band.runtime.custom_tools import (
     is_marked_terminal,
 )
 from band.runtime.tools import (
+    CAPABILITY_TOOL_NAMES,
     EVENT_TOOL_NAMES,
-    SEND_MESSAGE_TOOL_NAME,
+    BandTool,
     append_available_mention_handles,
+    get_band_tool_category,
     get_tool_description,
-    is_mcp_content_result,
     is_terminal_success,
-    platform_args_schema,
-    serialize_tool_result,
-    validate_tool_arguments,
 )
 
 logger = logging.getLogger(__name__)
 
-_CREWAI_TOOL_CATEGORIES = {
-    "band_send_message": "chat",
-    "band_send_event": "chat",
-    "band_add_participant": "chat",
-    "band_remove_participant": "chat",
-    "band_get_participants": "chat",
-    "band_lookup_peers": "chat",
-    "band_create_chatroom": "chat",
-    "band_list_contacts": "contacts",
-    "band_add_contact": "contacts",
-    "band_remove_contact": "contacts",
-    "band_list_contact_requests": "contacts",
-    "band_respond_contact_request": "contacts",
-    "band_list_memories": "memory",
-    "band_store_memory": "memory",
-    "band_get_memory": "memory",
-    "band_supersede_memory": "memory",
-    "band_archive_memory": "memory",
-    "band_list_room_files": "files",
-    "band_read_room_file": "files",
-    "band_send_room_file": "files",
-}
 
-
-# --- Shared context + reporter contracts ---
-
-
-@dataclass
-class ReplyTracker:
-    """Mutable per-turn markers shared (by reference) with the tool wrappers.
-
-    ``replied`` flips once ``band_send_message`` succeeds; ``tool_executed`` flips
-    once *any* tool succeeds. Together they let an adapter tell a benign "empty
-    final answer" from CrewAI — emitted after the agent already did its work, via
-    a reply or any other tool (e.g. a memory store on a turn instructed not to
-    message) — apart from a genuine no-response failure where nothing happened.
-    """
-
-    replied: bool = False
-    tool_executed: bool = False
-
-
-@dataclass(frozen=True)
-class CrewAIToolContext:
-    """Snapshot of the current room context passed to tool wrappers.
-
-    Each adapter owns its own ContextVar and supplies its own getter that
-    returns this dataclass. Tools never reach back into the adapter directly.
-    """
-
-    room_id: str
-    tools: AgentToolsProtocol
-    reply_tracker: ReplyTracker | None = None
-
-
-@runtime_checkable
-class CrewAIToolReporter(Protocol):
-    """Hook for tool execution event emission.
-
-    Implementations decide whether to send tool_call / tool_result events to
-    the platform. The default EmitToolCallsReporter gates emission on
-    Emit.TOOL_CALLS. NoopReporter never emits.
-
-    Both methods are best-effort: implementations must not raise on transport
-    failure. Wrappers depend on this contract.
-    """
-
-    async def report_call(
-        self,
-        tools: AgentToolsProtocol,
-        tool_name: str,
-        input_data: dict[str, Any],
-    ) -> None: ...
-
-    async def report_result(
-        self,
-        tools: AgentToolsProtocol,
-        tool_name: str,
-        result: Any,
-        is_error: bool = False,
-    ) -> None: ...
-
-
-class EmitToolCallsReporter:
-    """Reporter gated by Emit.TOOL_CALLS — matches legacy CrewAIAdapter behavior."""
-
-    def __init__(self, features: AdapterFeatures) -> None:
-        self._features = features
-
-    async def report_call(
-        self,
-        tools: AgentToolsProtocol,
-        tool_name: str,
-        input_data: dict[str, Any],
-    ) -> None:
-        if Emit.TOOL_CALLS not in self._features.emit:
-            return
-        try:
-            await tools.send_event(
-                content=json.dumps(
-                    {ToolEventKey.NAME: tool_name, ToolEventKey.ARGS: input_data}
-                ),
-                message_type="tool_call",
-            )
-        except Exception as e:
-            logger.warning("Failed to send tool_call event: %s", e)
-
-    async def report_result(
-        self,
-        tools: AgentToolsProtocol,
-        tool_name: str,
-        result: Any,
-        is_error: bool = False,
-    ) -> None:
-        if Emit.TOOL_CALLS not in self._features.emit:
-            return
-        try:
-            await tools.send_event(
-                content=json.dumps(
-                    {
-                        ToolEventKey.NAME: tool_name,
-                        ToolEventKey.OUTPUT: result,
-                        ToolEventKey.IS_ERROR: is_error,
-                    }
-                ),
-                message_type="tool_result",
-            )
-        except Exception as e:
-            logger.warning("Failed to send tool_result event: %s", e)
-
-
-class NoopReporter:
-    """Reporter that emits nothing — useful for adapters that report elsewhere."""
-
-    async def report_call(
-        self,
-        tools: AgentToolsProtocol,
-        tool_name: str,
-        input_data: dict[str, Any],
-    ) -> None:
-        return None
-
-    async def report_result(
-        self,
-        tools: AgentToolsProtocol,
-        tool_name: str,
-        result: Any,
-        is_error: bool = False,
-    ) -> None:
-        return None
-
-
-# --- Helpers ---
-
-
-def serialize_success_result(result: Any) -> str:
-    """Serialize a successful tool result without losing domain status fields.
-
-    Pydantic models are converted via serialize_tool_result at the boundary.
-    Dicts that already carry a "status" key (e.g. domain status from REST
-    responses) get that field renamed to "result_status" so the wrapper's
-    own "status": "success" envelope stays unambiguous.
-    """
-    result = serialize_tool_result(result)
-    if isinstance(result, dict):
-        payload = dict(result)
-        result_status = payload.pop("status", None)
-        response: dict[str, Any] = {"status": "success", **payload}
-        if result_status is not None:
-            response["result_status"] = result_status
-        return json.dumps(response, default=str)
-    return json.dumps({"status": "success", "result": result}, default=str)
-
-
-def vision_sentinel(result: dict[str, Any]) -> str:
-    """Encode an MCP-content-shaped image result as CrewAI's native vision
-    sentinel string, so the model gets real image content instead of a
-    JSON-stringified blob.
-
-    CrewAI's own StepExecutor (crewai/agents/step_executor.py, on the default
-    native-tool-calling execution path) recognizes a tool result string
-    shaped ``VISION_IMAGE:<media_type>:<base64_data>`` and rewrites it into a
-    real ``image_url`` content block before the LLM ever sees it -- verified
-    against the installed crewai package, not documented publicly. Only the
-    first content block is encoded: the sentinel carries one image, and
-    AgentTools.read_room_file() only ever returns one for a previewable image.
-    """
-    block = result["content"][0]
-    return f"VISION_IMAGE:{block['mimeType']}:{block['data']}"
+# --- Execution ---
 
 
 def _execute_tool(
@@ -287,7 +99,7 @@ def _execute_tool(
             return await coro_factory(tools)
         except Exception as e:
             error_msg = str(e)
-            if tool_name == SEND_MESSAGE_TOOL_NAME and isinstance(
+            if tool_name == BandTool.SEND_MESSAGE and isinstance(
                 e, (ValueError, BandToolError)
             ):
                 error_msg = append_available_mention_handles(
@@ -302,82 +114,35 @@ def _execute_tool(
 
     result = run_async(_execute(), fallback_loop=fallback_loop)
 
-    # Record that the agent did productive work this turn so the adapter can treat
-    # CrewAI's "empty final answer" ValueError as benign (the work already
-    # happened) instead of a genuine no-response failure. ``replied`` is the
-    # stricter signal (a user-facing reply went out via band_send_message);
-    # ``tool_executed`` covers any successful *terminal* tool — a non-read-only
-    # band tool, or a custom tool that opted in via ``band_terminal`` — so a
-    # tool-only turn (e.g. a memory store the user told the agent not to follow
-    # with a message) is also benign. Read-only band tools and undeclared custom
-    # tools do NOT count: an empty answer after only those is a genuine
-    # no-response failure (fail-loud). ``is_terminal_success`` is the single
-    # source of truth, shared with the pydantic-ai adapter.
     if context.reply_tracker is not None:
-        try:
-            if json.loads(result).get("status") == "success":
-                if is_terminal_success(
-                    tool_name, succeeded=True, custom_terminal=custom_terminal
-                ):
-                    context.reply_tracker.tool_executed = True
-                if tool_name == SEND_MESSAGE_TOOL_NAME:
-                    context.reply_tracker.replied = True
-        except (json.JSONDecodeError, AttributeError, TypeError):
-            pass
-
+        _mark_productive_work(
+            context.reply_tracker,
+            tool_name,
+            result,
+            custom_terminal=custom_terminal,
+        )
     return result
 
 
-# --- CrewAI-specific parsing leniency ---
+def _mark_productive_work(
+    tracker: ReplyTracker, tool_name: str, result: str, *, custom_terminal: bool
+) -> None:
+    """Record that the turn did real work, so an empty final answer stays benign.
 
-
-def normalize_mentions_lenient(value: Any) -> list[str]:
-    """Coerce whatever CrewAI's tool layer produced into a list of handles.
-
-    Smaller models driving CrewAI emit ``mentions`` as a JSON-encoded string or
-    a bracketed list of bare handles (``"[@john/agent]"``) rather than a real
-    list. Without this the platform rejects the call for having no mentions and
-    the agent retries in a loop, so the leniency lives here rather than on the
-    master model, which every other adapter satisfies as-is.
+    CrewAI raises on an empty final answer; that is a genuine no-response
+    failure only when nothing terminal ran. ``is_terminal_success`` is the
+    shared rule for what counts (read-only Band tools and undeclared custom
+    tools do not).
     """
-    if value is None or value == "":
-        return []
-    if isinstance(value, list):
-        return [str(item) for item in value]
-    if isinstance(value, str):
-        try:
-            decoded = json.loads(value)
-        except json.JSONDecodeError:
-            pass
-        else:
-            if isinstance(decoded, list):
-                return [str(item) for item in decoded]
-        stripped = value.strip().strip("[]")
-        return [
-            token.strip().strip("'\"") for token in stripped.split(",") if token.strip()
-        ]
-    return [str(value)]
-
-
-SEND_MESSAGE_ARGS_SCHEMA: type[BaseModel] = platform_args_schema(
-    SEND_MESSAGE_TOOL_NAME,
-    validators={
-        "normalize_mentions": field_validator("mentions", mode="before")(
-            staticmethod(normalize_mentions_lenient)
-        ),
-    },
-)
-
-# band_send_room_file's mentions field is the same shape/purpose as
-# band_send_message's -- smaller models hit the same leniency need here.
-SEND_ROOM_FILE_ARGS_SCHEMA: type[BaseModel] = platform_args_schema(
-    "band_send_room_file",
-    validators={
-        "normalize_mentions": field_validator("mentions", mode="before")(
-            staticmethod(normalize_mentions_lenient)
-        ),
-    },
-)
+    try:
+        if json.loads(result).get("status") != "success":
+            return
+    except (json.JSONDecodeError, AttributeError, TypeError):
+        return
+    if is_terminal_success(tool_name, succeeded=True, custom_terminal=custom_terminal):
+        tracker.tool_executed = True
+    if tool_name == BandTool.SEND_MESSAGE:
+        tracker.replied = True
 
 
 # --- Tool factory ---
@@ -385,670 +150,87 @@ SEND_ROOM_FILE_ARGS_SCHEMA: type[BaseModel] = platform_args_schema(
 _no_cache: Any = staticmethod(lambda *_a, **_kw: False)
 
 
-def _make_platform_tools(
+def _platform_tool(
+    spec: ToolSpec,
     *,
     get_context: Callable[[], CrewAIToolContext | None],
     reporter: CrewAIToolReporter,
     fallback_loop: asyncio.AbstractEventLoop | None,
-) -> tuple[list[BaseTool], list[BaseTool], list[BaseTool], list[BaseTool]]:
-    """Build the 7 base + 5 contact + 5 memory + 3 file platform tools.
-
-    Returns a (base, contacts, memory, files) quadruple.
-    ``build_band_crewai_tools`` is responsible for stitching them together
-    based on the requested capabilities.
-    """
+) -> BaseTool:
+    """Wrap one ToolSpec as the CrewAI BaseTool instance the crew is handed."""
     from crewai.tools import BaseTool
 
-    def _exec(tool_name: str, factory: Callable[[AgentToolsProtocol], Any]) -> str:
-        return _execute_tool(
-            tool_name=tool_name,
-            coro_factory=factory,
-            get_context=get_context,
-            reporter=reporter,
-            fallback_loop=fallback_loop,
-        )
-
-    class SendMessageTool(BaseTool):
-        name: str = SEND_MESSAGE_TOOL_NAME
-        description: str = get_tool_description(SEND_MESSAGE_TOOL_NAME)
-        args_schema: type[BaseModel] = SEND_MESSAGE_ARGS_SCHEMA
+    class PlatformTool(BaseTool):
+        name: str = spec.name
+        description: str = get_tool_description(spec.name)
+        args_schema: type[BaseModel] = spec.args_schema
         cache_function: Any = _no_cache
 
         def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            content: str = kwargs.get("content", "")
-            # Normalized here too, not just in the schema: _run is also called
-            # directly, bypassing args_schema validation.
-            mention_list = normalize_mentions_lenient(kwargs.get("mentions"))
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                execute_send_message = getattr(reporter, "execute_send_message", None)
-                if callable(execute_send_message):
-                    typed_execute_send_message = cast(
-                        Callable[[AgentToolsProtocol, str, list[str]], Awaitable[None]],
-                        execute_send_message,
-                    )
-                    await typed_execute_send_message(tools, content, mention_list)
-                    return json.dumps({"status": "success", "message": "Message sent"})
-
-                await reporter.report_call(
-                    tools,
-                    SEND_MESSAGE_TOOL_NAME,
-                    {"content": content, "mentions": mention_list},
-                )
-                await tools.send_message(content, mention_list)
-                await reporter.report_result(tools, SEND_MESSAGE_TOOL_NAME, "success")
-                return json.dumps({"status": "success", "message": "Message sent"})
-
-            return _exec(SEND_MESSAGE_TOOL_NAME, execute)
-
-    class SendEventTool(BaseTool):
-        name: str = "band_send_event"
-        description: str = get_tool_description("band_send_event")
-        args_schema: type[BaseModel] = platform_args_schema("band_send_event")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            async def execute(tools: AgentToolsProtocol) -> str:
-                # Validated here, not in _run: _run is also called directly,
-                # bypassing args_schema validation, and _exec turns the
-                # ValueError into the error result the caller expects.
-                args = validate_tool_arguments(
-                    "band_send_event", self.args_schema, kwargs
-                )
-                # No execution reporting for send_event to avoid meta-events
-                # (the failure path honors this too — see _SEND_EVENT_TOOL).
-                await tools.send_event(
-                    args["content"], args["message_type"], metadata=args.get("metadata")
-                )
-                return json.dumps({"status": "success", "message": "Event sent"})
-
-            return _exec("band_send_event", execute)
-
-    class AddParticipantTool(BaseTool):
-        name: str = "band_add_participant"
-        description: str = get_tool_description("band_add_participant")
-        args_schema: type[BaseModel] = platform_args_schema("band_add_participant")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            identifier: str = kwargs.get("identifier", "")
-            role: str = kwargs.get("role", "member")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools,
-                    "band_add_participant",
-                    {"identifier": identifier, "role": role},
-                )
-                result = await tools.add_participant(identifier, role)
-                await reporter.report_result(tools, "band_add_participant", result)
-                return serialize_success_result(result)
-
-            return _exec("band_add_participant", execute)
-
-    class RemoveParticipantTool(BaseTool):
-        name: str = "band_remove_participant"
-        description: str = get_tool_description("band_remove_participant")
-        args_schema: type[BaseModel] = platform_args_schema("band_remove_participant")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            identifier: str = kwargs.get("identifier", "")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools, "band_remove_participant", {"identifier": identifier}
-                )
-                result = await tools.remove_participant(identifier)
-                await reporter.report_result(tools, "band_remove_participant", result)
-                return serialize_success_result(result)
-
-            return _exec("band_remove_participant", execute)
-
-    class GetParticipantsTool(BaseTool):
-        name: str = "band_get_participants"
-        description: str = get_tool_description("band_get_participants")
-        args_schema: type[BaseModel] = platform_args_schema("band_get_participants")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **_kwargs: Any) -> Any:
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(tools, "band_get_participants", {})
-                participants = await tools.get_participants()
-                serialized = (
-                    [
-                        p.model_dump() if hasattr(p, "model_dump") else p
-                        for p in participants
-                    ]
-                    if isinstance(participants, list)
-                    else participants
-                )
-                result = {
-                    "status": "success",
-                    "participants": serialized,
-                    "count": len(participants) if isinstance(participants, list) else 0,
-                }
-                await reporter.report_result(tools, "band_get_participants", result)
-                return json.dumps(result, default=str)
-
-            return _exec("band_get_participants", execute)
-
-    class LookupPeersTool(BaseTool):
-        name: str = "band_lookup_peers"
-        description: str = get_tool_description("band_lookup_peers")
-        args_schema: type[BaseModel] = platform_args_schema("band_lookup_peers")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            page: int = kwargs.get("page", 1)
-            page_size: int = kwargs.get("page_size", 50)
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools,
-                    "band_lookup_peers",
-                    {"page": page, "page_size": page_size},
-                )
-                result = await tools.lookup_peers(page, page_size)
-                await reporter.report_result(tools, "band_lookup_peers", result)
-                return serialize_success_result(result)
-
-            return _exec("band_lookup_peers", execute)
-
-    class CreateChatroomTool(BaseTool):
-        name: str = "band_create_chatroom"
-        description: str = get_tool_description("band_create_chatroom")
-        args_schema: type[BaseModel] = platform_args_schema("band_create_chatroom")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            task_id: str | None = kwargs.get("task_id")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools, "band_create_chatroom", {"task_id": task_id}
-                )
-                new_room_id = await tools.create_chatroom(task_id)
-                result = {
-                    "status": "success",
-                    "message": "Chat room created",
-                    "room_id": new_room_id,
-                }
-                await reporter.report_result(tools, "band_create_chatroom", result)
-                return json.dumps(result)
-
-            return _exec("band_create_chatroom", execute)
-
-    class ListContactsTool(BaseTool):
-        name: str = "band_list_contacts"
-        description: str = get_tool_description("band_list_contacts")
-        args_schema: type[BaseModel] = platform_args_schema("band_list_contacts")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            page: int = kwargs.get("page", 1)
-            page_size: int = kwargs.get("page_size", 50)
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools,
-                    "band_list_contacts",
-                    {"page": page, "page_size": page_size},
-                )
-                result = await tools.list_contacts(page, page_size)
-                await reporter.report_result(tools, "band_list_contacts", result)
-                return serialize_success_result(result)
-
-            return _exec("band_list_contacts", execute)
-
-    class AddContactTool(BaseTool):
-        name: str = "band_add_contact"
-        description: str = get_tool_description("band_add_contact")
-        args_schema: type[BaseModel] = platform_args_schema("band_add_contact")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            handle: str = kwargs.get("handle", "")
-            message: str | None = kwargs.get("message")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools,
-                    "band_add_contact",
-                    {"handle": handle, "message": message},
-                )
-                result = await tools.add_contact(handle, message)
-                await reporter.report_result(tools, "band_add_contact", result)
-                return serialize_success_result(result)
-
-            return _exec("band_add_contact", execute)
-
-    class RemoveContactTool(BaseTool):
-        name: str = "band_remove_contact"
-        description: str = get_tool_description("band_remove_contact")
-        args_schema: type[BaseModel] = platform_args_schema("band_remove_contact")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            handle: str | None = kwargs.get("handle")
-            contact_id: str | None = kwargs.get("contact_id")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools,
-                    "band_remove_contact",
-                    {"handle": handle, "contact_id": contact_id},
-                )
-                result = await tools.remove_contact(handle, contact_id)
-                await reporter.report_result(tools, "band_remove_contact", result)
-                return serialize_success_result(result)
-
-            return _exec("band_remove_contact", execute)
-
-    class ListContactRequestsTool(BaseTool):
-        name: str = "band_list_contact_requests"
-        description: str = get_tool_description("band_list_contact_requests")
-        args_schema: type[BaseModel] = platform_args_schema(
-            "band_list_contact_requests"
-        )
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            page: int = kwargs.get("page", 1)
-            page_size: int = kwargs.get("page_size", 50)
-            sent_status: str = kwargs.get("sent_status", "pending")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools,
-                    "band_list_contact_requests",
-                    {
-                        "page": page,
-                        "page_size": page_size,
-                        "sent_status": sent_status,
-                    },
-                )
-                result = await tools.list_contact_requests(page, page_size, sent_status)
-                await reporter.report_result(
-                    tools, "band_list_contact_requests", result
-                )
-                return serialize_success_result(result)
-
-            return _exec("band_list_contact_requests", execute)
-
-    class RespondContactRequestTool(BaseTool):
-        name: str = "band_respond_contact_request"
-        description: str = get_tool_description("band_respond_contact_request")
-        args_schema: type[BaseModel] = platform_args_schema(
-            "band_respond_contact_request"
-        )
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            action: str = kwargs.get("action", "")
-            handle: str | None = kwargs.get("handle")
-            request_id: str | None = kwargs.get("request_id")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools,
-                    "band_respond_contact_request",
-                    {"action": action, "handle": handle, "request_id": request_id},
-                )
-                result = await tools.respond_contact_request(action, handle, request_id)
-                await reporter.report_result(
-                    tools, "band_respond_contact_request", result
-                )
-                return serialize_success_result(result)
-
-            return _exec("band_respond_contact_request", execute)
-
-    class ListMemoriesTool(BaseTool):
-        name: str = "band_list_memories"
-        description: str = get_tool_description("band_list_memories")
-        args_schema: type[BaseModel] = platform_args_schema("band_list_memories")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            subject_id = kwargs.get("subject_id")
-            scope = kwargs.get("scope")
-            system = kwargs.get("system")
-            memory_type = kwargs.get("type")
-            segment = kwargs.get("segment")
-            content_query = kwargs.get("content_query")
-            page_size = kwargs.get("page_size", 50)
-            status = kwargs.get("status")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools,
-                    "band_list_memories",
-                    {
-                        "subject_id": subject_id,
-                        "scope": scope,
-                        "system": system,
-                        "type": memory_type,
-                        "segment": segment,
-                        "content_query": content_query,
-                        "page_size": page_size,
-                        "status": status,
-                    },
-                )
-                list_kwargs = {"page_size": page_size}
-                optional_filters = {
-                    "subject_id": subject_id,
-                    "scope": scope,
-                    "system": system,
-                    "type": memory_type,
-                    "segment": segment,
-                    "content_query": content_query,
-                    "status": status,
-                }
-                list_kwargs.update(
-                    {
-                        key: value
-                        for key, value in optional_filters.items()
-                        if value is not None
-                    }
-                )
-                result = await tools.list_memories(**list_kwargs)
-                await reporter.report_result(tools, "band_list_memories", result)
-                return serialize_success_result(result)
-
-            return _exec("band_list_memories", execute)
-
-    class StoreMemoryTool(BaseTool):
-        name: str = "band_store_memory"
-        description: str = get_tool_description("band_store_memory")
-        args_schema: type[BaseModel] = platform_args_schema("band_store_memory")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            content = kwargs.get("content", "")
-            system = kwargs.get("system", "")
-            memory_type = kwargs.get("type", "")
-            segment = kwargs.get("segment", "")
-            thought = kwargs.get("thought", "")
-            scope = kwargs.get("scope", "")
-            subject_id = kwargs.get("subject_id")
-            metadata = kwargs.get("metadata")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools,
-                    "band_store_memory",
-                    {
-                        "content": content,
-                        "system": system,
-                        "type": memory_type,
-                        "segment": segment,
-                        "thought": thought,
-                        "scope": scope,
-                        "subject_id": subject_id,
-                        "metadata": metadata,
-                    },
-                )
-                store_kwargs = {
-                    "content": content,
-                    "system": system,
-                    "type": memory_type,
-                    "segment": segment,
-                    "thought": thought,
-                    "scope": scope,
-                }
-                if subject_id is not None:
-                    store_kwargs["subject_id"] = subject_id
-                if metadata is not None:
-                    store_kwargs["metadata"] = metadata
-                result = await tools.store_memory(**store_kwargs)
-                await reporter.report_result(tools, "band_store_memory", result)
-                return serialize_success_result(result)
-
-            return _exec("band_store_memory", execute)
-
-    class GetMemoryTool(BaseTool):
-        name: str = "band_get_memory"
-        description: str = get_tool_description("band_get_memory")
-        args_schema: type[BaseModel] = platform_args_schema("band_get_memory")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            memory_id = kwargs.get("memory_id", "")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools, "band_get_memory", {"memory_id": memory_id}
-                )
-                result = await tools.get_memory(memory_id)
-                await reporter.report_result(tools, "band_get_memory", result)
-                return serialize_success_result(result)
-
-            return _exec("band_get_memory", execute)
-
-    class SupersedeMemoryTool(BaseTool):
-        name: str = "band_supersede_memory"
-        description: str = get_tool_description("band_supersede_memory")
-        args_schema: type[BaseModel] = platform_args_schema("band_supersede_memory")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            memory_id = kwargs.get("memory_id", "")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools, "band_supersede_memory", {"memory_id": memory_id}
-                )
-                result = await tools.supersede_memory(memory_id)
-                await reporter.report_result(tools, "band_supersede_memory", result)
-                return serialize_success_result(result)
-
-            return _exec("band_supersede_memory", execute)
-
-    class ArchiveMemoryTool(BaseTool):
-        name: str = "band_archive_memory"
-        description: str = get_tool_description("band_archive_memory")
-        args_schema: type[BaseModel] = platform_args_schema("band_archive_memory")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            memory_id = kwargs.get("memory_id", "")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools, "band_archive_memory", {"memory_id": memory_id}
-                )
-                result = await tools.archive_memory(memory_id)
-                await reporter.report_result(tools, "band_archive_memory", result)
-                return serialize_success_result(result)
-
-            return _exec("band_archive_memory", execute)
-
-    class ListRoomFilesTool(BaseTool):
-        name: str = "band_list_room_files"
-        description: str = get_tool_description("band_list_room_files")
-        args_schema: type[BaseModel] = platform_args_schema("band_list_room_files")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            cursor: str | None = kwargs.get("cursor")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools, "band_list_room_files", {"cursor": cursor}
-                )
-                result = await tools.list_room_files(cursor)
-                await reporter.report_result(tools, "band_list_room_files", result)
-                return serialize_success_result(result)
-
-            return _exec("band_list_room_files", execute)
-
-    class ReadRoomFileTool(BaseTool):
-        name: str = "band_read_room_file"
-        description: str = get_tool_description("band_read_room_file")
-        args_schema: type[BaseModel] = platform_args_schema("band_read_room_file")
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            file_id: str = kwargs.get("file_id", "")
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools, "band_read_room_file", {"file_id": file_id}
-                )
-                result = await tools.read_room_file(file_id)
-                if is_mcp_content_result(result):
-                    sentinel = vision_sentinel(result)
-                    await reporter.report_result(tools, "band_read_room_file", sentinel)
-                    return sentinel
-                await reporter.report_result(tools, "band_read_room_file", result)
-                return serialize_success_result(result)
-
-            return _exec("band_read_room_file", execute)
-
-    class SendRoomFileTool(BaseTool):
-        name: str = "band_send_room_file"
-        description: str = get_tool_description("band_send_room_file")
-        args_schema: type[BaseModel] = SEND_ROOM_FILE_ARGS_SCHEMA
-        cache_function: Any = _no_cache
-
-        def _run(self, *_args: Any, **kwargs: Any) -> Any:
-            content: str = kwargs.get("content", "")
-            filename: str = kwargs.get("filename", "")
-            caption: str = kwargs.get("caption") or ""
-            # Normalized here too, not just in the schema: _run is also called
-            # directly, bypassing args_schema validation.
-            mention_list = normalize_mentions_lenient(kwargs.get("mentions"))
-
-            async def execute(tools: AgentToolsProtocol) -> str:
-                await reporter.report_call(
-                    tools,
-                    "band_send_room_file",
-                    {
-                        "content": content,
-                        "filename": filename,
-                        "caption": caption,
-                        "mentions": mention_list,
-                    },
-                )
-                result = await tools.send_room_file(
-                    content, filename, caption, mention_list
-                )
-                await reporter.report_result(tools, "band_send_room_file", result)
-                return serialize_success_result(result)
-
-            return _exec("band_send_room_file", execute)
-
-    base_tools: list[BaseTool] = [
-        SendMessageTool(),
-        SendEventTool(),
-        AddParticipantTool(),
-        RemoveParticipantTool(),
-        GetParticipantsTool(),
-        LookupPeersTool(),
-        CreateChatroomTool(),
-    ]
-    contact_tools: list[BaseTool] = [
-        ListContactsTool(),
-        AddContactTool(),
-        RemoveContactTool(),
-        ListContactRequestsTool(),
-        RespondContactRequestTool(),
-    ]
-    memory_tools: list[BaseTool] = [
-        ListMemoriesTool(),
-        StoreMemoryTool(),
-        GetMemoryTool(),
-        SupersedeMemoryTool(),
-        ArchiveMemoryTool(),
-    ]
-    file_tools: list[BaseTool] = [
-        ListRoomFilesTool(),
-        ReadRoomFileTool(),
-        SendRoomFileTool(),
-    ]
-
-    return base_tools, contact_tools, memory_tools, file_tools
-
-
-def _make_custom_tools(
+            return _execute_tool(
+                tool_name=spec.name,
+                coro_factory=lambda tools: spec.invoke(
+                    Invocation(tools=tools, reporter=reporter), kwargs
+                ),
+                get_context=get_context,
+                reporter=reporter,
+                fallback_loop=fallback_loop,
+            )
+
+    return PlatformTool()
+
+
+def _custom_tool(
+    definition: CustomToolDef,
     *,
-    custom_tools: list[CustomToolDef],
     get_context: Callable[[], CrewAIToolContext | None],
     reporter: CrewAIToolReporter,
     fallback_loop: asyncio.AbstractEventLoop | None,
-) -> list[BaseTool]:
-    """Convert CustomToolDef tuples to CrewAI BaseTool instances."""
+) -> BaseTool:
+    """Wrap one CustomToolDef as a CrewAI BaseTool instance."""
     from crewai.tools import BaseTool
 
-    crewai_tools: list[BaseTool] = []
+    input_model, handler = definition
+    tool_name = get_custom_tool_name(input_model)
+    # Only a custom tool that opts in (band_terminal=True) lets an empty final
+    # answer be treated as benign; undeclared customs fail loud.
+    terminal = is_marked_terminal(handler)
 
-    def _exec(
-        tool_name: str,
-        factory: Callable[[AgentToolsProtocol], Any],
-        *,
-        custom_terminal: bool = False,
-    ) -> str:
-        return _execute_tool(
-            tool_name=tool_name,
-            coro_factory=factory,
-            get_context=get_context,
-            reporter=reporter,
-            fallback_loop=fallback_loop,
-            custom_terminal=custom_terminal,
+    class CustomCrewAITool(BaseTool):
+        name: str = tool_name
+        description: str = input_model.__doc__ or f"Execute {tool_name}"
+        args_schema: type[BaseModel] = input_model
+        cache_function: Any = _no_cache
+
+        def _run(self, *_args: Any, **kwargs: Any) -> Any:
+            async def execute(tools: AgentToolsProtocol) -> str:
+                await reporter.report_call(tools, tool_name, kwargs)
+                result = await execute_custom_tool(definition, kwargs)
+                await reporter.report_result(tools, tool_name, result)
+                return json.dumps({"status": "success", "result": result}, default=str)
+
+            return _execute_tool(
+                tool_name=tool_name,
+                coro_factory=execute,
+                get_context=get_context,
+                reporter=reporter,
+                fallback_loop=fallback_loop,
+                custom_terminal=terminal,
+            )
+
+    return CustomCrewAITool()
+
+
+def _enabled_specs(capabilities: frozenset[Capability]) -> list[ToolSpec]:
+    """The platform tools a crew with these capabilities is allowed to see."""
+    withheld: frozenset[str] = frozenset().union(
+        *(
+            names
+            for capability, names in CAPABILITY_TOOL_NAMES.items()
+            if capability not in capabilities
         )
-
-    for input_model, func in custom_tools:
-        tool_name = get_custom_tool_name(input_model)
-        tool_description = input_model.__doc__ or f"Execute {tool_name}"
-
-        def make_tool(
-            tool_name_param: str,
-            tool_desc_param: str,
-            model: type[BaseModel],
-            handler: Any,
-        ) -> BaseTool:
-            _tool_name = tool_name_param
-            _tool_desc = tool_desc_param
-            # Only a custom tool that opts in (band_terminal=True) lets an empty
-            # final answer be treated as benign; undeclared customs fail loud.
-            _terminal = is_marked_terminal(handler)
-
-            class CustomCrewAITool(BaseTool):
-                name: str = _tool_name  # type: ignore[misc]
-                description: str = _tool_desc  # type: ignore[misc]
-                args_schema: type[BaseModel] = model
-                cache_function: Any = staticmethod(lambda *_a, **_kw: False)
-
-                def _run(self, *_args: Any, **kwargs: Any) -> Any:
-                    async def execute(_tools: AgentToolsProtocol) -> str:
-                        try:
-                            await reporter.report_call(_tools, _tool_name, kwargs)
-                            result = await execute_custom_tool((model, handler), kwargs)
-                            await reporter.report_result(_tools, _tool_name, result)
-                            if isinstance(result, str):
-                                return json.dumps(
-                                    {"status": "success", "result": result}
-                                )
-                            return json.dumps(
-                                {"status": "success", "result": result}, default=str
-                            )
-                        except Exception as e:
-                            error_msg = str(e)
-                            logger.error(
-                                "Custom tool %s failed: %s", _tool_name, error_msg
-                            )
-                            await reporter.report_result(
-                                _tools, _tool_name, error_msg, is_error=True
-                            )
-                            return json.dumps({"status": "error", "message": error_msg})
-
-                    return _exec(_tool_name, execute, custom_terminal=_terminal)
-
-            return CustomCrewAITool()
-
-        crewai_tools.append(make_tool(tool_name, tool_description, input_model, func))
-
-    return crewai_tools
+    )
+    return [spec for spec in PLATFORM_TOOLS if spec.name not in withheld]
 
 
 def build_band_crewai_tools(
@@ -1060,51 +242,41 @@ def build_band_crewai_tools(
     custom_tools: list[CustomToolDef] | None = None,
     fallback_loop: asyncio.AbstractEventLoop | None = None,
 ) -> list[BaseTool]:
-    """Build the list of CrewAI BaseTool instances for the platform tool surface.
+    """Build the CrewAI BaseTool instances for the platform tool surface.
 
-    Selection:
-      - 7 base tools always.
-      - +5 contact tools when Capability.CONTACTS is in `capabilities`.
-      - +5 memory tools when Capability.MEMORY is in `capabilities`.
-      - +3 file tools when Capability.FILES is in `capabilities`.
-      - +N custom tools after platform tools.
-
-    The returned tools close over `get_context`, `reporter`, and `fallback_loop`.
-    Each adapter passes its own getter/reporter so the wrappers stay
+    Chat tools are always present; contact, memory and file tools follow their
+    capability, and custom tools are appended after the platform ones. The
+    returned tools close over ``get_context``, ``reporter`` and
+    ``fallback_loop``, so each adapter supplies its own and the wrappers stay
     framework-agnostic.
     """
-    base, contacts, memories, files = _make_platform_tools(
-        get_context=get_context,
-        reporter=reporter,
-        fallback_loop=fallback_loop,
-    )
-
     active_features = features or AdapterFeatures(capabilities=capabilities)
-    selected: list[BaseTool] = list(base)
-    if Capability.CONTACTS in active_features.capabilities:
-        selected.extend(contacts)
-    if Capability.MEMORY in active_features.capabilities:
-        selected.extend(memories)
-    if Capability.FILES in active_features.capabilities:
-        selected.extend(files)
+    selected: list[BaseTool] = [
+        _platform_tool(
+            spec,
+            get_context=get_context,
+            reporter=reporter,
+            fallback_loop=fallback_loop,
+        )
+        for spec in _enabled_specs(active_features.capabilities)
+    ]
 
     selected = filter_tool_schemas(
         selected,
         active_features,
         get_name=lambda tool: tool.name,
-        get_category=lambda tool: _CREWAI_TOOL_CATEGORIES.get(tool.name),
+        get_category=lambda tool: get_band_tool_category(tool.name),
     )
 
-    if custom_tools:
-        selected.extend(
-            _make_custom_tools(
-                custom_tools=custom_tools,
-                get_context=get_context,
-                reporter=reporter,
-                fallback_loop=fallback_loop,
-            )
+    selected.extend(
+        _custom_tool(
+            definition,
+            get_context=get_context,
+            reporter=reporter,
+            fallback_loop=fallback_loop,
         )
-
+        for definition in custom_tools or ()
+    )
     return selected
 
 
@@ -1113,6 +285,7 @@ __all__ = [
     "CrewAIToolReporter",
     "EmitToolCallsReporter",
     "NoopReporter",
+    "ReplyTracker",
     "build_band_crewai_tools",
     "serialize_success_result",
     "vision_sentinel",

--- a/src/band/integrations/crewai/tools.py
+++ b/src/band/integrations/crewai/tools.py
@@ -161,7 +161,11 @@ def _platform_tool(
     from crewai.tools import BaseTool
 
     class PlatformTool(BaseTool):
-        name: str = spec.name
+        # str(...): pydantic doesn't validate field defaults (no
+        # validate_default here), so an unwrapped BandTool (StrEnum) default
+        # would leave tool.name a BandTool instance at runtime, not the str
+        # the field is typed as.
+        name: str = str(spec.name)
         description: str = get_tool_description(spec.name)
         args_schema: type[BaseModel] = spec.args_schema
         cache_function: Any = _no_cache

--- a/src/band/integrations/crewai/tools.py
+++ b/src/band/integrations/crewai/tools.py
@@ -896,9 +896,11 @@ def _make_platform_tools(
                     tools, "band_read_room_file", {"file_id": file_id}
                 )
                 result = await tools.read_room_file(file_id)
-                await reporter.report_result(tools, "band_read_room_file", result)
                 if is_mcp_content_result(result):
-                    return vision_sentinel(result)
+                    sentinel = vision_sentinel(result)
+                    await reporter.report_result(tools, "band_read_room_file", sentinel)
+                    return sentinel
+                await reporter.report_result(tools, "band_read_room_file", result)
                 return serialize_success_result(result)
 
             return _exec("band_read_room_file", execute)

--- a/src/band/integrations/crewai/tools.py
+++ b/src/band/integrations/crewai/tools.py
@@ -57,6 +57,7 @@ from band.runtime.tools import (
     SEND_MESSAGE_TOOL_NAME,
     append_available_mention_handles,
     get_tool_description,
+    is_mcp_content_result,
     is_terminal_success,
     platform_args_schema,
     serialize_tool_result,
@@ -237,6 +238,23 @@ def serialize_success_result(result: Any) -> str:
             response["result_status"] = result_status
         return json.dumps(response, default=str)
     return json.dumps({"status": "success", "result": result}, default=str)
+
+
+def vision_sentinel(result: dict[str, Any]) -> str:
+    """Encode an MCP-content-shaped image result as CrewAI's native vision
+    sentinel string, so the model gets real image content instead of a
+    JSON-stringified blob.
+
+    CrewAI's own StepExecutor (crewai/agents/step_executor.py, on the default
+    native-tool-calling execution path) recognizes a tool result string
+    shaped ``VISION_IMAGE:<media_type>:<base64_data>`` and rewrites it into a
+    real ``image_url`` content block before the LLM ever sees it -- verified
+    against the installed crewai package, not documented publicly. Only the
+    first content block is encoded: the sentinel carries one image, and
+    AgentTools.read_room_file() only ever returns one for a previewable image.
+    """
+    block = result["content"][0]
+    return f"VISION_IMAGE:{block['mimeType']}:{block['data']}"
 
 
 def _execute_tool(
@@ -879,6 +897,8 @@ def _make_platform_tools(
                 )
                 result = await tools.read_room_file(file_id)
                 await reporter.report_result(tools, "band_read_room_file", result)
+                if is_mcp_content_result(result):
+                    return vision_sentinel(result)
                 return serialize_success_result(result)
 
             return _exec("band_read_room_file", execute)
@@ -1093,4 +1113,5 @@ __all__ = [
     "NoopReporter",
     "build_band_crewai_tools",
     "serialize_success_result",
+    "vision_sentinel",
 ]

--- a/src/band/integrations/crewai/tools.py
+++ b/src/band/integrations/crewai/tools.py
@@ -83,6 +83,9 @@ _CREWAI_TOOL_CATEGORIES = {
     "band_get_memory": "memory",
     "band_supersede_memory": "memory",
     "band_archive_memory": "memory",
+    "band_list_room_files": "files",
+    "band_read_room_file": "files",
+    "band_send_room_file": "files",
 }
 
 
@@ -347,6 +350,17 @@ SEND_MESSAGE_ARGS_SCHEMA: type[BaseModel] = platform_args_schema(
     },
 )
 
+# band_send_room_file's mentions field is the same shape/purpose as
+# band_send_message's -- smaller models hit the same leniency need here.
+SEND_ROOM_FILE_ARGS_SCHEMA: type[BaseModel] = platform_args_schema(
+    "band_send_room_file",
+    validators={
+        "normalize_mentions": field_validator("mentions", mode="before")(
+            staticmethod(normalize_mentions_lenient)
+        ),
+    },
+)
+
 
 # --- Tool factory ---
 
@@ -358,12 +372,12 @@ def _make_platform_tools(
     get_context: Callable[[], CrewAIToolContext | None],
     reporter: CrewAIToolReporter,
     fallback_loop: asyncio.AbstractEventLoop | None,
-) -> tuple[list[BaseTool], list[BaseTool], list[BaseTool]]:
-    """Build the 7 base + 5 contact + 5 memory platform tools.
+) -> tuple[list[BaseTool], list[BaseTool], list[BaseTool], list[BaseTool]]:
+    """Build the 7 base + 5 contact + 5 memory + 3 file platform tools.
 
-    Returns a (base, contacts, memory) triple. ``build_band_crewai_tools``
-    is responsible for stitching them together based on the requested
-    capabilities.
+    Returns a (base, contacts, memory, files) quadruple.
+    ``build_band_crewai_tools`` is responsible for stitching them together
+    based on the requested capabilities.
     """
     from crewai.tools import BaseTool
 
@@ -831,6 +845,77 @@ def _make_platform_tools(
 
             return _exec("band_archive_memory", execute)
 
+    class ListRoomFilesTool(BaseTool):
+        name: str = "band_list_room_files"
+        description: str = get_tool_description("band_list_room_files")
+        args_schema: type[BaseModel] = platform_args_schema("band_list_room_files")
+        cache_function: Any = _no_cache
+
+        def _run(self, *_args: Any, **kwargs: Any) -> Any:
+            cursor: str | None = kwargs.get("cursor")
+
+            async def execute(tools: AgentToolsProtocol) -> str:
+                await reporter.report_call(
+                    tools, "band_list_room_files", {"cursor": cursor}
+                )
+                result = await tools.list_room_files(cursor)
+                await reporter.report_result(tools, "band_list_room_files", result)
+                return serialize_success_result(result)
+
+            return _exec("band_list_room_files", execute)
+
+    class ReadRoomFileTool(BaseTool):
+        name: str = "band_read_room_file"
+        description: str = get_tool_description("band_read_room_file")
+        args_schema: type[BaseModel] = platform_args_schema("band_read_room_file")
+        cache_function: Any = _no_cache
+
+        def _run(self, *_args: Any, **kwargs: Any) -> Any:
+            file_id: str = kwargs.get("file_id", "")
+
+            async def execute(tools: AgentToolsProtocol) -> str:
+                await reporter.report_call(
+                    tools, "band_read_room_file", {"file_id": file_id}
+                )
+                result = await tools.read_room_file(file_id)
+                await reporter.report_result(tools, "band_read_room_file", result)
+                return serialize_success_result(result)
+
+            return _exec("band_read_room_file", execute)
+
+    class SendRoomFileTool(BaseTool):
+        name: str = "band_send_room_file"
+        description: str = get_tool_description("band_send_room_file")
+        args_schema: type[BaseModel] = SEND_ROOM_FILE_ARGS_SCHEMA
+        cache_function: Any = _no_cache
+
+        def _run(self, *_args: Any, **kwargs: Any) -> Any:
+            content: str = kwargs.get("content", "")
+            filename: str = kwargs.get("filename", "")
+            caption: str = kwargs.get("caption") or ""
+            # Normalized here too, not just in the schema: _run is also called
+            # directly, bypassing args_schema validation.
+            mention_list = normalize_mentions_lenient(kwargs.get("mentions"))
+
+            async def execute(tools: AgentToolsProtocol) -> str:
+                await reporter.report_call(
+                    tools,
+                    "band_send_room_file",
+                    {
+                        "content": content,
+                        "filename": filename,
+                        "caption": caption,
+                        "mentions": mention_list,
+                    },
+                )
+                result = await tools.send_room_file(
+                    content, filename, caption, mention_list
+                )
+                await reporter.report_result(tools, "band_send_room_file", result)
+                return serialize_success_result(result)
+
+            return _exec("band_send_room_file", execute)
+
     base_tools: list[BaseTool] = [
         SendMessageTool(),
         SendEventTool(),
@@ -854,8 +939,13 @@ def _make_platform_tools(
         SupersedeMemoryTool(),
         ArchiveMemoryTool(),
     ]
+    file_tools: list[BaseTool] = [
+        ListRoomFilesTool(),
+        ReadRoomFileTool(),
+        SendRoomFileTool(),
+    ]
 
-    return base_tools, contact_tools, memory_tools
+    return base_tools, contact_tools, memory_tools, file_tools
 
 
 def _make_custom_tools(
@@ -954,13 +1044,14 @@ def build_band_crewai_tools(
       - 7 base tools always.
       - +5 contact tools when Capability.CONTACTS is in `capabilities`.
       - +5 memory tools when Capability.MEMORY is in `capabilities`.
+      - +3 file tools when Capability.FILES is in `capabilities`.
       - +N custom tools after platform tools.
 
     The returned tools close over `get_context`, `reporter`, and `fallback_loop`.
     Each adapter passes its own getter/reporter so the wrappers stay
     framework-agnostic.
     """
-    base, contacts, memories = _make_platform_tools(
+    base, contacts, memories, files = _make_platform_tools(
         get_context=get_context,
         reporter=reporter,
         fallback_loop=fallback_loop,
@@ -972,6 +1063,8 @@ def build_band_crewai_tools(
         selected.extend(contacts)
     if Capability.MEMORY in active_features.capabilities:
         selected.extend(memories)
+    if Capability.FILES in active_features.capabilities:
+        selected.extend(files)
 
     selected = filter_tool_schemas(
         selected,

--- a/src/band/integrations/langgraph/langchain_tools.py
+++ b/src/band/integrations/langgraph/langchain_tools.py
@@ -11,6 +11,7 @@ import logging
 import warnings
 from typing import Any
 
+from langchain_core.messages import ImageContentBlock
 from langchain_core.tools import StructuredTool
 
 from band.core.exceptions import BandToolError
@@ -24,7 +25,7 @@ from band.runtime.custom_tools import (
     get_custom_tool_name,
 )
 from band.runtime.tools import (
-    READ_ROOM_FILE_TOOL_NAME,
+    BandTool,
     format_tool_validation_error,
     get_band_tool_category,
     get_tool_description,
@@ -40,6 +41,16 @@ def _with_capability(
 ) -> frozenset[Capability]:
     """``capabilities`` with ``capability`` forced on or off per ``enabled``."""
     return capabilities | {capability} if enabled else capabilities - {capability}
+
+
+def _image_content_blocks(result: dict[str, Any]) -> list[ImageContentBlock]:
+    """LangChain image content blocks for an MCP-content-shaped tool result."""
+    return [
+        ImageContentBlock(
+            type="image", mime_type=block["mimeType"], base64=block["data"]
+        )
+        for block in result["content"]
+    ]
 
 
 def agent_tools_to_langchain(
@@ -108,6 +119,8 @@ def agent_tools_to_langchain(
             definition.name
         )
 
+        # ``execute_tool_call`` is typed ``Any`` by ``AgentToolsProtocol``, so the
+        # pass-through branch below cannot honestly be narrowed here.
         async def execute_definition(
             *,
             _tool_name: str = definition.name,
@@ -115,17 +128,10 @@ def agent_tools_to_langchain(
         ) -> Any:
             try:
                 result = await tools.execute_tool_call(_tool_name, kwargs)
-                if _tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(
+                if _tool_name == BandTool.READ_ROOM_FILE and is_mcp_content_result(
                     result
                 ):
-                    return [
-                        {
-                            "type": "image",
-                            "mime_type": block["mimeType"],
-                            "base64": block["data"],
-                        }
-                        for block in result["content"]
-                    ]
+                    return _image_content_blocks(result)
                 return result
             except (BandToolError, ValueError) as e:
                 return str(e)

--- a/src/band/integrations/langgraph/langchain_tools.py
+++ b/src/band/integrations/langgraph/langchain_tools.py
@@ -24,6 +24,7 @@ from band.runtime.custom_tools import (
     get_custom_tool_name,
 )
 from band.runtime.tools import (
+    READ_ROOM_FILE_TOOL_NAME,
     format_tool_validation_error,
     get_band_tool_category,
     get_tool_description,
@@ -114,7 +115,7 @@ def agent_tools_to_langchain(
         ) -> Any:
             try:
                 result = await tools.execute_tool_call(_tool_name, kwargs)
-                if _tool_name == "band_read_room_file" and is_mcp_content_result(
+                if _tool_name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(
                     result
                 ):
                     return [

--- a/src/band/integrations/langgraph/langchain_tools.py
+++ b/src/band/integrations/langgraph/langchain_tools.py
@@ -27,6 +27,7 @@ from band.runtime.tools import (
     format_tool_validation_error,
     get_band_tool_category,
     get_tool_description,
+    is_mcp_content_result,
     iter_tool_definitions,
 )
 
@@ -112,7 +113,19 @@ def agent_tools_to_langchain(
             **kwargs: Any,
         ) -> Any:
             try:
-                return await tools.execute_tool_call(_tool_name, kwargs)
+                result = await tools.execute_tool_call(_tool_name, kwargs)
+                if _tool_name == "band_read_room_file" and is_mcp_content_result(
+                    result
+                ):
+                    return [
+                        {
+                            "type": "image",
+                            "mime_type": block["mimeType"],
+                            "base64": block["data"],
+                        }
+                        for block in result["content"]
+                    ]
+                return result
             except (BandToolError, ValueError) as e:
                 return str(e)
             except Exception:

--- a/src/band/integrations/langgraph/langchain_tools.py
+++ b/src/band/integrations/langgraph/langchain_tools.py
@@ -25,11 +25,10 @@ from band.runtime.custom_tools import (
     get_custom_tool_name,
 )
 from band.runtime.tools import (
-    BandTool,
     format_tool_validation_error,
     get_band_tool_category,
     get_tool_description,
-    is_mcp_content_result,
+    is_image_passthrough_result,
     iter_tool_definitions,
 )
 
@@ -128,9 +127,7 @@ def agent_tools_to_langchain(
         ) -> Any:
             try:
                 result = await tools.execute_tool_call(_tool_name, kwargs)
-                if _tool_name == BandTool.READ_ROOM_FILE and is_mcp_content_result(
-                    result
-                ):
+                if is_image_passthrough_result(_tool_name, result):
                     return _image_content_blocks(result)
                 return result
             except (BandToolError, ValueError) as e:

--- a/src/band/integrations/letta/prompts.py
+++ b/src/band/integrations/letta/prompts.py
@@ -15,7 +15,7 @@ SEND_MESSAGE_TOOL_NAMES: tuple[str, ...] = (
     "create_agent_chat_message",
 )
 SEND_EVENT_TOOL_NAMES: tuple[str, ...] = (
-    "band_send_event",
+    BandTool.SEND_EVENT,
     "create_agent_chat_event",
 )
 

--- a/src/band/integrations/letta/prompts.py
+++ b/src/band/integrations/letta/prompts.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from band.runtime.tools import CHAT_ID_FIELD_NAME, SEND_MESSAGE_TOOL_NAME
+from band.runtime.tools import CHAT_ID_FIELD_NAME, BandTool
 
 # Known names of the message/event send tools across the Band MCP surfaces the
 # adapter can be pointed at: the SDK's self-hosted LocalMCPServer exposes the
@@ -11,7 +11,7 @@ from band.runtime.tools import CHAT_ID_FIELD_NAME, SEND_MESSAGE_TOOL_NAME
 # the enforcement prompt, silent-reporting set, and auto-relay detection all
 # follow whichever server is wired — first entry doubles as the fallback.
 SEND_MESSAGE_TOOL_NAMES: tuple[str, ...] = (
-    SEND_MESSAGE_TOOL_NAME,
+    BandTool.SEND_MESSAGE,
     "create_agent_chat_message",
 )
 SEND_EVENT_TOOL_NAMES: tuple[str, ...] = (

--- a/src/band/integrations/mcp/engine.py
+++ b/src/band/integrations/mcp/engine.py
@@ -34,6 +34,7 @@ from typing import Annotated, Any, Literal, Protocol
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
+from mcp.types import ImageContent
 from pydantic import AliasChoices, BaseModel, Field, create_model
 from pydantic.fields import FieldInfo
 from pydantic.json_schema import SkipJsonSchema
@@ -54,6 +55,7 @@ from band.runtime.tools import (
     Surface,
     ToolDefinition,
     append_available_mention_handles,
+    is_mcp_content_result,
     iter_tool_definitions,
     serialize_tool_result,
     validate_tool_arguments,
@@ -77,6 +79,14 @@ class MCPToolRegistration:
     description: str
     input_model: type[BaseModel]
     execute: MCPToolExecutor
+    # Passed straight through to FastMCP's add_tool(structured_output=...).
+    # None (default) preserves today's auto-inferred behavior for every
+    # tool. False is for band_read_room_file only: its image branch returns
+    # real MCP content blocks (see _mcp_content_blocks), and a declared
+    # structured-output schema would validate that non-str return value
+    # against the model FastMCP infers from the dispatch function's return
+    # annotation and reject it.
+    structured_output: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -468,6 +478,8 @@ def build_tool_registration(
             else validated.get(CHAT_ID_FIELD_NAME)
         )
         result = await resolver.invoke(definition, chat_id, validated)
+        if definition.name == "band_read_room_file" and is_mcp_content_result(result):
+            return _mcp_content_blocks(result)
         return _serialize(result)
 
     return MCPToolRegistration(
@@ -475,6 +487,7 @@ def build_tool_registration(
         description=(input_model.__doc__ or "").strip(),
         input_model=input_model,
         execute=execute,
+        structured_output=False if definition.name == "band_read_room_file" else None,
     )
 
 
@@ -606,6 +619,21 @@ def build_resolved_band_mcp_tool_registrations(
     return registrations
 
 
+def _mcp_content_blocks(result: dict[str, Any]) -> list[ImageContent]:
+    """Convert an MCP-content-shaped tool result into real MCP content blocks.
+
+    ``is_mcp_content_result`` already confirmed ``result["content"]`` is a
+    list of MCP content block dicts. FastMCP's own result conversion
+    recognizes an actual ``ContentBlock`` instance (or a list of them) and
+    passes it through to the client verbatim -- a plain dict does not match
+    and would otherwise fall through to JSON-text encoding, same as any
+    other tool result. Only "image" blocks exist today (the sole structured
+    branch of ``AgentTools.read_room_file``); a block of any other shape
+    fails Pydantic validation here rather than silently being dropped.
+    """
+    return [ImageContent(**block) for block in result["content"]]
+
+
 def _serialize(result: Any) -> str:
     """Serialize a tool method's return value to a JSON string for the wire.
 
@@ -686,6 +714,9 @@ def build_engine(
     for registration in spec.tools:
         handler = _make_dispatch_function(registration)
         mcp.add_tool(
-            handler, name=registration.name, description=registration.description
+            handler,
+            name=registration.name,
+            description=registration.description,
+            structured_output=registration.structured_output,
         )
     return mcp

--- a/src/band/integrations/mcp/engine.py
+++ b/src/band/integrations/mcp/engine.py
@@ -468,6 +468,8 @@ def build_tool_registration(
       when set (CLI-only feature; the embedded door never pins).
     """
 
+    is_read_room_file = definition.name == READ_ROOM_FILE_TOOL_NAME
+
     async def execute(arguments: dict[str, Any]) -> Any:
         kwargs = dict(arguments)
         if pinned_room_id is not None:
@@ -479,9 +481,7 @@ def build_tool_registration(
             else validated.get(CHAT_ID_FIELD_NAME)
         )
         result = await resolver.invoke(definition, chat_id, validated)
-        if definition.name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(
-            result
-        ):
+        if is_read_room_file and is_mcp_content_result(result):
             return _mcp_content_blocks(result)
         return _serialize(result)
 
@@ -490,9 +490,7 @@ def build_tool_registration(
         description=(input_model.__doc__ or "").strip(),
         input_model=input_model,
         execute=execute,
-        structured_output=False
-        if definition.name == READ_ROOM_FILE_TOOL_NAME
-        else None,
+        structured_output=False if is_read_room_file else None,
     )
 
 

--- a/src/band/integrations/mcp/engine.py
+++ b/src/band/integrations/mcp/engine.py
@@ -50,8 +50,7 @@ from band.runtime.custom_tools import (
 from band.runtime.tools import (
     CHAT_ID_FIELD_NAME,
     CHAT_ID_MAX_LENGTH,
-    READ_ROOM_FILE_TOOL_NAME,
-    SEND_MESSAGE_TOOL_NAME,
+    BandTool,
     SendEventInput,
     Surface,
     ToolDefinition,
@@ -80,13 +79,8 @@ class MCPToolRegistration:
     description: str
     input_model: type[BaseModel]
     execute: MCPToolExecutor
-    # Passed straight through to FastMCP's add_tool(structured_output=...).
-    # None (default) preserves today's auto-inferred behavior for every
-    # tool. False is for band_read_room_file only: its image branch returns
-    # real MCP content blocks (see _mcp_content_blocks), and a declared
-    # structured-output schema would validate that non-str return value
-    # against the model FastMCP infers from the dispatch function's return
-    # annotation and reject it.
+    # False only for band_read_room_file: its image branch returns MCP content
+    # blocks, which the schema FastMCP infers from ``-> str`` would reject.
     structured_output: bool | None = None
 
 
@@ -215,7 +209,7 @@ def enrich_send_message_error(
     ``EmbeddedResolver`` above and the CLI's ``StandaloneResolver`` can call
     this with whatever tools instance they hold.
     """
-    if definition.name != SEND_MESSAGE_TOOL_NAME:
+    if definition.name != BandTool.SEND_MESSAGE:
         return error
     message = append_available_mention_handles(
         str(error),
@@ -468,7 +462,7 @@ def build_tool_registration(
       when set (CLI-only feature; the embedded door never pins).
     """
 
-    is_read_room_file = definition.name == READ_ROOM_FILE_TOOL_NAME
+    is_read_room_file = definition.name == BandTool.READ_ROOM_FILE
 
     async def execute(arguments: dict[str, Any]) -> Any:
         kwargs = dict(arguments)
@@ -623,16 +617,10 @@ def build_resolved_band_mcp_tool_registrations(
 
 
 def _mcp_content_blocks(result: dict[str, Any]) -> list[ImageContent]:
-    """Convert an MCP-content-shaped tool result into real MCP content blocks.
+    """Rebuild an MCP-content-shaped tool result as real ``ContentBlock``s.
 
-    ``is_mcp_content_result`` already confirmed ``result["content"]`` is a
-    list of MCP content block dicts. FastMCP's own result conversion
-    recognizes an actual ``ContentBlock`` instance (or a list of them) and
-    passes it through to the client verbatim -- a plain dict does not match
-    and would otherwise fall through to JSON-text encoding, same as any
-    other tool result. Only "image" blocks exist today (the sole structured
-    branch of ``AgentTools.read_room_file``); a block of any other shape
-    fails Pydantic validation here rather than silently being dropped.
+    FastMCP passes a ``ContentBlock`` instance through to the client verbatim;
+    the equivalent plain dict falls through to JSON-text encoding instead.
     """
     return [ImageContent(**block) for block in result["content"]]
 

--- a/src/band/integrations/mcp/engine.py
+++ b/src/band/integrations/mcp/engine.py
@@ -50,6 +50,7 @@ from band.runtime.custom_tools import (
 from band.runtime.tools import (
     CHAT_ID_FIELD_NAME,
     CHAT_ID_MAX_LENGTH,
+    READ_ROOM_FILE_TOOL_NAME,
     SEND_MESSAGE_TOOL_NAME,
     SendEventInput,
     Surface,
@@ -478,7 +479,9 @@ def build_tool_registration(
             else validated.get(CHAT_ID_FIELD_NAME)
         )
         result = await resolver.invoke(definition, chat_id, validated)
-        if definition.name == "band_read_room_file" and is_mcp_content_result(result):
+        if definition.name == READ_ROOM_FILE_TOOL_NAME and is_mcp_content_result(
+            result
+        ):
             return _mcp_content_blocks(result)
         return _serialize(result)
 
@@ -487,7 +490,9 @@ def build_tool_registration(
         description=(input_model.__doc__ or "").strip(),
         input_model=input_model,
         execute=execute,
-        structured_output=False if definition.name == "band_read_room_file" else None,
+        structured_output=False
+        if definition.name == READ_ROOM_FILE_TOOL_NAME
+        else None,
     )
 
 

--- a/src/band/integrations/parlant/tools.py
+++ b/src/band/integrations/parlant/tools.py
@@ -278,8 +278,23 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
 
         @functools.wraps(func)
         async def run(context: Any, *args: Any, **kwargs: Any) -> Any:
-            call = inspect.signature(func).bind(context, *args, **kwargs)
-            call.apply_defaults()
+            # bind() gets its own try: a signature/argument-shape mismatch
+            # raises TypeError here, before the call-handling try below even
+            # starts, and there's no `call.arguments` yet to build the usual
+            # failure message from.
+            try:
+                call = inspect.signature(func).bind(context, *args, **kwargs)
+                call.apply_defaults()
+            except TypeError as exc:
+                logger.error(
+                    "%s %s: malformed call arguments: %s",
+                    LOG_PREFIX,
+                    func.__name__,
+                    exc,
+                    exc_info=True,
+                )
+                return ToolResult(data=f"Error calling {func.__name__}: {exc}")
+
             logger.info(
                 "%s %s called: session=%s%s",
                 LOG_PREFIX,
@@ -288,7 +303,7 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
                 _logged_arguments(call),
             )
             try:
-                return await func(context, *args, **kwargs)
+                result = await func(context, *args, **kwargs)
             except NoSessionTools:
                 logger.error(
                     "%s %s: no tools available for session %s",
@@ -308,6 +323,8 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
                     if session_tools:
                         message = with_mention_handles(message, session_tools)
                 return ToolResult(data=f"Error {context_phrase}: {message}")
+            logger.info("%s %s -> %s", LOG_PREFIX, func.__name__, result)
+            return result
 
         return run
 

--- a/src/band/integrations/parlant/tools.py
+++ b/src/band/integrations/parlant/tools.py
@@ -17,6 +17,9 @@ This module provides the same tools as LangGraph/Claude adapters:
 - band_remove_contact: Remove an existing contact
 - band_list_contact_requests: List received and sent requests
 - band_respond_contact_request: Approve, reject, or cancel requests
+- band_list_room_files: List files shared in the current room
+- band_read_room_file: Read a file shared in the current room
+- band_send_room_file: Upload text content as a file and share it
 
 NOTE: We intentionally do NOT use `from __future__ import annotations` here
 because Parlant's @p.tool decorator checks annotation types at runtime.
@@ -651,6 +654,159 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
             )
             return ToolResult(data=f"Error responding to contact request: {e}")
 
+    include_files = features is None or Capability.FILES in features.capabilities
+
+    @band_tool()
+    async def band_list_room_files(
+        context: ToolContext,
+        cursor: str = "",
+    ) -> ToolResult:
+        logger.info(
+            "[Parlant Tool] list_room_files called: session=%s, cursor=%s",
+            context.session_id,
+            cursor,
+        )
+        tools = get_session_tools(context.session_id)
+        if not tools:
+            logger.error(
+                "[Parlant Tool] list_room_files: No tools available for session %s",
+                context.session_id,
+            )
+            return ToolResult(data="Error: No tools available in current context")
+
+        try:
+            result = await tools.list_room_files(cursor if cursor else None)
+            data = serialize_tool_result(result)
+            files = data.get("data") or []
+            if not files:
+                return ToolResult(data="No files found in this room")
+            lines = ["Files in this room:"]
+            for f in files:
+                name = f.get("name", "Unknown")
+                content_type = f.get("content_type", "unknown")
+                size = f.get("bytes", 0)
+                file_id = f.get("id", "")
+                lines.append(f"- {name} ({content_type}, {size} bytes) id={file_id}")
+            next_cursor = data.get("next_cursor")
+            if next_cursor:
+                lines.append(
+                    f"More files available; call again with cursor='{next_cursor}' "
+                    "to see the rest."
+                )
+            return ToolResult(data="\n".join(lines))
+        except Exception as e:
+            logger.error(
+                "[Parlant Tool] Error listing room files: %s", e, exc_info=True
+            )
+            return ToolResult(data=f"Error listing room files: {e}")
+
+    @band_tool()
+    async def band_read_room_file(
+        context: ToolContext,
+        file_id: str,
+    ) -> ToolResult:
+        logger.info(
+            "[Parlant Tool] read_room_file called: session=%s, file_id=%s",
+            context.session_id,
+            file_id,
+        )
+        tools = get_session_tools(context.session_id)
+        if not tools:
+            logger.error(
+                "[Parlant Tool] read_room_file: No tools available for session %s",
+                context.session_id,
+            )
+            return ToolResult(data="Error: No tools available in current context")
+
+        try:
+            result = await tools.read_room_file(file_id)
+            if "text" in result:
+                text = result["text"]
+                note = result.get("description")
+                return ToolResult(data=text if not note else f"{text}\n\n({note})")
+            if "content" in result:
+                # This tool's result is text-only, so an inline-previewable
+                # image is described instead of shown -- other frameworks
+                # (anthropic, gemini, ...) pass the same result through as
+                # real vision content; Parlant tool results have no such
+                # multimodal channel.
+                block = result["content"][0]
+                mime_type = block.get("mimeType", "image")
+                return ToolResult(
+                    data=(
+                        f"This file is a {mime_type} image; image content cannot "
+                        "be shown inline by this tool."
+                    )
+                )
+            name = result.get("name", "Unknown")
+            content_type = result.get("content_type", "unknown")
+            size = result.get("bytes", 0)
+            description = result.get("description", "")
+            summary = f"{name} ({content_type}, {size} bytes)"
+            return ToolResult(
+                data=f"{summary}. {description}" if description else summary
+            )
+        except Exception as e:
+            logger.error("[Parlant Tool] Error reading room file: %s", e, exc_info=True)
+            return ToolResult(data=f"Error reading room file: {e}")
+
+    @band_tool(
+        SEND_MESSAGE_MENTIONS_NOTE,
+        param_overrides={"mentions": SEND_MESSAGE_MENTIONS_PARAM_NOTE},
+    )
+    async def band_send_room_file(
+        context: ToolContext,
+        content: str,
+        filename: str,
+        mentions: str,
+        caption: str = "",
+    ) -> ToolResult:
+        logger.info(
+            "[Parlant Tool] send_room_file called: session=%s, filename=%s",
+            context.session_id,
+            filename,
+        )
+        tools = get_session_tools(context.session_id)
+        if not tools:
+            logger.error(
+                "[Parlant Tool] send_room_file: No tools available for session %s",
+                context.session_id,
+            )
+            return ToolResult(data="Error: No tools available in current context")
+
+        try:
+            mention_list = [m.strip() for m in mentions.split(",") if m.strip()]
+            if not mention_list:
+                logger.warning("[Parlant Tool] send_room_file: No mentions provided")
+                error = append_available_mention_handles(
+                    "At least one mention is required",
+                    tools.participants,
+                    getattr(tools, "agent_id", None),
+                )
+                return ToolResult(data=f"Error: {error}")
+
+            result = await tools.send_room_file(
+                content, filename, caption, mention_list
+            )
+            attachment = result.get("attachment") or {}
+            name = attachment.get("name", filename)
+            file_id = attachment.get("id", "")
+            logger.info("[Parlant Tool] Uploaded room file: %s (id=%s)", name, file_id)
+            return ToolResult(
+                data=f"Uploaded '{name}' (id={file_id}) and shared with "
+                f"{', '.join(mention_list)}"
+            )
+        except Exception as e:
+            logger.error("[Parlant Tool] Error sending room file: %s", e, exc_info=True)
+            error = str(e)
+            if isinstance(e, (ValueError, BandToolError)):
+                error = append_available_mention_handles(
+                    error,
+                    tools.participants,
+                    getattr(tools, "agent_id", None),
+                )
+            return ToolResult(data=f"Error sending room file: {error}")
+
     tools = [
         band_send_message,
         band_send_event,
@@ -669,6 +825,15 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
                 band_remove_contact,
                 band_list_contact_requests,
                 band_respond_contact_request,
+            ]
+        )
+
+    if include_files:
+        tools.extend(
+            [
+                band_list_room_files,
+                band_read_room_file,
+                band_send_room_file,
             ]
         )
 

--- a/src/band/integrations/parlant/tools.py
+++ b/src/band/integrations/parlant/tools.py
@@ -36,6 +36,7 @@ from band.core.types import AdapterFeatures, Capability
 from band.runtime.tools import (
     append_available_mention_handles,
     get_tool_description,
+    is_mcp_content_result,
     resolve_tool_model,
     serialize_tool_result,
 )
@@ -724,7 +725,7 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
                 text = result["text"]
                 note = result.get("description")
                 return ToolResult(data=text if not note else f"{text}\n\n({note})")
-            if "content" in result:
+            if is_mcp_content_result(result):
                 # This tool's result is text-only, so an inline-previewable
                 # image is described instead of shown -- other frameworks
                 # (anthropic, gemini, ...) pass the same result through as

--- a/src/band/integrations/parlant/tools.py
+++ b/src/band/integrations/parlant/tools.py
@@ -115,9 +115,8 @@ class NoSessionTools(Exception):
 def require_session_tools(context: Any) -> Any:
     """The room's ``AgentTools`` for this Parlant session, or refuse to run.
 
-    Raising (rather than returning ``None``) is what lets every tool body open
-    with one intent-revealing line instead of repeating the same guard —
-    ``band_tool`` turns the refusal into the model-visible error.
+    Raising rather than returning ``None`` is what lets ``band_tool`` turn the
+    refusal into the model-visible error from one place.
     """
     tools = get_session_tools(context.session_id)
     if not tools:
@@ -126,16 +125,14 @@ def require_session_tools(context: Any) -> Any:
 
 
 def with_mention_handles(message: str, tools: Any) -> str:
-    """``message`` plus the handles this room actually offers, so a failed
-    mention tells the model what it could have said instead."""
+    """``message`` plus the handles this room offers, so a bad mention can retry."""
     return append_available_mention_handles(
         message, tools.participants, getattr(tools, "agent_id", None)
     )
 
 
 def split_mentions(mentions: str) -> list[str]:
-    """Parlant hands mentions over as one comma-separated string (see
-    ``SEND_MESSAGE_MENTIONS_NOTE``); the platform wants a list of handles."""
+    """Parlant's one comma-separated mentions string, as the platform's handle list."""
     return [mention.strip() for mention in mentions.split(",") if mention.strip()]
 
 
@@ -150,8 +147,7 @@ def _logged_arguments(call: inspect.BoundArguments) -> str:
 
 
 def or_none(value: str) -> str | None:
-    """Parlant has no optional-string parameter, so ``""`` is how the model
-    omits one — and the platform wants that absence as ``None``."""
+    """``""`` is how a Parlant model omits a string; the platform wants ``None``."""
     return value or None
 
 
@@ -240,25 +236,12 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
     ) -> None:
         """Give *func* its tool and per-argument text from the master model.
 
-        The tool name is never retyped as a string — it's ``func.__name__``,
-        which is always written to match its ``TOOL_MODELS`` entry (e.g. the
-        function below is literally named ``band_send_message``). ``extra_doc``
-        appends prose the master tool description can't express (a
-        Parlant-only argument shape); ``param_overrides`` does the same per
-        argument, keyed by parameter name. Neither ever replaces master text —
-        only appends — so a master model edit keeps propagating.
-
-        Parlant's own schema builder never reads a docstring's ``Args:``
-        section (unlike pydantic-ai's griffe parser) — a parameter only gets a
-        description if its type annotation is
-        ``Annotated[T, ToolParameterOptions(description=...)]``. So this also
-        wraps each parameter's annotation from the master model's
-        ``Field(description=...)``, skipping ``context`` (must stay exactly
-        ``ToolContext``) and any parameter with no master description. A master
-        field typed ``Literal[...]`` has its string choices folded into that
-        same description text (see ``_literal_choices``) — the function keeps
-        its own ``str`` annotation, since handing Parlant the ``Literal``
-        itself crashes registration.
+        Parlant's schema builder never reads a docstring's ``Args:`` section —
+        a parameter is described only via
+        ``Annotated[T, ToolParameterOptions(description=...)]``, so every
+        annotation is rewrapped here, skipping ``context`` (must stay exactly
+        ``ToolContext``). ``extra_doc`` and ``param_overrides`` only append to
+        master text, so a master model edit keeps propagating.
         """
         func.__doc__ = get_tool_description(func.__name__).rstrip() + extra_doc
 
@@ -284,20 +267,13 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
     def guard_failures(
         func: Callable[..., Any], failure: str, mention_hints: bool
     ) -> Callable[..., Any]:
-        """Wrap *func* so every tool body can be just its own job.
+        """Wrap *func* with the logging and failure handling every tool shares.
 
-        Handles what all of them share: logging the call, turning a missing
-        session into ``NO_SESSION_TOOLS_ERROR``, and rendering any exception as
-        a model-readable ``ToolResult`` rather than crashing the turn.
-        ``failure`` is the phrase completing ``"Error {failure}: {exc}"`` and may
-        reference the call's own arguments (e.g. ``"adding participant
-        '{identifier}'"``). ``mention_hints`` adds the room's available handles
-        to a mention-related failure.
-
-        ``functools.wraps`` keeps ``__wrapped__`` pointing at *func*, so the
-        signature Parlant introspects (first parameter ``context: ToolContext``,
-        return ``ToolResult``, plus every ``Annotated`` argument) stays exactly
-        the one written below.
+        ``failure`` completes ``"Error {failure}: {exc}"`` and may template the
+        call's own arguments (e.g. ``"adding participant '{identifier}'"``);
+        ``mention_hints`` appends the room's available handles to a
+        mention-related failure. ``functools.wraps`` is load-bearing: Parlant
+        introspects ``__wrapped__``, so the registered signature is *func*'s own.
         """
 
         @functools.wraps(func)
@@ -606,11 +582,8 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
                     note = result.get("description")
                     return ToolResult(data=f"{text}\n\n({note})" if note else text)
                 case _ if is_mcp_content_result(result):
-                    # This tool's result is text-only, so an inline-previewable
-                    # image is described instead of shown -- other frameworks
-                    # (anthropic, gemini, ...) pass the same result through as
-                    # real vision content; Parlant tool results have no such
-                    # multimodal channel.
+                    # A Parlant ToolResult has no multimodal channel, so the
+                    # image is described rather than passed through as vision.
                     mime_type = result["content"][0].get("mimeType", "image")
                     return ToolResult(
                         data=(

--- a/src/band/integrations/parlant/tools.py
+++ b/src/band/integrations/parlant/tools.py
@@ -304,9 +304,9 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
                 )
                 message = str(exc)
                 if mention_hints and isinstance(exc, (ValueError, BandToolError)):
-                    message = with_mention_handles(
-                        message, get_session_tools(context.session_id)
-                    )
+                    session_tools = get_session_tools(context.session_id)
+                    if session_tools:
+                        message = with_mention_handles(message, session_tools)
                 return ToolResult(data=f"Error {context_phrase}: {message}")
 
         return run

--- a/src/band/integrations/parlant/tools.py
+++ b/src/band/integrations/parlant/tools.py
@@ -25,6 +25,7 @@ NOTE: We intentionally do NOT use `from __future__ import annotations` here
 because Parlant's @p.tool decorator checks annotation types at runtime.
 """
 
+import functools
 import inspect
 import json
 import logging
@@ -42,6 +43,18 @@ from band.runtime.tools import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Every log line this module emits is tagged with it, so a Parlant run's tool
+# activity greps out of a mixed log in one pass.
+LOG_PREFIX = "[Parlant Tool]"
+
+# What a tool answers the model with when its Parlant session has no Band room
+# bound — a session that outlived its room, or a tool called before one was set.
+NO_SESSION_TOOLS_ERROR = "Error: No tools available in current context"
+
+# Longest argument value echoed into the per-call log line; a full message body
+# or file payload would otherwise dominate the log.
+LOGGED_VALUE_CHARS = 50
 
 # Session-keyed registry to hold tools for each session
 # This approach works across async contexts (unlike ContextVar)
@@ -93,6 +106,53 @@ def _literal_choices(annotation: Any) -> tuple[str, ...] | None:
         if args and all(isinstance(a, str) for a in args):
             return args
     return None
+
+
+class NoSessionTools(Exception):
+    """A tool ran while its Parlant session had no Band room bound to it."""
+
+
+def require_session_tools(context: Any) -> Any:
+    """The room's ``AgentTools`` for this Parlant session, or refuse to run.
+
+    Raising (rather than returning ``None``) is what lets every tool body open
+    with one intent-revealing line instead of repeating the same guard —
+    ``band_tool`` turns the refusal into the model-visible error.
+    """
+    tools = get_session_tools(context.session_id)
+    if not tools:
+        raise NoSessionTools(context.session_id)
+    return tools
+
+
+def with_mention_handles(message: str, tools: Any) -> str:
+    """``message`` plus the handles this room actually offers, so a failed
+    mention tells the model what it could have said instead."""
+    return append_available_mention_handles(
+        message, tools.participants, getattr(tools, "agent_id", None)
+    )
+
+
+def split_mentions(mentions: str) -> list[str]:
+    """Parlant hands mentions over as one comma-separated string (see
+    ``SEND_MESSAGE_MENTIONS_NOTE``); the platform wants a list of handles."""
+    return [mention.strip() for mention in mentions.split(",") if mention.strip()]
+
+
+def _logged_arguments(call: inspect.BoundArguments) -> str:
+    """The call's own arguments, truncated, for one per-tool log line."""
+    rendered = ", ".join(
+        f"{name}={str(value)[:LOGGED_VALUE_CHARS]}"
+        for name, value in call.arguments.items()
+        if name != "context"
+    )
+    return f", {rendered}" if rendered else ""
+
+
+def or_none(value: str) -> str | None:
+    """Parlant has no optional-string parameter, so ``""`` is how the model
+    omits one — and the platform wants that absence as ``None``."""
+    return value or None
 
 
 def set_session_tools(session_id: str, tools: Optional[Any]) -> None:
@@ -173,11 +233,12 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
         logger.warning("Parlant SDK not installed, skipping tool creation")
         return []
 
-    def band_tool(
-        extra_doc: str = "",
-        param_overrides: dict[str, str] | None = None,
-    ) -> Callable[[Callable[..., Any]], Any]:
-        """Decorator: describe *func* and its parameters from the master model, then register it.
+    def describe_from_master(
+        func: Callable[..., Any],
+        extra_doc: str,
+        param_overrides: dict[str, str] | None,
+    ) -> None:
+        """Give *func* its tool and per-argument text from the master model.
 
         The tool name is never retyped as a string — it's ``func.__name__``,
         which is always written to match its ``TOOL_MODELS`` entry (e.g. the
@@ -192,650 +253,421 @@ def create_parlant_tools(features: AdapterFeatures | None = None) -> list[Any]:
         description if its type annotation is
         ``Annotated[T, ToolParameterOptions(description=...)]``. So this also
         wraps each parameter's annotation from the master model's
-        ``Field(description=...)`` before registering, skipping ``context``
-        (must stay exactly ``ToolContext``) and any parameter with no master
-        description. A master field typed ``Literal[...]`` has its string
-        choices folded into that same description text (see
-        ``_literal_choices``) — the function keeps its own ``str``
-        annotation, since handing Parlant the ``Literal`` itself crashes
-        registration.
+        ``Field(description=...)``, skipping ``context`` (must stay exactly
+        ``ToolContext``) and any parameter with no master description. A master
+        field typed ``Literal[...]`` has its string choices folded into that
+        same description text (see ``_literal_choices``) — the function keeps
+        its own ``str`` annotation, since handing Parlant the ``Literal``
+        itself crashes registration.
+        """
+        func.__doc__ = get_tool_description(func.__name__).rstrip() + extra_doc
+
+        model = resolve_tool_model(func.__name__)
+        if model is None:
+            return
+
+        for param_name, param in inspect.signature(func).parameters.items():
+            if param_name == "context":
+                continue
+            field = model.model_fields.get(param_name)
+            if field is None or not field.description:
+                continue
+            description = field.description
+            if choices := _literal_choices(field.annotation):
+                description = description.rstrip() + f" One of: {', '.join(choices)}."
+            if param_overrides and param_name in param_overrides:
+                description = description.rstrip() + param_overrides[param_name]
+            func.__annotations__[param_name] = Annotated[
+                param.annotation, ToolParameterOptions(description=description)
+            ]
+
+    def guard_failures(
+        func: Callable[..., Any], failure: str, mention_hints: bool
+    ) -> Callable[..., Any]:
+        """Wrap *func* so every tool body can be just its own job.
+
+        Handles what all of them share: logging the call, turning a missing
+        session into ``NO_SESSION_TOOLS_ERROR``, and rendering any exception as
+        a model-readable ``ToolResult`` rather than crashing the turn.
+        ``failure`` is the phrase completing ``"Error {failure}: {exc}"`` and may
+        reference the call's own arguments (e.g. ``"adding participant
+        '{identifier}'"``). ``mention_hints`` adds the room's available handles
+        to a mention-related failure.
+
+        ``functools.wraps`` keeps ``__wrapped__`` pointing at *func*, so the
+        signature Parlant introspects (first parameter ``context: ToolContext``,
+        return ``ToolResult``, plus every ``Annotated`` argument) stays exactly
+        the one written below.
         """
 
+        @functools.wraps(func)
+        async def run(context: Any, *args: Any, **kwargs: Any) -> Any:
+            call = inspect.signature(func).bind(context, *args, **kwargs)
+            call.apply_defaults()
+            logger.info(
+                "%s %s called: session=%s%s",
+                LOG_PREFIX,
+                func.__name__,
+                context.session_id,
+                _logged_arguments(call),
+            )
+            try:
+                return await func(context, *args, **kwargs)
+            except NoSessionTools:
+                logger.error(
+                    "%s %s: no tools available for session %s",
+                    LOG_PREFIX,
+                    func.__name__,
+                    context.session_id,
+                )
+                return ToolResult(data=NO_SESSION_TOOLS_ERROR)
+            except Exception as exc:
+                context_phrase = failure.format(**call.arguments)
+                logger.error(
+                    "%s Error %s: %s", LOG_PREFIX, context_phrase, exc, exc_info=True
+                )
+                message = str(exc)
+                if mention_hints and isinstance(exc, (ValueError, BandToolError)):
+                    message = with_mention_handles(
+                        message, get_session_tools(context.session_id)
+                    )
+                return ToolResult(data=f"Error {context_phrase}: {message}")
+
+        return run
+
+    def band_tool(
+        failure: str,
+        extra_doc: str = "",
+        param_overrides: dict[str, str] | None = None,
+        mention_hints: bool = False,
+    ) -> Callable[[Callable[..., Any]], Any]:
+        """Decorator: describe the tool from the master model, guard it, register it."""
+
         def decorator(func: Callable[..., Any]) -> Any:
-            func.__doc__ = get_tool_description(func.__name__).rstrip() + extra_doc
-
-            model = resolve_tool_model(func.__name__)
-            if model is not None:
-                for param_name, param in inspect.signature(func).parameters.items():
-                    if param_name == "context":
-                        continue
-                    field = model.model_fields.get(param_name)
-                    if field is None or not field.description:
-                        continue
-                    description = field.description
-                    if choices := _literal_choices(field.annotation):
-                        description = (
-                            description.rstrip() + f" One of: {', '.join(choices)}."
-                        )
-                    if param_overrides and param_name in param_overrides:
-                        description = description.rstrip() + param_overrides[param_name]
-                    func.__annotations__[param_name] = Annotated[
-                        param.annotation, ToolParameterOptions(description=description)
-                    ]
-
-            return p.tool(func)
+            describe_from_master(func, extra_doc, param_overrides)
+            return p.tool(guard_failures(func, failure, mention_hints))
 
         return decorator
 
-    @band_tool(
-        SEND_MESSAGE_MENTIONS_NOTE,
-        param_overrides={"mentions": SEND_MESSAGE_MENTIONS_PARAM_NOTE},
-    )
-    async def band_send_message(
-        context: ToolContext,
-        content: str,
-        mentions: str,
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] send_message called: session=%s, content=%s..., mentions=%s",
-            context.session_id,
-            content[:50],
-            mentions,
+    def chat_tools() -> list[Any]:
+        """The room tools every Parlant agent gets, capability-free."""
+
+        @band_tool(
+            "sending message",
+            SEND_MESSAGE_MENTIONS_NOTE,
+            param_overrides={"mentions": SEND_MESSAGE_MENTIONS_PARAM_NOTE},
+            mention_hints=True,
         )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] send_message: No tools available for session %s",
-                context.session_id,
-            )
-            return ToolResult(data="Error: No tools available in current context")
-
-        try:
-            # Parse mentions from comma-separated string
-            mention_list = [m.strip() for m in mentions.split(",") if m.strip()]
-            if not mention_list:
-                logger.warning("[Parlant Tool] send_message: No mentions provided")
-                error = append_available_mention_handles(
-                    "At least one mention is required",
-                    tools.participants,
-                    getattr(tools, "agent_id", None),
+        async def band_send_message(
+            context: ToolContext,
+            content: str,
+            mentions: str,
+        ) -> ToolResult:
+            tools = require_session_tools(context)
+            recipients = split_mentions(mentions)
+            if not recipients:
+                return ToolResult(
+                    data="Error: "
+                    + with_mention_handles("At least one mention is required", tools)
                 )
-                return ToolResult(data=f"Error: {error}")
 
-            logger.info("[Parlant Tool] Sending message to: %s", mention_list)
-            await tools.send_message(content, mention_list)
-            # Mark that we sent a message via the tool (so adapter doesn't duplicate)
+            await tools.send_message(content, recipients)
+            # Tells the adapter its own reply would duplicate this one.
             mark_message_sent(context.session_id)
-            logger.info("[Parlant Tool] Message sent successfully via tool")
-            return ToolResult(data=f"Message sent to {', '.join(mention_list)}")
-        except Exception as e:
-            logger.error("[Parlant Tool] Error sending message: %s", e, exc_info=True)
-            error = str(e)
-            if isinstance(e, (ValueError, BandToolError)):
-                error = append_available_mention_handles(
-                    error,
-                    tools.participants,
-                    getattr(tools, "agent_id", None),
+            return ToolResult(data=f"Message sent to {', '.join(recipients)}")
+
+        @band_tool("sending event")
+        async def band_send_event(
+            context: ToolContext,
+            content: str,
+            message_type: str,
+        ) -> ToolResult:
+            tools = require_session_tools(context)
+            if message_type not in ("thought", "error", "task"):
+                return ToolResult(
+                    data=f"Error: Invalid message_type '{message_type}'. Use 'thought', 'error', or 'task'"
                 )
-            return ToolResult(data=f"Error sending message: {error}")
 
-    @band_tool()
-    async def band_send_event(
-        context: ToolContext,
-        content: str,
-        message_type: str,
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] send_event called: session=%s, type=%s",
-            context.session_id,
-            message_type,
-        )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] send_event: No tools available for session %s",
-                context.session_id,
-            )
-            return ToolResult(data="Error: No tools available in current context")
-
-        if message_type not in ("thought", "error", "task"):
-            return ToolResult(
-                data=f"Error: Invalid message_type '{message_type}'. Use 'thought', 'error', or 'task'"
-            )
-
-        try:
             await tools.send_event(content, message_type, None)
-            logger.info("[Parlant Tool] Event (%s) sent successfully", message_type)
             return ToolResult(data=f"Event ({message_type}) sent successfully")
-        except Exception as e:
-            logger.error("[Parlant Tool] Error sending event: %s", e, exc_info=True)
-            return ToolResult(data=f"Error sending event: {e}")
 
-    @band_tool()
-    async def band_add_participant(
-        context: ToolContext,
-        identifier: str,
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] add_participant called: session=%s, identifier=%s",
-            context.session_id,
-            identifier,
-        )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] add_participant: No tools available for session %s",
-                context.session_id,
-            )
-            return ToolResult(data="Error: No tools available in current context")
-
-        try:
+        @band_tool("adding participant '{identifier}'")
+        async def band_add_participant(
+            context: ToolContext,
+            identifier: str,
+        ) -> ToolResult:
+            tools = require_session_tools(context)
             result = await tools.add_participant(identifier, "member")
-            status = result.get("status", "added")
-            if status == "already_in_room":
-                logger.info("[Parlant Tool] '%s' is already in the room", identifier)
+            if result.get("status", "added") == "already_in_room":
                 return ToolResult(
                     data=f"'{identifier}' is already in the room - no action needed"
                 )
-            logger.info(
-                "[Parlant Tool] Successfully added '%s' to the room", identifier
-            )
             return ToolResult(data=f"Successfully added '{identifier}' to the room")
-        except Exception as e:
-            logger.error(
-                "[Parlant Tool] Error adding participant '%s': %s",
-                identifier,
-                e,
-                exc_info=True,
-            )
-            return ToolResult(data=f"Error adding participant '{identifier}': {e}")
 
-    @band_tool()
-    async def band_remove_participant(
-        context: ToolContext,
-        identifier: str,
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] remove_participant called: session=%s, identifier=%s",
-            context.session_id,
-            identifier,
-        )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] remove_participant: No tools available for session %s",
-                context.session_id,
-            )
-            return ToolResult(data="Error: No tools available in current context")
-
-        try:
+        @band_tool("removing participant '{identifier}'")
+        async def band_remove_participant(
+            context: ToolContext,
+            identifier: str,
+        ) -> ToolResult:
+            tools = require_session_tools(context)
             await tools.remove_participant(identifier)
-            logger.info(
-                "[Parlant Tool] Successfully removed '%s' from the room", identifier
-            )
             return ToolResult(data=f"Successfully removed '{identifier}' from the room")
-        except Exception as e:
-            logger.error(
-                "[Parlant Tool] Error removing participant '%s': %s",
-                identifier,
-                e,
-                exc_info=True,
-            )
-            return ToolResult(data=f"Error removing participant '{identifier}': {e}")
 
-    @band_tool(LOOKUP_PEERS_RETURN_NOTE)
-    async def band_lookup_peers(
-        context: ToolContext,
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] lookup_peers called: session=%s", context.session_id
-        )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] lookup_peers: No tools available for session %s",
-                context.session_id,
-            )
-            return ToolResult(data="Error: No tools available in current context")
-
-        try:
-            # Use defaults - pagination rarely needed for agent lookups
-            result = await tools.lookup_peers(page=1, page_size=50)
-            logger.info("[Parlant Tool] lookup_peers result: %s", result)
-            # Normalize Fern model -> dict for uniform handling
-            data = serialize_tool_result(result)
+        @band_tool("looking up peers", LOOKUP_PEERS_RETURN_NOTE)
+        async def band_lookup_peers(
+            context: ToolContext,
+        ) -> ToolResult:
+            tools = require_session_tools(context)
+            # Pagination is rarely needed for agent lookups, so it isn't exposed.
+            data = serialize_tool_result(await tools.lookup_peers(page=1, page_size=50))
             peers = data.get("data") or []
-            metadata = data.get("metadata") or {}
             if not peers:
                 return ToolResult(data="No available agents found")
 
-            page_num = metadata.get("page", 1)
-            total_pages = metadata.get("total_pages", 1)
-            lines = [f"Available agents (page {page_num} of {total_pages}):"]
-            for peer in peers:
-                name = peer.get("name", "Unknown")
-                desc = peer.get("description") or "No description"
-                peer_type = peer.get("type", "Agent")
-                lines.append(f"- {name} ({peer_type}): {desc}")
+            metadata = data.get("metadata") or {}
+            lines = [
+                f"Available agents (page {metadata.get('page', 1)} of "
+                f"{metadata.get('total_pages', 1)}):"
+            ]
+            lines.extend(
+                f"- {peer.get('name', 'Unknown')} ({peer.get('type', 'Agent')}): "
+                f"{peer.get('description') or 'No description'}"
+                for peer in peers
+            )
             return ToolResult(data="\n".join(lines))
-        except Exception as e:
-            logger.error("[Parlant Tool] Error looking up peers: %s", e, exc_info=True)
-            return ToolResult(data=f"Error looking up peers: {e}")
 
-    @band_tool()
-    async def band_get_participants(
-        context: ToolContext,
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] get_participants called: session=%s", context.session_id
-        )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] get_participants: No tools available for session %s",
-                context.session_id,
-            )
-            return ToolResult(data="Error: No tools available in current context")
-
-        try:
+        @band_tool("getting participants")
+        async def band_get_participants(
+            context: ToolContext,
+        ) -> ToolResult:
+            tools = require_session_tools(context)
             result = await tools.get_participants()
-            logger.info("[Parlant Tool] get_participants result: %s", result)
-            # Normalize Fern models -> dicts for uniform handling
-            if isinstance(result, list):
-                items = serialize_tool_result(result)
-                if not items:
-                    return ToolResult(data="No participants in the room")
-                lines = ["Current participants:"]
-                for participant in items:
-                    name = participant.get("name", "Unknown")
-                    p_type = participant.get("type", "Unknown")
-                    lines.append(f"- {name} ({p_type})")
-                return ToolResult(data="\n".join(lines))
-            return ToolResult(data=str(result))
-        except Exception as e:
-            logger.error(
-                "[Parlant Tool] Error getting participants: %s", e, exc_info=True
+            if not isinstance(result, list):
+                return ToolResult(data=str(result))
+
+            participants = serialize_tool_result(result)
+            if not participants:
+                return ToolResult(data="No participants in the room")
+            lines = ["Current participants:"]
+            lines.extend(
+                f"- {participant.get('name', 'Unknown')} "
+                f"({participant.get('type', 'Unknown')})"
+                for participant in participants
             )
-            return ToolResult(data=f"Error getting participants: {e}")
+            return ToolResult(data="\n".join(lines))
 
-    @band_tool()
-    async def band_create_chatroom(
-        context: ToolContext,
-        task_id: str = "",
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] create_chatroom called: session=%s, task_id=%s",
-            context.session_id,
-            task_id,
-        )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] create_chatroom: No tools available for session %s",
-                context.session_id,
-            )
-            return ToolResult(data="Error: No tools available in current context")
+        @band_tool("creating chatroom")
+        async def band_create_chatroom(
+            context: ToolContext,
+            task_id: str = "",
+        ) -> ToolResult:
+            tools = require_session_tools(context)
+            room_id = await tools.create_chatroom(or_none(task_id))
+            return ToolResult(data=f"Created new chat room: {room_id}")
 
-        try:
-            result = await tools.create_chatroom(task_id if task_id else None)
-            logger.info("[Parlant Tool] Created chatroom: %s", result)
-            return ToolResult(data=f"Created new chat room: {result}")
-        except Exception as e:
-            logger.error("[Parlant Tool] Error creating chatroom: %s", e, exc_info=True)
-            return ToolResult(data=f"Error creating chatroom: {e}")
+        return [
+            band_send_message,
+            band_send_event,
+            band_add_participant,
+            band_remove_participant,
+            band_lookup_peers,
+            band_get_participants,
+            band_create_chatroom,
+        ]
 
-    include_contacts = features is None or Capability.CONTACTS in features.capabilities
+    def contact_tools() -> list[Any]:
+        """Contact management — gated behind ``Capability.CONTACTS``."""
 
-    @band_tool()
-    async def band_list_contacts(
-        context: ToolContext,
-        page: int = 1,
-        page_size: int = 50,
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] list_contacts called: session=%s, page=%s",
-            context.session_id,
-            page,
-        )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] list_contacts: No tools available for session %s",
-                context.session_id,
-            )
-            return ToolResult(data="Error: No tools available in current context")
-
-        try:
-            result = await tools.list_contacts(page, page_size)
-            # Fern model: serialize via model_dump if available, fallback to str
-            data = serialize_tool_result(result)
+        @band_tool("listing contacts")
+        async def band_list_contacts(
+            context: ToolContext,
+            page: int = 1,
+            page_size: int = 50,
+        ) -> ToolResult:
+            tools = require_session_tools(context)
+            data = serialize_tool_result(await tools.list_contacts(page, page_size))
             return ToolResult(data=json.dumps(data, default=str))
-        except Exception as e:
-            logger.error("[Parlant Tool] Error listing contacts: %s", e, exc_info=True)
-            return ToolResult(data=f"Error listing contacts: {e}")
 
-    @band_tool()
-    async def band_add_contact(
-        context: ToolContext,
-        handle: str,
-        message: str = "",
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] add_contact called: session=%s, handle=%s",
-            context.session_id,
-            handle,
-        )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] add_contact: No tools available for session %s",
-                context.session_id,
+        @band_tool("adding contact")
+        async def band_add_contact(
+            context: ToolContext,
+            handle: str,
+            message: str = "",
+        ) -> ToolResult:
+            tools = require_session_tools(context)
+            data = serialize_tool_result(
+                await tools.add_contact(handle, or_none(message))
             )
-            return ToolResult(data="Error: No tools available in current context")
-
-        try:
-            result = await tools.add_contact(handle, message if message else None)
-            data = serialize_tool_result(result)
             status = (
                 data.get("status", "pending") if isinstance(data, dict) else "pending"
             )
             return ToolResult(data=f"Contact request to {handle}: {status}")
-        except Exception as e:
-            logger.error("[Parlant Tool] Error adding contact: %s", e, exc_info=True)
-            return ToolResult(data=f"Error adding contact: {e}")
 
-    @band_tool()
-    async def band_remove_contact(
-        context: ToolContext,
-        handle: str = "",
-        contact_id: str = "",
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] remove_contact called: session=%s, handle=%s, contact_id=%s",
-            context.session_id,
-            handle,
-            contact_id,
-        )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] remove_contact: No tools available for session %s",
-                context.session_id,
-            )
-            return ToolResult(data="Error: No tools available in current context")
+        @band_tool("removing contact")
+        async def band_remove_contact(
+            context: ToolContext,
+            handle: str = "",
+            contact_id: str = "",
+        ) -> ToolResult:
+            tools = require_session_tools(context)
+            if not handle and not contact_id:
+                return ToolResult(
+                    data="Error: Either handle or contact_id must be provided"
+                )
 
-        h = handle if handle else None
-        cid = contact_id if contact_id else None
-        if not h and not cid:
+            await tools.remove_contact(or_none(handle), or_none(contact_id))
             return ToolResult(
-                data="Error: Either handle or contact_id must be provided"
+                data=f"Contact '{handle or contact_id}' removed successfully"
             )
 
-        try:
-            await tools.remove_contact(h, cid)
-            identifier = handle or contact_id
-            return ToolResult(data=f"Contact '{identifier}' removed successfully")
-        except Exception as e:
-            logger.error("[Parlant Tool] Error removing contact: %s", e, exc_info=True)
-            return ToolResult(data=f"Error removing contact: {e}")
-
-    @band_tool()
-    async def band_list_contact_requests(
-        context: ToolContext,
-        page: int = 1,
-        page_size: int = 50,
-        sent_status: str = "pending",
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] list_contact_requests called: session=%s, sent_status=%s",
-            context.session_id,
-            sent_status,
-        )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] list_contact_requests: No tools available for session %s",
-                context.session_id,
+        @band_tool("listing contact requests")
+        async def band_list_contact_requests(
+            context: ToolContext,
+            page: int = 1,
+            page_size: int = 50,
+            sent_status: str = "pending",
+        ) -> ToolResult:
+            tools = require_session_tools(context)
+            data = serialize_tool_result(
+                await tools.list_contact_requests(page, page_size, sent_status)
             )
-            return ToolResult(data="Error: No tools available in current context")
-
-        try:
-            result = await tools.list_contact_requests(page, page_size, sent_status)
-            # Fern model: serialize via model_dump if available, fallback to str
-            data = serialize_tool_result(result)
             return ToolResult(data=json.dumps(data, default=str))
-        except Exception as e:
-            logger.error(
-                "[Parlant Tool] Error listing contact requests: %s", e, exc_info=True
-            )
-            return ToolResult(data=f"Error listing contact requests: {e}")
 
-    @band_tool()
-    async def band_respond_contact_request(
-        context: ToolContext,
-        action: str,
-        handle: str = "",
-        request_id: str = "",
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] respond_contact_request called: session=%s, action=%s",
-            context.session_id,
-            action,
-        )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] respond_contact_request: No tools available for session %s",
-                context.session_id,
-            )
-            return ToolResult(data="Error: No tools available in current context")
+        @band_tool("responding to contact request")
+        async def band_respond_contact_request(
+            context: ToolContext,
+            action: str,
+            handle: str = "",
+            request_id: str = "",
+        ) -> ToolResult:
+            tools = require_session_tools(context)
+            if not handle and not request_id:
+                return ToolResult(
+                    data="Error: Either handle or request_id must be provided"
+                )
+            if action not in ("approve", "reject", "cancel"):
+                return ToolResult(
+                    data=f"Error: Invalid action '{action}'. Use 'approve', 'reject', or 'cancel'"
+                )
 
-        h = handle if handle else None
-        rid = request_id if request_id else None
-        if not h and not rid:
-            return ToolResult(
-                data="Error: Either handle or request_id must be provided"
+            data = serialize_tool_result(
+                await tools.respond_contact_request(
+                    action, or_none(handle), or_none(request_id)
+                )
             )
-
-        if action not in ("approve", "reject", "cancel"):
-            return ToolResult(
-                data=f"Error: Invalid action '{action}'. Use 'approve', 'reject', or 'cancel'"
-            )
-
-        try:
-            result = await tools.respond_contact_request(action, h, rid)
-            data = serialize_tool_result(result)
             status = data.get("status", action) if isinstance(data, dict) else action
             return ToolResult(data=f"Contact request {action}d: {status}")
-        except Exception as e:
-            logger.error(
-                "[Parlant Tool] Error responding to contact request: %s",
-                e,
-                exc_info=True,
-            )
-            return ToolResult(data=f"Error responding to contact request: {e}")
 
-    include_files = features is None or Capability.FILES in features.capabilities
+        return [
+            band_list_contacts,
+            band_add_contact,
+            band_remove_contact,
+            band_list_contact_requests,
+            band_respond_contact_request,
+        ]
 
-    @band_tool()
-    async def band_list_room_files(
-        context: ToolContext,
-        cursor: str = "",
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] list_room_files called: session=%s, cursor=%s",
-            context.session_id,
-            cursor,
-        )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] list_room_files: No tools available for session %s",
-                context.session_id,
-            )
-            return ToolResult(data="Error: No tools available in current context")
+    def file_tools() -> list[Any]:
+        """Room files — gated behind ``Capability.FILES``."""
 
-        try:
-            result = await tools.list_room_files(cursor if cursor else None)
-            data = serialize_tool_result(result)
+        @band_tool("listing room files")
+        async def band_list_room_files(
+            context: ToolContext,
+            cursor: str = "",
+        ) -> ToolResult:
+            tools = require_session_tools(context)
+            data = serialize_tool_result(await tools.list_room_files(or_none(cursor)))
             files = data.get("data") or []
             if not files:
                 return ToolResult(data="No files found in this room")
+
             lines = ["Files in this room:"]
-            for f in files:
-                name = f.get("name", "Unknown")
-                content_type = f.get("content_type", "unknown")
-                size = f.get("bytes", 0)
-                file_id = f.get("id", "")
-                lines.append(f"- {name} ({content_type}, {size} bytes) id={file_id}")
-            next_cursor = data.get("next_cursor")
-            if next_cursor:
+            lines.extend(
+                f"- {file.get('name', 'Unknown')} "
+                f"({file.get('content_type', 'unknown')}, {file.get('bytes', 0)} bytes) "
+                f"id={file.get('id', '')}"
+                for file in files
+            )
+            if next_cursor := data.get("next_cursor"):
                 lines.append(
                     f"More files available; call again with cursor='{next_cursor}' "
                     "to see the rest."
                 )
             return ToolResult(data="\n".join(lines))
-        except Exception as e:
-            logger.error(
-                "[Parlant Tool] Error listing room files: %s", e, exc_info=True
-            )
-            return ToolResult(data=f"Error listing room files: {e}")
 
-    @band_tool()
-    async def band_read_room_file(
-        context: ToolContext,
-        file_id: str,
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] read_room_file called: session=%s, file_id=%s",
-            context.session_id,
-            file_id,
-        )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] read_room_file: No tools available for session %s",
-                context.session_id,
-            )
-            return ToolResult(data="Error: No tools available in current context")
-
-        try:
+        @band_tool("reading room file")
+        async def band_read_room_file(
+            context: ToolContext,
+            file_id: str,
+        ) -> ToolResult:
+            tools = require_session_tools(context)
             result = await tools.read_room_file(file_id)
-            if "text" in result:
-                text = result["text"]
-                note = result.get("description")
-                return ToolResult(data=text if not note else f"{text}\n\n({note})")
-            if is_mcp_content_result(result):
-                # This tool's result is text-only, so an inline-previewable
-                # image is described instead of shown -- other frameworks
-                # (anthropic, gemini, ...) pass the same result through as
-                # real vision content; Parlant tool results have no such
-                # multimodal channel.
-                block = result["content"][0]
-                mime_type = block.get("mimeType", "image")
-                return ToolResult(
-                    data=(
-                        f"This file is a {mime_type} image; image content cannot "
-                        "be shown inline by this tool."
+            match result:
+                case {"text": str() as text}:
+                    note = result.get("description")
+                    return ToolResult(data=f"{text}\n\n({note})" if note else text)
+                case _ if is_mcp_content_result(result):
+                    # This tool's result is text-only, so an inline-previewable
+                    # image is described instead of shown -- other frameworks
+                    # (anthropic, gemini, ...) pass the same result through as
+                    # real vision content; Parlant tool results have no such
+                    # multimodal channel.
+                    mime_type = result["content"][0].get("mimeType", "image")
+                    return ToolResult(
+                        data=(
+                            f"This file is a {mime_type} image; image content cannot "
+                            "be shown inline by this tool."
+                        )
                     )
-                )
-            name = result.get("name", "Unknown")
-            content_type = result.get("content_type", "unknown")
-            size = result.get("bytes", 0)
+
+            summary = (
+                f"{result.get('name', 'Unknown')} "
+                f"({result.get('content_type', 'unknown')}, "
+                f"{result.get('bytes', 0)} bytes)"
+            )
             description = result.get("description", "")
-            summary = f"{name} ({content_type}, {size} bytes)"
             return ToolResult(
                 data=f"{summary}. {description}" if description else summary
             )
-        except Exception as e:
-            logger.error("[Parlant Tool] Error reading room file: %s", e, exc_info=True)
-            return ToolResult(data=f"Error reading room file: {e}")
 
-    @band_tool(
-        SEND_MESSAGE_MENTIONS_NOTE,
-        param_overrides={"mentions": SEND_MESSAGE_MENTIONS_PARAM_NOTE},
-    )
-    async def band_send_room_file(
-        context: ToolContext,
-        content: str,
-        filename: str,
-        mentions: str,
-        caption: str = "",
-    ) -> ToolResult:
-        logger.info(
-            "[Parlant Tool] send_room_file called: session=%s, filename=%s",
-            context.session_id,
-            filename,
+        @band_tool(
+            "sending room file",
+            SEND_MESSAGE_MENTIONS_NOTE,
+            param_overrides={"mentions": SEND_MESSAGE_MENTIONS_PARAM_NOTE},
+            mention_hints=True,
         )
-        tools = get_session_tools(context.session_id)
-        if not tools:
-            logger.error(
-                "[Parlant Tool] send_room_file: No tools available for session %s",
-                context.session_id,
-            )
-            return ToolResult(data="Error: No tools available in current context")
-
-        try:
-            mention_list = [m.strip() for m in mentions.split(",") if m.strip()]
-            if not mention_list:
-                logger.warning("[Parlant Tool] send_room_file: No mentions provided")
-                error = append_available_mention_handles(
-                    "At least one mention is required",
-                    tools.participants,
-                    getattr(tools, "agent_id", None),
+        async def band_send_room_file(
+            context: ToolContext,
+            content: str,
+            filename: str,
+            mentions: str,
+            caption: str = "",
+        ) -> ToolResult:
+            tools = require_session_tools(context)
+            recipients = split_mentions(mentions)
+            if not recipients:
+                return ToolResult(
+                    data="Error: "
+                    + with_mention_handles("At least one mention is required", tools)
                 )
-                return ToolResult(data=f"Error: {error}")
 
-            result = await tools.send_room_file(
-                content, filename, caption, mention_list
-            )
+            result = await tools.send_room_file(content, filename, caption, recipients)
             attachment = result.get("attachment") or {}
-            name = attachment.get("name", filename)
-            file_id = attachment.get("id", "")
-            logger.info("[Parlant Tool] Uploaded room file: %s (id=%s)", name, file_id)
             return ToolResult(
-                data=f"Uploaded '{name}' (id={file_id}) and shared with "
-                f"{', '.join(mention_list)}"
+                data=f"Uploaded '{attachment.get('name', filename)}' "
+                f"(id={attachment.get('id', '')}) and shared with "
+                f"{', '.join(recipients)}"
             )
-        except Exception as e:
-            logger.error("[Parlant Tool] Error sending room file: %s", e, exc_info=True)
-            error = str(e)
-            if isinstance(e, (ValueError, BandToolError)):
-                error = append_available_mention_handles(
-                    error,
-                    tools.participants,
-                    getattr(tools, "agent_id", None),
-                )
-            return ToolResult(data=f"Error sending room file: {error}")
 
-    tools = [
-        band_send_message,
-        band_send_event,
-        band_add_participant,
-        band_remove_participant,
-        band_lookup_peers,
-        band_get_participants,
-        band_create_chatroom,
-    ]
+        return [
+            band_list_room_files,
+            band_read_room_file,
+            band_send_room_file,
+        ]
 
-    if include_contacts:
-        tools.extend(
-            [
-                band_list_contacts,
-                band_add_contact,
-                band_remove_contact,
-                band_list_contact_requests,
-                band_respond_contact_request,
-            ]
-        )
-
-    if include_files:
-        tools.extend(
-            [
-                band_list_room_files,
-                band_read_room_file,
-                band_send_room_file,
-            ]
-        )
-
+    capabilities = features.capabilities if features else None
+    tools = chat_tools()
+    if capabilities is None or Capability.CONTACTS in capabilities:
+        tools += contact_tools()
+    if capabilities is None or Capability.FILES in capabilities:
+        tools += file_tools()
     return tools

--- a/src/band/runtime/prompts.py
+++ b/src/band/runtime/prompts.py
@@ -2,8 +2,8 @@
 System prompt rendering for Band agents.
 
 Combines agent identity + custom instructions + base environment instructions.
-Capability-gated: memory/contact tool instruction sections are only included
-when the corresponding AdapterFeatures capabilities are enabled.
+Capability-gated: memory/contact/file tool instruction sections are only
+included when the corresponding AdapterFeatures capabilities are enabled.
 
 Example:
     from band.runtime.prompts import render_system_prompt
@@ -139,6 +139,14 @@ You have access to contact management tools. Use `band_list_contacts`
 to see your contacts, `band_add_contact` to send contact requests,
 and `band_respond_contact_request` to handle incoming requests.
 """
+FILES_SECTION = """
+## Room File Tools
+
+You have access to file tools for the current room. Use
+`band_list_room_files` to see files shared in the room, `band_read_room_file`
+to fetch one by id, and `band_send_room_file` to upload text content as a
+file and share it in the room.
+"""
 
 # Backward-compatible template dict — DEPRECATED.
 # This static template does NOT include capability-gated sections (MEMORY_SECTION,
@@ -192,6 +200,8 @@ def render_system_prompt(
             capability_sections.append(MEMORY_SECTION.strip())
         if Capability.CONTACTS in features.capabilities:
             capability_sections.append(CONTACT_SECTION.strip())
+        if Capability.FILES in features.capabilities:
+            capability_sections.append(FILES_SECTION.strip())
 
     if not include_base_instructions:
         # Minimal prompt: identity + capability/adapter sections + custom section.

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -1804,6 +1804,7 @@ def is_mcp_content_result(data: Any) -> bool:
     return (
         isinstance(data, dict)
         and isinstance(data.get("content"), list)
+        and bool(data["content"])
         and all(
             isinstance(block, dict) and "type" in block for block in data["content"]
         )
@@ -1816,6 +1817,16 @@ def image_block_placeholder(block_count: int) -> str:
     they build separately. Single source of truth so every adapter's image
     branch reports the same wording instead of re-typing this f-string."""
     return f"<{block_count} image content block(s)>"
+
+
+def decode_image_block(block: dict[str, Any]) -> tuple[bytes, str]:
+    """Decode one MCP image content block into (raw bytes, mime type).
+
+    Every adapter whose target SDK wants raw bytes (as opposed to the
+    base64 string as-is) needs this exact decode -- single source of truth
+    so a rename/reshape of the block's keys only needs updating here.
+    """
+    return base64.b64decode(block["data"]), block["mimeType"]
 
 
 class AttachmentCache(Protocol):

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -938,7 +938,7 @@ AGENT_ROOM_BOUND_TOOL_NAMES: frozenset[str] = frozenset(
         "band_get_participants",
         "band_lookup_peers",
         "band_list_room_files",
-        "band_read_room_file",
+        READ_ROOM_FILE_TOOL_NAME,
         "band_send_room_file",
     }
 )
@@ -1078,7 +1078,7 @@ _TOOL_DEFINITIONS: tuple[ToolDefinition, ...] = (
         method_name="list_room_files",
     ),
     ToolDefinition(
-        name="band_read_room_file",
+        name=READ_ROOM_FILE_TOOL_NAME,
         input_model=ReadRoomFileInput,
         method_name="read_room_file",
     ),
@@ -1305,7 +1305,7 @@ CONTACT_TOOL_NAMES: frozenset[str] = frozenset(
 FILE_TOOL_NAMES: frozenset[str] = frozenset(
     {
         "band_list_room_files",
-        "band_read_room_file",
+        READ_ROOM_FILE_TOOL_NAME,
         "band_send_room_file",
     }
 )
@@ -1365,7 +1365,7 @@ READ_ONLY_TOOL_NAMES: frozenset[str] = frozenset(
         "band_list_memories",
         "band_get_memory",
         "band_list_room_files",
-        "band_read_room_file",
+        READ_ROOM_FILE_TOOL_NAME,
     }
 )
 
@@ -1808,6 +1808,14 @@ def is_mcp_content_result(data: Any) -> bool:
             isinstance(block, dict) and "type" in block for block in data["content"]
         )
     )
+
+
+def image_block_placeholder(block_count: int) -> str:
+    """Text stand-in for an image tool result, for adapters that also log/emit
+    a text summary of the tool output alongside the real multimodal content
+    they build separately. Single source of truth so every adapter's image
+    branch reports the same wording instead of re-typing this f-string."""
+    return f"<{block_count} image content block(s)>"
 
 
 class AttachmentCache(Protocol):

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -844,18 +844,41 @@ class ListMyPeersInput(BaseModel):
 # match here, and ``integrations.mcp.backends`` names the server from it.
 BAND_MCP_SERVER_NAME = "band"
 
-# The one tool whose identity is checked by name well outside its own
-# ToolDefinition entry: room-posting detection, room-binding classification,
-# mention-hint error enrichment, and several adapters' own send-message
-# special cases (crewai, claude_sdk, agno, letta) all need this exact value.
-# Single source of truth so none of those re-type the literal independently.
-SEND_MESSAGE_TOOL_NAME = "band_send_message"
 
-# Every adapter's image-vision-passthrough branch gates on this exact tool
-# name (is_mcp_content_result(result) only means anything for this one tool's
-# result shape). Single source of truth so none of those re-type the literal
-# independently -- same rationale as SEND_MESSAGE_TOOL_NAME above.
-READ_ROOM_FILE_TOOL_NAME = "band_read_room_file"
+class BandTool(StrEnum):
+    """The agent-surface Band tool names.
+
+    One vocabulary for every site that checks a tool's identity by name:
+    room-posting detection, room-binding classification, capability gating,
+    mention-hint enrichment, and the adapters' own per-tool branches (the
+    send-message special cases in crewai/claude_sdk/agno/letta, the
+    image-vision passthrough only a ``READ_ROOM_FILE`` result can trigger).
+    Members are ``str``, so they compare, hash, and serialize as the wire
+    name. The human surface is a separate vocabulary, deliberately not
+    modeled here.
+    """
+
+    SEND_MESSAGE = "band_send_message"
+    SEND_EVENT = "band_send_event"
+    ADD_PARTICIPANT = "band_add_participant"
+    REMOVE_PARTICIPANT = "band_remove_participant"
+    GET_PARTICIPANTS = "band_get_participants"
+    LOOKUP_PEERS = "band_lookup_peers"
+    CREATE_CHATROOM = "band_create_chatroom"
+    LIST_CONTACTS = "band_list_contacts"
+    ADD_CONTACT = "band_add_contact"
+    REMOVE_CONTACT = "band_remove_contact"
+    LIST_CONTACT_REQUESTS = "band_list_contact_requests"
+    RESPOND_CONTACT_REQUEST = "band_respond_contact_request"
+    LIST_MEMORIES = "band_list_memories"
+    STORE_MEMORY = "band_store_memory"
+    GET_MEMORY = "band_get_memory"
+    SUPERSEDE_MEMORY = "band_supersede_memory"
+    ARCHIVE_MEMORY = "band_archive_memory"
+    LIST_ROOM_FILES = "band_list_room_files"
+    READ_ROOM_FILE = "band_read_room_file"
+    SEND_ROOM_FILE = "band_send_room_file"
+
 
 # Tool names whose successful call posts a visible message into the room.
 # Bridge adapters (copilot_sdk, codex, ACP client) use this to suppress their
@@ -867,7 +890,7 @@ READ_ROOM_FILE_TOOL_NAME = "band_read_room_file"
 # still match. ``band_send_room_file`` also posts a message (the file's
 # attaching message), same reply-once reasoning.
 ROOM_POSTING_TOOL_NAMES: frozenset[str] = frozenset(
-    {SEND_MESSAGE_TOOL_NAME, "create_agent_chat_message", "band_send_room_file"}
+    {BandTool.SEND_MESSAGE, "create_agent_chat_message", BandTool.SEND_ROOM_FILE}
 )
 
 
@@ -931,15 +954,15 @@ def canonicalize_mcp_tool_name(tool_name: str, own_names: Collection[str]) -> st
 # instance selection.
 AGENT_ROOM_BOUND_TOOL_NAMES: frozenset[str] = frozenset(
     {
-        SEND_MESSAGE_TOOL_NAME,
-        "band_send_event",
-        "band_add_participant",
-        "band_remove_participant",
-        "band_get_participants",
-        "band_lookup_peers",
-        "band_list_room_files",
-        READ_ROOM_FILE_TOOL_NAME,
-        "band_send_room_file",
+        BandTool.SEND_MESSAGE,
+        BandTool.SEND_EVENT,
+        BandTool.ADD_PARTICIPANT,
+        BandTool.REMOVE_PARTICIPANT,
+        BandTool.GET_PARTICIPANTS,
+        BandTool.LOOKUP_PEERS,
+        BandTool.LIST_ROOM_FILES,
+        BandTool.READ_ROOM_FILE,
+        BandTool.SEND_ROOM_FILE,
     }
 )
 
@@ -988,102 +1011,102 @@ def classify_room_binding(definition: ToolDefinition) -> tuple[bool, bool]:
 # keys from that instead of retyping the name a second time as a dict key.
 _TOOL_DEFINITIONS: tuple[ToolDefinition, ...] = (
     ToolDefinition(
-        name=SEND_MESSAGE_TOOL_NAME,
+        name=BandTool.SEND_MESSAGE,
         input_model=SendMessageInput,
         method_name="send_message",
     ),
     ToolDefinition(
-        name="band_send_event",
+        name=BandTool.SEND_EVENT,
         input_model=SendEventInput,
         method_name="send_event",
     ),
     ToolDefinition(
-        name="band_add_participant",
+        name=BandTool.ADD_PARTICIPANT,
         input_model=AddParticipantInput,
         method_name="add_participant",
     ),
     ToolDefinition(
-        name="band_remove_participant",
+        name=BandTool.REMOVE_PARTICIPANT,
         input_model=RemoveParticipantInput,
         method_name="remove_participant",
     ),
     ToolDefinition(
-        name="band_lookup_peers",
+        name=BandTool.LOOKUP_PEERS,
         input_model=LookupPeersInput,
         method_name="lookup_peers",
     ),
     ToolDefinition(
-        name="band_get_participants",
+        name=BandTool.GET_PARTICIPANTS,
         input_model=GetParticipantsInput,
         method_name="get_participants",
     ),
     ToolDefinition(
-        name="band_create_chatroom",
+        name=BandTool.CREATE_CHATROOM,
         input_model=CreateChatroomInput,
         method_name="create_chatroom",
     ),
     ToolDefinition(
-        name="band_list_contacts",
+        name=BandTool.LIST_CONTACTS,
         input_model=ListContactsInput,
         method_name="list_contacts",
     ),
     ToolDefinition(
-        name="band_add_contact",
+        name=BandTool.ADD_CONTACT,
         input_model=AddContactInput,
         method_name="add_contact",
     ),
     ToolDefinition(
-        name="band_remove_contact",
+        name=BandTool.REMOVE_CONTACT,
         input_model=RemoveContactInput,
         method_name="remove_contact",
     ),
     ToolDefinition(
-        name="band_list_contact_requests",
+        name=BandTool.LIST_CONTACT_REQUESTS,
         input_model=ListContactRequestsInput,
         method_name="list_contact_requests",
     ),
     ToolDefinition(
-        name="band_respond_contact_request",
+        name=BandTool.RESPOND_CONTACT_REQUEST,
         input_model=RespondContactRequestInput,
         method_name="respond_contact_request",
     ),
     ToolDefinition(
-        name="band_list_memories",
+        name=BandTool.LIST_MEMORIES,
         input_model=ListMemoriesInput,
         method_name="list_memories",
     ),
     ToolDefinition(
-        name="band_store_memory",
+        name=BandTool.STORE_MEMORY,
         input_model=StoreMemoryInput,
         method_name="store_memory",
     ),
     ToolDefinition(
-        name="band_get_memory",
+        name=BandTool.GET_MEMORY,
         input_model=GetMemoryInput,
         method_name="get_memory",
     ),
     ToolDefinition(
-        name="band_supersede_memory",
+        name=BandTool.SUPERSEDE_MEMORY,
         input_model=SupersedeMemoryInput,
         method_name="supersede_memory",
     ),
     ToolDefinition(
-        name="band_archive_memory",
+        name=BandTool.ARCHIVE_MEMORY,
         input_model=ArchiveMemoryInput,
         method_name="archive_memory",
     ),
     ToolDefinition(
-        name="band_list_room_files",
+        name=BandTool.LIST_ROOM_FILES,
         input_model=ListRoomFilesInput,
         method_name="list_room_files",
     ),
     ToolDefinition(
-        name=READ_ROOM_FILE_TOOL_NAME,
+        name=BandTool.READ_ROOM_FILE,
         input_model=ReadRoomFileInput,
         method_name="read_room_file",
     ),
     ToolDefinition(
-        name="band_send_room_file",
+        name=BandTool.SEND_ROOM_FILE,
         input_model=SendRoomFileInput,
         method_name="send_room_file",
     ),
@@ -1277,11 +1300,11 @@ TOOL_MODELS: dict[str, type[BaseModel]] = {
 # expose functionality that should be gated.
 MEMORY_TOOL_NAMES: frozenset[str] = frozenset(
     {
-        "band_list_memories",
-        "band_store_memory",
-        "band_get_memory",
-        "band_supersede_memory",
-        "band_archive_memory",
+        BandTool.LIST_MEMORIES,
+        BandTool.STORE_MEMORY,
+        BandTool.GET_MEMORY,
+        BandTool.SUPERSEDE_MEMORY,
+        BandTool.ARCHIVE_MEMORY,
     }
 )
 
@@ -1290,11 +1313,11 @@ MEMORY_TOOL_NAMES: frozenset[str] = frozenset(
 # band_get_contact_context) would be silently misclassified.
 CONTACT_TOOL_NAMES: frozenset[str] = frozenset(
     {
-        "band_list_contacts",
-        "band_add_contact",
-        "band_remove_contact",
-        "band_list_contact_requests",
-        "band_respond_contact_request",
+        BandTool.LIST_CONTACTS,
+        BandTool.ADD_CONTACT,
+        BandTool.REMOVE_CONTACT,
+        BandTool.LIST_CONTACT_REQUESTS,
+        BandTool.RESPOND_CONTACT_REQUEST,
     }
 )
 
@@ -1304,9 +1327,9 @@ CONTACT_TOOL_NAMES: frozenset[str] = frozenset(
 # above.
 FILE_TOOL_NAMES: frozenset[str] = frozenset(
     {
-        "band_list_room_files",
-        READ_ROOM_FILE_TOOL_NAME,
-        "band_send_room_file",
+        BandTool.LIST_ROOM_FILES,
+        BandTool.READ_ROOM_FILE,
+        BandTool.SEND_ROOM_FILE,
     }
 )
 
@@ -1358,14 +1381,14 @@ FILENAME_HEADER_SAFE_PATTERN = re.compile(r"[\x20-\x7e]+")
 # final answer is a genuine no-response failure, not benign noise.
 READ_ONLY_TOOL_NAMES: frozenset[str] = frozenset(
     {
-        "band_get_participants",
-        "band_lookup_peers",
-        "band_list_contacts",
-        "band_list_contact_requests",
-        "band_list_memories",
-        "band_get_memory",
-        "band_list_room_files",
-        READ_ROOM_FILE_TOOL_NAME,
+        BandTool.GET_PARTICIPANTS,
+        BandTool.LOOKUP_PEERS,
+        BandTool.LIST_CONTACTS,
+        BandTool.LIST_CONTACT_REQUESTS,
+        BandTool.LIST_MEMORIES,
+        BandTool.GET_MEMORY,
+        BandTool.LIST_ROOM_FILES,
+        BandTool.READ_ROOM_FILE,
     }
 )
 
@@ -1373,7 +1396,7 @@ READ_ONLY_TOOL_NAMES: frozenset[str] = frozenset(
 # thought/error/task event (narration/status) — not a chat reply or a durable requested
 # action. Like read-only tools, a turn that only sends an event and then yields an empty
 # final answer is a genuine no-response failure, not benign (see is_terminal_success).
-EVENT_TOOL_NAMES: frozenset[str] = frozenset({"band_send_event"})
+EVENT_TOOL_NAMES: frozenset[str] = frozenset({BandTool.SEND_EVENT})
 
 # Human-surface memory tools - parallel to MEMORY_TOOL_NAMES but on the
 # ``surface="human"`` side of the registry. Used by iter_tool_definitions()
@@ -1489,6 +1512,20 @@ if FILE_TOOL_NAMES - ALL_TOOL_NAMES:
 if EVENT_TOOL_NAMES - ALL_TOOL_NAMES:
     raise ValueError(f"Unknown event tools: {EVENT_TOOL_NAMES - ALL_TOOL_NAMES}")
 
+# BandTool is the agent surface's vocabulary, so it must stay exactly the set
+# of agent-surface definitions -- a new agent tool that skips the enum, or an
+# enum member with no definition behind it, is a bug either way.
+_AGENT_DEFINITION_NAMES: frozenset[str] = frozenset(
+    definition.name
+    for definition in _TOOL_DEFINITIONS
+    if definition.surface == Surface.AGENT
+)
+if frozenset(BandTool) != _AGENT_DEFINITION_NAMES:
+    raise ValueError(
+        "BandTool drifted from the agent-surface tool definitions: "
+        f"{frozenset(BandTool) ^ _AGENT_DEFINITION_NAMES}"
+    )
+
 # Human-surface registry membership is validated against TOOL_DEFINITIONS
 # (not TOOL_MODELS, which stays agent-only for back-compat).
 _ALL_DEFINITION_NAMES: frozenset[str] = frozenset(TOOL_DEFINITIONS.keys())
@@ -1578,7 +1615,7 @@ def get_tool_description(name: str) -> str:
     Descriptions are sourced from the Pydantic model docstrings.
 
     Args:
-        name: Tool name (e.g., "band_send_message", "band_lookup_peers")
+        name: Tool name (e.g. ``band_send_message``, ``band_lookup_peers``)
               Also accepts unprefixed names for backwards compatibility (deprecated).
 
     Returns:
@@ -1791,15 +1828,10 @@ def serialize_tool_result(result: Any) -> Any:
 def is_mcp_content_result(data: Any) -> bool:
     """True when ``data`` is already MCP-content-shaped (``{"content": [...]}``).
 
-    ``read_room_file``'s image branch returns exactly this shape (a real MCP
-    image content block), so a consumer that can pass MCP content through to
-    its model verbatim needs to recognize it instead of ``json.dumps``-ing it
-    into a text block like every other tool result. Single source of truth
-    for that recognition -- scope any use of it to the one call site that
-    actually knows it's looking at a ``band_read_room_file`` result; a bare
-    structural check applied to every tool result would misfire on an
-    unrelated tool (built-in or custom) whose own return value happens to
-    have a "content" list of dicts each carrying a "type" key.
+    Only ``read_room_file``'s image branch returns this shape, so gate any use
+    on that tool's name: applied to every tool result the structural check
+    would misfire on an unrelated tool whose return value happens to carry a
+    "content" list of dicts with a "type" key.
     """
     return (
         isinstance(data, dict)
@@ -1812,20 +1844,12 @@ def is_mcp_content_result(data: Any) -> bool:
 
 
 def image_block_placeholder(block_count: int) -> str:
-    """Text stand-in for an image tool result, for adapters that also log/emit
-    a text summary of the tool output alongside the real multimodal content
-    they build separately. Single source of truth so every adapter's image
-    branch reports the same wording instead of re-typing this f-string."""
+    """The text an adapter emits alongside image content it passes separately."""
     return f"<{block_count} image content block(s)>"
 
 
 def decode_image_block(block: dict[str, Any]) -> tuple[bytes, str]:
-    """Decode one MCP image content block into (raw bytes, mime type).
-
-    Every adapter whose target SDK wants raw bytes (as opposed to the
-    base64 string as-is) needs this exact decode -- single source of truth
-    so a rename/reshape of the block's keys only needs updating here.
-    """
+    """Decode one MCP image content block into (raw bytes, mime type)."""
     return base64.b64decode(block["data"]), block["mimeType"]
 
 

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -1782,6 +1782,28 @@ def serialize_tool_result(result: Any) -> Any:
     return result
 
 
+def is_mcp_content_result(data: Any) -> bool:
+    """True when ``data`` is already MCP-content-shaped (``{"content": [...]}``).
+
+    ``read_room_file``'s image branch returns exactly this shape (a real MCP
+    image content block), so a consumer that can pass MCP content through to
+    its model verbatim needs to recognize it instead of ``json.dumps``-ing it
+    into a text block like every other tool result. Single source of truth
+    for that recognition -- scope any use of it to the one call site that
+    actually knows it's looking at a ``band_read_room_file`` result; a bare
+    structural check applied to every tool result would misfire on an
+    unrelated tool (built-in or custom) whose own return value happens to
+    have a "content" list of dicts each carrying a "type" key.
+    """
+    return (
+        isinstance(data, dict)
+        and isinstance(data.get("content"), list)
+        and all(
+            isinstance(block, dict) and "type" in block for block in data["content"]
+        )
+    )
+
+
 class AttachmentCache(Protocol):
     """The subset of async_lru's wrapper object AgentTools relies on.
 

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -851,6 +851,12 @@ BAND_MCP_SERVER_NAME = "band"
 # Single source of truth so none of those re-type the literal independently.
 SEND_MESSAGE_TOOL_NAME = "band_send_message"
 
+# Every adapter's image-vision-passthrough branch gates on this exact tool
+# name (is_mcp_content_result(result) only means anything for this one tool's
+# result shape). Single source of truth so none of those re-type the literal
+# independently -- same rationale as SEND_MESSAGE_TOOL_NAME above.
+READ_ROOM_FILE_TOOL_NAME = "band_read_room_file"
+
 # Tool names whose successful call posts a visible message into the room.
 # Bridge adapters (copilot_sdk, codex, ACP client) use this to suppress their
 # fallback text relay once the turn has already replied in the room, so the

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -1826,21 +1826,39 @@ def serialize_tool_result(result: Any) -> Any:
 
 
 def is_mcp_content_result(data: Any) -> bool:
-    """True when ``data`` is already MCP-content-shaped (``{"content": [...]}``).
+    """True when ``data`` is ``read_room_file``'s image-content-block shape.
 
-    Only ``read_room_file``'s image branch returns this shape, so gate any use
-    on that tool's name: applied to every tool result the structural check
-    would misfire on an unrelated tool whose return value happens to carry a
-    "content" list of dicts with a "type" key.
+    Only ``read_room_file``'s image branch returns this shape (see its
+    "image" case: a ``content`` list of one ``{"type": "image", "data":
+    ..., "mimeType": ...}`` block), so gate any use on that tool's name --
+    prefer ``is_image_passthrough_result`` over calling this directly.
+    Requires ``data``/``mimeType`` on every block (not just ``type``) so a
+    malformed or future-extended block fails this check instead of reaching
+    ``decode_image_block`` and raising past it.
     """
     return (
         isinstance(data, dict)
         and isinstance(data.get("content"), list)
         and bool(data["content"])
         and all(
-            isinstance(block, dict) and "type" in block for block in data["content"]
+            isinstance(block, dict)
+            and block.get("type") == "image"
+            and "data" in block
+            and "mimeType" in block
+            for block in data["content"]
         )
     )
+
+
+def is_image_passthrough_result(tool_name: str, result: Any) -> bool:
+    """True when ``result`` is ``band_read_room_file``'s image-block result.
+
+    The combined check (right tool + right shape) that every adapter's
+    image-passthrough branch needs -- single source of truth instead of
+    re-deriving ``tool_name == BandTool.READ_ROOM_FILE and
+    is_mcp_content_result(result)`` at each call site.
+    """
+    return tool_name == BandTool.READ_ROOM_FILE and is_mcp_content_result(result)
 
 
 def image_block_placeholder(block_count: int) -> str:
@@ -1851,6 +1869,26 @@ def image_block_placeholder(block_count: int) -> str:
 def file_content_placeholder(byte_count: int) -> str:
     """The text a tool-call event reports in place of a file's raw content."""
     return f"<{byte_count} byte file content>"
+
+
+def redact_tool_call_args(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Replace ``band_send_room_file``'s raw ``content`` before it reaches an event.
+
+    Adapters that report a tool_call event by json.dumps-ing the tool's raw
+    kwargs have no idea ``band_send_room_file``'s ``content`` argument can
+    carry up to ``MAX_SEND_CONTENT_BYTES`` of real file bytes -- redact it
+    centrally rather than teaching every adapter's generic reporter the same
+    field name.
+    """
+    if tool_name != BandTool.SEND_ROOM_FILE or not isinstance(args, dict):
+        return args
+    content = args.get("content")
+    if not isinstance(content, str):
+        return args
+    return {
+        **args,
+        "content": file_content_placeholder(len(content.encode("utf-8"))),
+    }
 
 
 def decode_image_block(block: dict[str, Any]) -> tuple[bytes, str]:

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -1848,6 +1848,11 @@ def image_block_placeholder(block_count: int) -> str:
     return f"<{block_count} image content block(s)>"
 
 
+def file_content_placeholder(byte_count: int) -> str:
+    """The text a tool-call event reports in place of a file's raw content."""
+    return f"<{byte_count} byte file content>"
+
+
 def decode_image_block(block: dict[str, Any]) -> tuple[bytes, str]:
     """Decode one MCP image content block into (raw bytes, mime type)."""
     return base64.b64decode(block["data"]), block["mimeType"]

--- a/tests/adapters/agno/test_adapter.py
+++ b/tests/adapters/agno/test_adapter.py
@@ -21,6 +21,7 @@ from agno.agent import Agent as AgnoAgent
 from agno.models.message import Message
 from agno.run import RunStatus
 from agno.run.agent import RunErrorEvent, RunOutput
+from agno.tools.function import ToolResult
 
 from band.adapters.agno import (
     AgnoAdapter,
@@ -300,6 +301,36 @@ class TestBandEntrypointBinding:
 
         assert "no active Band context" in result
         assert tools.tool_calls == []
+
+    async def test_read_room_file_image_result_passes_through_as_agno_image(self):
+        class _ImageTools(FakeAgentTools):
+            async def execute_tool_call(self, tool_name: str, arguments: dict) -> Any:
+                return {
+                    "content": [
+                        {"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}
+                    ]
+                }
+
+        entry = _make_band_entrypoint("band_read_room_file")
+        with _bind_room_tools(_ImageTools()):
+            result = await entry(file_id="f1")
+
+        assert isinstance(result, ToolResult)
+        assert result.images is not None
+        assert len(result.images) == 1
+        assert result.images[0].content == b"fake"
+        assert result.images[0].mime_type == "image/png"
+
+    async def test_read_room_file_non_image_result_stays_json(self):
+        class _TextTools(FakeAgentTools):
+            async def execute_tool_call(self, tool_name: str, arguments: dict) -> Any:
+                return {"name": "notes.txt", "content_type": "text/plain"}
+
+        entry = _make_band_entrypoint("band_read_room_file")
+        with _bind_room_tools(_TextTools()):
+            result = await entry(file_id="f1")
+
+        assert result == '{"name": "notes.txt", "content_type": "text/plain"}'
 
 
 class TestReply:

--- a/tests/adapters/agno/test_adapter.py
+++ b/tests/adapters/agno/test_adapter.py
@@ -332,6 +332,24 @@ class TestBandEntrypointBinding:
 
         assert result == '{"name": "notes.txt", "content_type": "text/plain"}'
 
+    async def test_read_room_file_malformed_image_data_returns_error_string(self):
+        """A decode_image_block failure (invalid base64) must degrade to the
+        adapter's usual error string, not raise uncaught out of the tool
+        entrypoint Agno invokes directly."""
+
+        class _MalformedImageTools(FakeAgentTools):
+            async def execute_tool_call(self, tool_name: str, arguments: dict) -> Any:
+                return {
+                    "content": [{"type": "image", "data": "A", "mimeType": "image/png"}]
+                }
+
+        entry = _make_band_entrypoint("band_read_room_file")
+        with _bind_room_tools(_MalformedImageTools()):
+            result = await entry(file_id="f1")
+
+        assert isinstance(result, str)
+        assert result.startswith("Error reading room file:")
+
 
 class TestReply:
     """The adapter delivers nothing on its own. Like the other adapters, the
@@ -446,6 +464,36 @@ class TestEmitExecution:
 
         types = [e["message_type"] for e in tools.events_sent]
         assert types == ["tool_call", "tool_result"]
+
+    async def test_send_room_file_tool_call_event_redacts_content(
+        self, make_started_adapter, sample_platform_message, tools
+    ):
+        """band_send_room_file's tool_call event must report a bounded
+        placeholder for content, not the raw file bytes -- generic ARGS
+        reporting has no idea this one tool's content argument can carry up
+        to MAX_SEND_CONTENT_BYTES of real file data."""
+        events = tool_events(
+            tool_execution(
+                "band_send_room_file",
+                args={"content": "raw file bytes", "filename": "notes.txt"},
+                result="ok",
+            )
+        )
+        adapter, _ = await make_started_adapter(emit=Emit.TOOL_CALLS, events=events)
+
+        await adapter.on_message(
+            sample_platform_message,
+            tools,
+            [],
+            None,
+            None,
+            is_session_bootstrap=True,
+            room_id="room-1",
+        )
+
+        call_payload = json.loads(tools.events_sent[0]["content"])
+        assert call_payload["args"]["content"] == "<14 byte file content>"
+        assert call_payload["args"]["filename"] == "notes.txt"
 
     async def test_no_events_without_execution_emit(
         self, make_started_adapter, sample_platform_message, tools

--- a/tests/adapters/copilot_sdk/test_tool_bridging.py
+++ b/tests/adapters/copilot_sdk/test_tool_bridging.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from pydantic import BaseModel
 
 from band.adapters.copilot_sdk import _COPILOT_SDK_AVAILABLE
 from band.core.types import Emit
+from band.runtime.tools import ToolCallOutcome
 from tests.adapters.copilot_sdk.fakes import (
     FakeCopilotClient,
     ToolSchemaFakeTools,
@@ -195,3 +198,86 @@ class TestToolBridging:
 
         assert not first_tools.tool_calls
         assert second_tools.tool_calls
+
+
+class _ReadRoomFileFakeTools(ToolSchemaFakeTools):
+    """ToolSchemaFakeTools plus band_read_room_file, which the base fake
+    doesn't expose (it only hardcodes send_message/get_participants)."""
+
+    def get_openai_tool_schemas(self, **kwargs: Any) -> list[dict[str, Any]]:
+        return [
+            *super().get_openai_tool_schemas(**kwargs),
+            {
+                "type": "function",
+                "function": {
+                    "name": "band_read_room_file",
+                    "description": "Read a room file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"file_id": {"type": "string"}},
+                        "required": ["file_id"],
+                    },
+                },
+            },
+        ]
+
+
+class TestReadRoomFileImagePassthrough:
+    @pytest.mark.asyncio
+    async def test_image_result_passes_through_as_binary_result(self):
+        class _ImageTools(_ReadRoomFileFakeTools):
+            async def execute_tool_call_structured(
+                self, tool_name: str, arguments: dict
+            ) -> ToolCallOutcome:
+                return ToolCallOutcome(
+                    value={
+                        "content": [
+                            {
+                                "type": "image",
+                                "data": "ZmFrZQ==",
+                                "mimeType": "image/png",
+                            }
+                        ]
+                    },
+                    ok=True,
+                )
+
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client, emit=Emit.TOOL_CALLS)
+        tools = _ImageTools()
+        await run_message(adapter, tools)
+
+        handler = client.sessions[0].find_tool("band_read_room_file").handler
+        result = await handler(
+            ToolInvocation(
+                tool_call_id="c1",
+                tool_name="band_read_room_file",
+                arguments={"file_id": "f1"},
+            )
+        )
+
+        assert result.result_type == "success"
+        assert result.binary_results_for_llm is not None
+        assert len(result.binary_results_for_llm) == 1
+        binary = result.binary_results_for_llm[0]
+        assert binary.data == "ZmFrZQ=="
+        assert binary.mime_type == "image/png"
+        assert binary.type == "image"
+
+    @pytest.mark.asyncio
+    async def test_non_image_result_stays_text_only(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client, emit=Emit.TOOL_CALLS)
+        tools = _ReadRoomFileFakeTools()
+        await run_message(adapter, tools)
+
+        handler = client.sessions[0].find_tool("band_read_room_file").handler
+        result = await handler(
+            ToolInvocation(
+                tool_call_id="c1",
+                tool_name="band_read_room_file",
+                arguments={"file_id": "f1"},
+            )
+        )
+
+        assert result.binary_results_for_llm is None

--- a/tests/adapters/copilot_sdk/test_tool_bridging.py
+++ b/tests/adapters/copilot_sdk/test_tool_bridging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -281,3 +282,61 @@ class TestReadRoomFileImagePassthrough:
         )
 
         assert result.binary_results_for_llm is None
+
+
+class _SendRoomFileFakeTools(ToolSchemaFakeTools):
+    """ToolSchemaFakeTools plus band_send_room_file, which the base fake
+    doesn't expose."""
+
+    def get_openai_tool_schemas(self, **kwargs: Any) -> list[dict[str, Any]]:
+        return [
+            *super().get_openai_tool_schemas(**kwargs),
+            {
+                "type": "function",
+                "function": {
+                    "name": "band_send_room_file",
+                    "description": "Send a room file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "content": {"type": "string"},
+                            "filename": {"type": "string"},
+                        },
+                        "required": ["content", "filename"],
+                    },
+                },
+            },
+        ]
+
+
+class TestSendRoomFileArgsRedaction:
+    @pytest.mark.asyncio
+    async def test_tool_call_event_redacts_file_content(self):
+        """band_send_room_file's raw content must never reach a tool_call
+        event -- report_tool_call json.dumps's the invocation's raw
+        arguments, and content can carry up to MAX_SEND_CONTENT_BYTES of
+        real file bytes."""
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client, emit=Emit.TOOL_CALLS)
+        tools = _SendRoomFileFakeTools()
+        await run_message(adapter, tools)
+
+        handler = client.sessions[0].find_tool("band_send_room_file").handler
+        raw_content = "raw file bytes that must never reach a tool_call event"
+        await handler(
+            ToolInvocation(
+                tool_call_id="c1",
+                tool_name="band_send_room_file",
+                arguments={"content": raw_content, "filename": "notes.txt"},
+            )
+        )
+
+        call_event = next(
+            e for e in tools.events_sent if e["message_type"] == "tool_call"
+        )
+        reported_args = json.loads(call_event["content"])["args"]
+        assert (
+            reported_args["content"]
+            == f"<{len(raw_content.encode('utf-8'))} byte file content>"
+        )
+        assert raw_content not in call_event["content"]

--- a/tests/adapters/langgraph/test_stream_events.py
+++ b/tests/adapters/langgraph/test_stream_events.py
@@ -138,6 +138,73 @@ class TestStreamEventHandling:
         assert payload["output"] == "missing mentions"
 
     @pytest.mark.asyncio
+    async def test_read_room_file_image_result_reports_placeholder(
+        self, mock_tools, mock_llm, mock_checkpointer
+    ):
+        """band_read_room_file's image result must not leak its base64 data
+        into a tool_result event. langchain_tools.py's execute_definition
+        returns a list[ImageContentBlock] for the image branch, which
+        LangChain wraps in a ToolMessage before on_tool_end sees it -- that
+        object isn't JSON-serializable, so json.dumps's default=str would
+        otherwise fall back to str(ToolMessage(...)), embedding the full
+        base64 payload."""
+        adapter = LangGraphAdapter(
+            llm=mock_llm,
+            checkpointer=mock_checkpointer,
+            emit=Emit.TOOL_CALLS,
+        )
+
+        tool_message = SimpleNamespace(
+            content=[
+                {
+                    "type": "image",
+                    "mime_type": "image/png",
+                    "base64": "not-really-base64-but-huge-in-real-life",
+                }
+            ]
+        )
+        event = {
+            "event": "on_tool_end",
+            "name": "band_read_room_file",
+            "run_id": "run-123",
+            "data": {"output": tool_message},
+        }
+
+        await adapter._handle_stream_event(event, "room-123", mock_tools)
+
+        call_kwargs = mock_tools.send_event.call_args.kwargs
+        assert "not-really-base64-but-huge-in-real-life" not in call_kwargs["content"]
+        payload = json.loads(call_kwargs["content"])
+        assert payload["output"] == "<1 image content block(s)>"
+
+    @pytest.mark.asyncio
+    async def test_send_room_file_args_content_reported_as_placeholder(
+        self, mock_tools, mock_llm, mock_checkpointer
+    ):
+        """band_send_room_file's raw file content must not leak into a
+        tool_call event's reported ARGS."""
+        adapter = LangGraphAdapter(
+            llm=mock_llm,
+            checkpointer=mock_checkpointer,
+            emit=Emit.TOOL_CALLS,
+        )
+
+        event = {
+            "event": "on_tool_start",
+            "name": "band_send_room_file",
+            "run_id": "run-123",
+            "data": {
+                "input": {"content": "the entire raw file body", "filename": "f.txt"}
+            },
+        }
+
+        await adapter._handle_stream_event(event, "room-123", mock_tools)
+
+        call_kwargs = mock_tools.send_event.call_args.kwargs
+        assert "the entire raw file body" not in call_kwargs["content"]
+        assert "byte file content" in call_kwargs["content"]
+
+    @pytest.mark.asyncio
     async def test_ignores_other_events(self, mock_tools, mock_llm, mock_checkpointer):
         """Should ignore events other than tool_start/end."""
         adapter = LangGraphAdapter(

--- a/tests/adapters/test_anthropic_adapter.py
+++ b/tests/adapters/test_anthropic_adapter.py
@@ -278,6 +278,74 @@ class TestToolExecution:
         assert mock_tools.send_event.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_read_room_file_image_result_passes_through_as_vision_content(
+        self, mock_tools
+    ):
+        """An image band_read_room_file result must reach the model as a
+        real Anthropic image content block, not get json.dumps'd into text
+        (which would send the model a giant base64 string it can't see)."""
+        from anthropic.types import ToolUseBlock
+
+        adapter = AnthropicAdapter(emit=())
+
+        mock_response = MagicMock()
+        mock_response.content = [
+            ToolUseBlock(
+                type="tool_use",
+                id="tool-1",
+                name="band_read_room_file",
+                input={"file_id": "f1"},
+            )
+        ]
+        mock_tools.execute_tool_call.return_value = {
+            "content": [{"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}]
+        }
+
+        results = await adapter._process_tool_calls(mock_response, mock_tools)
+
+        assert len(results) == 1
+        assert results[0]["is_error"] is False
+        assert results[0]["content"] == [
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "ZmFrZQ==",
+                },
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_read_room_file_non_image_result_stays_text(self, mock_tools):
+        """A description-only (non-image) read_room_file result keeps the
+        ordinary json.dumps'd text content -- the image branch only fires
+        for the real MCP-content shape."""
+        from anthropic.types import ToolUseBlock
+
+        adapter = AnthropicAdapter(emit=())
+
+        mock_response = MagicMock()
+        mock_response.content = [
+            ToolUseBlock(
+                type="tool_use",
+                id="tool-1",
+                name="band_read_room_file",
+                input={"file_id": "f1"},
+            )
+        ]
+        mock_tools.execute_tool_call.return_value = {
+            "name": "notes.txt",
+            "description": "File not shown inline: too large.",
+        }
+
+        results = await adapter._process_tool_calls(mock_response, mock_tools)
+
+        assert len(results) == 1
+        assert isinstance(results[0]["content"], str)
+        assert "notes.txt" in results[0]["content"]
+
+    @pytest.mark.asyncio
     async def test_send_event_403_does_not_crash_tool_execution(self, mock_tools):
         """send_event 403 should not prevent tool from executing."""
         from anthropic.types import ToolUseBlock

--- a/tests/adapters/test_anthropic_adapter.py
+++ b/tests/adapters/test_anthropic_adapter.py
@@ -317,6 +317,78 @@ class TestToolExecution:
         ]
 
     @pytest.mark.asyncio
+    async def test_read_room_file_image_result_reports_placeholder_not_raw_base64(
+        self, mock_tools
+    ):
+        """The tool_result event for an image band_read_room_file call must
+        report a bounded placeholder, not the raw base64 payload -- the LLM-
+        facing content block (asserted above) is a separate path from what
+        gets reported to the platform-visible event."""
+        import json
+
+        from anthropic.types import ToolUseBlock
+
+        from band.core.types import ToolEventKey
+
+        adapter = AnthropicAdapter(emit=Emit.TOOL_CALLS)
+
+        mock_response = MagicMock()
+        mock_response.content = [
+            ToolUseBlock(
+                type="tool_use",
+                id="tool-1",
+                name="band_read_room_file",
+                input={"file_id": "f1"},
+            )
+        ]
+        mock_tools.execute_tool_call.return_value = {
+            "content": [{"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}]
+        }
+
+        await adapter._process_tool_calls(mock_response, mock_tools)
+
+        result_event = mock_tools.send_event.call_args_list[-1]
+        reported = json.loads(result_event.kwargs["content"])
+        assert reported[ToolEventKey.OUTPUT] == "<1 image content block(s)>"
+        assert "ZmFrZQ==" not in result_event.kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_send_room_file_reports_content_placeholder_not_raw_bytes(
+        self, mock_tools
+    ):
+        """The tool_call event for band_send_room_file must report a bounded
+        placeholder for `content`, not the raw file text -- real file bytes
+        (up to ~1MB) have no business in a platform-visible log event."""
+        import json
+
+        from anthropic.types import ToolUseBlock
+
+        from band.core.types import ToolEventKey
+
+        adapter = AnthropicAdapter(emit=Emit.TOOL_CALLS)
+
+        raw_content = "the quick brown fox" * 100
+        mock_response = MagicMock()
+        mock_response.content = [
+            ToolUseBlock(
+                type="tool_use",
+                id="tool-1",
+                name="band_send_room_file",
+                input={"content": raw_content, "filename": "notes.txt"},
+            )
+        ]
+        mock_tools.execute_tool_call.return_value = {"status": "success"}
+
+        await adapter._process_tool_calls(mock_response, mock_tools)
+
+        call_event = mock_tools.send_event.call_args_list[0]
+        reported = json.loads(call_event.kwargs["content"])
+        assert reported[ToolEventKey.ARGS]["content"] == (
+            f"<{len(raw_content.encode('utf-8'))} byte file content>"
+        )
+        assert raw_content not in call_event.kwargs["content"]
+
+    @pytest.mark.asyncio
     async def test_read_room_file_non_image_result_stays_text(self, mock_tools):
         """A description-only (non-image) read_room_file result keeps the
         ordinary json.dumps'd text content -- the image branch only fires

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -19,6 +19,7 @@ from band.core.types import AgentInput, Emit, HistoryProvider, PlatformMessage
 from band.integrations.codex import CodexJsonRpcError, RpcEvent
 from band.integrations.codex.types import CodexSessionState
 from band.runtime.custom_tools import CustomToolDef
+from band.runtime.tools import ToolCallOutcome
 from band.testing import FakeAgentTools
 
 
@@ -7332,3 +7333,108 @@ class TestConfigEnvSourcing:
         config = CodexAdapterConfig(codex_command=("explicit", "--kwarg"))
 
         assert config.codex_command == ("explicit", "--kwarg")
+
+
+class TestReadRoomFileImagePassthrough:
+    @pytest.mark.asyncio
+    async def test_image_result_becomes_input_image_content_item(self) -> None:
+        class _ImageTools(ToolSchemaFakeTools):
+            async def execute_tool_call_structured(
+                self, tool_name: str, arguments: dict[str, Any]
+            ) -> ToolCallOutcome:
+                return ToolCallOutcome(
+                    value={
+                        "content": [
+                            {
+                                "type": "image",
+                                "data": "ZmFrZQ==",
+                                "mimeType": "image/png",
+                            }
+                        ]
+                    },
+                    ok=True,
+                )
+
+        events = [
+            _event_request(
+                42,
+                "item/tool/call",
+                {"tool": "band_read_room_file", "arguments": {"file_id": "f1"}},
+            ),
+            _event_notification(
+                "turn/completed",
+                {
+                    "turn": {
+                        "id": "turn-1",
+                        "status": "completed",
+                        "items": [],
+                        "error": None,
+                    }
+                },
+            ),
+        ]
+        fake_client = FakeCodexClient(events=events)
+        adapter = CodexAdapter(
+            config=CodexAdapterConfig(transport="ws"),
+            client_factory=lambda _config: fake_client,
+        )
+        tools = _ImageTools()
+
+        await adapter.on_started("Codex Agent", "A coding agent")
+        await adapter.on_message(
+            make_platform_message(),
+            tools,
+            CodexSessionState(),
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-1",
+        )
+
+        response_id, response_payload = fake_client.responses[0]
+        assert response_id == 42
+        assert response_payload["success"] is True
+        assert response_payload["contentItems"] == [
+            {"type": "inputImage", "imageUrl": "data:image/png;base64,ZmFrZQ=="}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_non_image_result_stays_input_text(self) -> None:
+        events = [
+            _event_request(
+                42,
+                "item/tool/call",
+                {"tool": "band_read_room_file", "arguments": {"file_id": "f1"}},
+            ),
+            _event_notification(
+                "turn/completed",
+                {
+                    "turn": {
+                        "id": "turn-1",
+                        "status": "completed",
+                        "items": [],
+                        "error": None,
+                    }
+                },
+            ),
+        ]
+        fake_client = FakeCodexClient(events=events)
+        adapter = CodexAdapter(
+            config=CodexAdapterConfig(transport="ws"),
+            client_factory=lambda _config: fake_client,
+        )
+        tools = ToolSchemaFakeTools()
+
+        await adapter.on_started("Codex Agent", "A coding agent")
+        await adapter.on_message(
+            make_platform_message(),
+            tools,
+            CodexSessionState(),
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-1",
+        )
+
+        response_id, response_payload = fake_client.responses[0]
+        assert response_payload["contentItems"][0]["type"] == "inputText"

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -1729,6 +1729,43 @@ class TestCodexAdapter:
         assert result_data["tool_call_id"] == "call-50"
 
     @pytest.mark.asyncio
+    async def test_send_room_file_tool_call_event_redacts_content(self) -> None:
+        """band_send_room_file's raw content must never reach a tool_call
+        event -- report has no idea content can carry real file bytes."""
+        raw_content = "raw file bytes that must never reach a tool_call event"
+        events = [
+            _tool_call_request(
+                50, "band_send_room_file", {"content": raw_content, "filename": "f.txt"}
+            ),
+            _turn_completed(),
+        ]
+        fake_client = FakeCodexClient(events=events)
+        adapter = CodexAdapter(
+            config=CodexAdapterConfig(transport="ws"),
+            client_factory=lambda _config: fake_client,
+            emit=Emit.TOOL_CALLS,
+        )
+        tools = ToolSchemaFakeTools()
+
+        await adapter.on_started("Codex Agent", "A coding agent")
+        await adapter.on_message(
+            make_platform_message(),
+            tools,
+            CodexSessionState(),
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-1",
+        )
+
+        call_data = json.loads(events_of_type(tools, "tool_call")[0]["content"])
+        assert (
+            call_data["args"]["content"]
+            == f"<{len(raw_content.encode('utf-8'))} byte file content>"
+        )
+        assert raw_content not in json.dumps(call_data)
+
+    @pytest.mark.asyncio
     async def test_execution_reporting_silenced_with_explicit_empty_emit(self) -> None:
         """emit=() silences tool_call/tool_result events (emit otherwise defaults on)."""
         events = [
@@ -1883,6 +1920,59 @@ class TestCodexAdapter:
 
 class TestItemCompletedForwarding:
     """Tests for forwarding internal Codex operations as platform events."""
+
+    @pytest.mark.asyncio
+    async def test_item_completed_mcpToolCall_send_room_file_redacts_content(
+        self,
+    ) -> None:
+        """band_send_room_file routed through Codex's own mcpToolCall item
+        (a separate reporting path from item/tool/call, keyed by the bare
+        "tool" field before it's wrapped in the "mcp:{server}/{tool}"
+        display name) must also redact raw file content before it reaches a
+        tool_call event."""
+        raw_content = "raw file bytes that must never reach a tool_call event"
+        events = [
+            _event_notification(
+                "item/completed",
+                {
+                    "item": {
+                        "type": "mcpToolCall",
+                        "id": "mcp-1",
+                        "server": "band",
+                        "tool": "band_send_room_file",
+                        "arguments": {"content": raw_content, "filename": "f.txt"},
+                        "result": {"status": "success"},
+                    }
+                },
+            ),
+            _turn_completed(),
+        ]
+        fake_client = FakeCodexClient(events=events)
+        adapter = CodexAdapter(
+            config=CodexAdapterConfig(transport="ws"),
+            client_factory=lambda _config: fake_client,
+            emit=Emit.TOOL_CALLS,
+        )
+        tools = ToolSchemaFakeTools()
+
+        await adapter.on_started("Codex Agent", "A coding agent")
+        await adapter.on_message(
+            make_platform_message(),
+            tools,
+            CodexSessionState(),
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-1",
+        )
+
+        call_data = json.loads(events_of_type(tools, "tool_call")[0]["content"])
+        assert call_data["name"] == "mcp:band/band_send_room_file"
+        assert (
+            call_data["args"]["content"]
+            == f"<{len(raw_content.encode('utf-8'))} byte file content>"
+        )
+        assert raw_content not in json.dumps(call_data)
 
     @pytest.mark.asyncio
     async def test_item_completed_commandExecution_emits_tool_events(self) -> None:

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -211,11 +211,7 @@ def _event_request(request_id: int, method: str, params: dict[str, Any]) -> RpcE
 
 
 def _turn_completed(turn_id: str = "turn-1") -> RpcEvent:
-    """The notification that ends a scripted turn.
-
-    Single source of the completed-turn envelope, which nearly every scripted
-    event list closes with -- a shape change lands here, not in ~80 literals.
-    """
+    """The notification that ends a scripted turn."""
     return _event_notification(
         "turn/completed",
         {"turn": {"id": turn_id, "status": "completed", "items": [], "error": None}},

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 from collections import OrderedDict, deque
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
@@ -209,6 +210,80 @@ def _event_request(request_id: int, method: str, params: dict[str, Any]) -> RpcE
     )
 
 
+def _turn_completed(turn_id: str = "turn-1") -> RpcEvent:
+    """The notification that ends a scripted turn.
+
+    Single source of the completed-turn envelope, which nearly every scripted
+    event list closes with -- a shape change lands here, not in ~80 literals.
+    """
+    return _event_notification(
+        "turn/completed",
+        {"turn": {"id": turn_id, "status": "completed", "items": [], "error": None}},
+    )
+
+
+def _tool_call_request(
+    request_id: int, tool: str, arguments: dict[str, Any] | None = None
+) -> RpcEvent:
+    """The server request Codex sends to invoke one Band tool."""
+    return _event_request(
+        request_id, "item/tool/call", {"tool": tool, "arguments": arguments or {}}
+    )
+
+
+@dataclass(frozen=True)
+class CodexTurn:
+    """What one driven turn left behind, as the projections tests assert on."""
+
+    adapter: CodexAdapter
+    client: FakeCodexClient
+    tools: FakeAgentTools
+
+    @property
+    def tool_response(self) -> tuple[int | str, dict[str, Any]]:
+        """``(request_id, payload)`` of the first tool-call response sent back."""
+        return self.client.responses[0]
+
+    @property
+    def content_items(self) -> list[dict[str, Any]]:
+        """Content items the adapter returned for the first tool call."""
+        return self.tool_response[1]["contentItems"]
+
+
+async def run_codex_turn(
+    *,
+    events: list[RpcEvent],
+    tools: FakeAgentTools | None = None,
+    config: CodexAdapterConfig | None = None,
+    **adapter_kwargs: Any,
+) -> CodexTurn:
+    """Drive one full Codex turn against ``events`` and return what it produced.
+
+    Wraps the scaffolding a turn test otherwise repeats -- fake transport,
+    adapter wired to it, ``on_started``, one bootstrap ``on_message`` -- so a
+    test states only the events it scripts and the outcome it asserts.
+    """
+    client = FakeCodexClient(events=events)
+    adapter = CodexAdapter(
+        config=config or CodexAdapterConfig(transport="ws"),
+        client_factory=lambda _config: client,
+        **adapter_kwargs,
+    )
+    room_tools = tools if tools is not None else ToolSchemaFakeTools()
+
+    await adapter.on_started("Codex Agent", "A coding agent")
+    await adapter.on_message(
+        make_platform_message(),
+        room_tools,
+        CodexSessionState(),
+        participants_msg=None,
+        contacts_msg=None,
+        is_session_bootstrap=True,
+        room_id="room-1",
+    )
+    return CodexTurn(adapter=adapter, client=client, tools=room_tools)
+
+
 async def _wait_for_pending_approval(
     adapter: CodexAdapter,
     room_id: str,
@@ -245,17 +320,7 @@ class TestCodexAdapter:
                 "item/agentMessage/delta",
                 {"itemId": "msg-1", "delta": "harness-ok"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -294,17 +359,7 @@ class TestCodexAdapter:
     async def test_system_prompt_retry_after_turn_start_failure(self) -> None:
         """System instructions stay pending until turn/start succeeds."""
         events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(
             events=events,
@@ -360,25 +415,8 @@ class TestCodexAdapter:
     @pytest.mark.asyncio
     async def test_tool_call_request_is_dispatched_and_responded(self) -> None:
         events = [
-            _event_request(
-                42,
-                "item/tool/call",
-                {
-                    "tool": "band_lookup_peers",
-                    "arguments": {"page": 1, "page_size": 10},
-                },
-            ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _tool_call_request(42, "band_lookup_peers", {"page": 1, "page_size": 10}),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -449,17 +487,7 @@ class TestCodexAdapter:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -487,19 +515,7 @@ class TestCodexAdapter:
 
     @pytest.mark.asyncio
     async def test_resume_failure_falls_back_to_thread_start(self) -> None:
-        events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            )
-        ]
+        events = [_turn_completed()]
         fake_client = FakeCodexClient(
             events=events,
             resume_error=CodexJsonRpcError(code=-32002, message="Not found"),
@@ -533,17 +549,7 @@ class TestCodexAdapter:
                 "item/commandExecution/requestApproval",
                 {"command": "rm -rf tmp"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -588,17 +594,7 @@ class TestCodexAdapter:
                 "item/commandExecution/requestApproval",
                 {"command": "rm -rf tmp"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -643,17 +639,7 @@ class TestCodexAdapter:
                 "item/commandExecution/requestApproval",
                 {"command": "rm -rf tmp"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -684,21 +670,7 @@ class TestCodexAdapter:
 
     @pytest.mark.asyncio
     async def test_cleanup_closes_client_when_last_room_removed(self) -> None:
-        fake_client = FakeCodexClient(
-            events=[
-                _event_notification(
-                    "turn/completed",
-                    {
-                        "turn": {
-                            "id": "turn-1",
-                            "status": "completed",
-                            "items": [],
-                            "error": None,
-                        }
-                    },
-                )
-            ]
-        )
+        fake_client = FakeCodexClient(events=[_turn_completed()])
         adapter = CodexAdapter(
             config=CodexAdapterConfig(transport="ws"),
             client_factory=lambda _config: fake_client,
@@ -723,21 +695,7 @@ class TestCodexAdapter:
     @pytest.mark.asyncio
     async def test_cleanup_idempotent(self) -> None:
         """Calling on_cleanup twice for the same room should not raise."""
-        fake_client = FakeCodexClient(
-            events=[
-                _event_notification(
-                    "turn/completed",
-                    {
-                        "turn": {
-                            "id": "turn-1",
-                            "status": "completed",
-                            "items": [],
-                            "error": None,
-                        }
-                    },
-                )
-            ]
-        )
+        fake_client = FakeCodexClient(events=[_turn_completed()])
         adapter = CodexAdapter(
             config=CodexAdapterConfig(transport="ws"),
             client_factory=lambda _config: fake_client,
@@ -763,32 +721,8 @@ class TestCodexAdapter:
     @pytest.mark.asyncio
     async def test_cleanup_multi_room_keeps_client_until_last(self) -> None:
         """Client stays open until the last room is cleaned up."""
-        events_room1 = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            )
-        ]
-        events_room2 = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-2",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            )
-        ]
+        events_room1 = [_turn_completed()]
+        events_room2 = [_turn_completed("turn-2")]
         fake_client = FakeCodexClient(events=events_room1 + events_room2)
         adapter = CodexAdapter(
             config=CodexAdapterConfig(transport="ws"),
@@ -835,17 +769,7 @@ class TestCodexAdapter:
                 "codex/event/task_complete",
                 {"taskId": "task-1", "summary": "Inspection finished"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -892,17 +816,7 @@ class TestCodexAdapter:
                 "codex/event/task_started",
                 {"taskId": "task-1", "task": {"title": "Inspect repository"}},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -945,17 +859,7 @@ class TestCodexAdapter:
                 "codex/event/task_started",
                 {"id": "turn-1"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -1287,17 +1191,7 @@ class TestCodexAdapter:
                     "arguments": {"model": "o3"},
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    },
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -1339,17 +1233,7 @@ class TestCodexAdapter:
                     "arguments": {"effort": "xhigh", "summary": "detailed"},
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    },
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -1382,17 +1266,7 @@ class TestCodexAdapter:
                     "arguments": {"effort": "ultra"},
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    },
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -1424,19 +1298,7 @@ class TestCodexAdapter:
 
     @pytest.mark.asyncio
     async def test_sandbox_alias_is_normalized_for_thread_and_turn(self) -> None:
-        events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            )
-        ]
+        events = [_turn_completed()]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
             config=CodexAdapterConfig(
@@ -1473,19 +1335,7 @@ class TestCodexAdapter:
 
     @pytest.mark.asyncio
     async def test_external_sandbox_alias_uses_sandbox_policy(self) -> None:
-        events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            )
-        ]
+        events = [_turn_completed()]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
             config=CodexAdapterConfig(
@@ -1724,17 +1574,7 @@ class TestCodexAdapter:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -1814,17 +1654,7 @@ class TestCodexAdapter:
                     "callId": "call-99",
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -1868,17 +1698,7 @@ class TestCodexAdapter:
                     "callId": "call-50",
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -1925,17 +1745,7 @@ class TestCodexAdapter:
                     "callId": "call-50",
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -1986,17 +1796,7 @@ class TestCodexAdapter:
                     "callId": "call-60",
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2048,17 +1848,7 @@ class TestCodexAdapter:
                     "callId": "call-70",
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2116,17 +1906,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2182,17 +1962,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2240,17 +2010,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2292,17 +2052,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2349,17 +2099,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2410,17 +2150,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2462,17 +2192,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2532,17 +2252,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2585,17 +2295,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2655,17 +2355,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2707,17 +2397,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2760,17 +2440,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2830,17 +2500,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2876,17 +2536,7 @@ class TestItemCompletedForwarding:
                 "item/completed",
                 {"item": {"type": "plan", "id": "plan-blank", "text": "   "}},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2935,17 +2585,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -2999,17 +2639,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -3051,17 +2681,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -3105,17 +2725,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -3155,17 +2765,7 @@ class TestItemCompletedForwarding:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -3198,19 +2798,7 @@ class TestHistoryInjection:
     @pytest.mark.asyncio
     async def test_history_injected_on_resume_failure(self) -> None:
         """Resume fails, fresh thread created, first turn input contains history block."""
-        events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            )
-        ]
+        events = [_turn_completed()]
         fake_client = FakeCodexClient(
             events=events,
             resume_error=CodexJsonRpcError(code=-32002, message="Thread expired"),
@@ -3273,19 +2861,7 @@ class TestHistoryInjection:
     @pytest.mark.asyncio
     async def test_history_not_injected_on_successful_resume(self) -> None:
         """Resume succeeds, no history injection."""
-        events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            )
-        ]
+        events = [_turn_completed()]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
             config=CodexAdapterConfig(transport="ws"),
@@ -3331,19 +2907,7 @@ class TestHistoryInjection:
     @pytest.mark.asyncio
     async def test_history_not_injected_when_disabled(self) -> None:
         """inject_history_on_resume_failure=False, no injection even on failure."""
-        events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            )
-        ]
+        events = [_turn_completed()]
         fake_client = FakeCodexClient(
             events=events,
             resume_error=CodexJsonRpcError(code=-32002, message="Thread expired"),
@@ -3387,19 +2951,7 @@ class TestHistoryInjection:
     @pytest.mark.asyncio
     async def test_history_filters_non_text_messages(self) -> None:
         """Only canonical text messages appear in injected context."""
-        events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            )
-        ]
+        events = [_turn_completed()]
         fake_client = FakeCodexClient(
             events=events,
             resume_error=CodexJsonRpcError(code=-32002, message="Not found"),
@@ -3479,19 +3031,7 @@ class TestHistoryInjection:
     @pytest.mark.asyncio
     async def test_history_respects_max_messages(self) -> None:
         """Only last max_history_messages are injected."""
-        events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            )
-        ]
+        events = [_turn_completed()]
         fake_client = FakeCodexClient(
             events=events,
             resume_error=CodexJsonRpcError(code=-32002, message="Not found"),
@@ -3550,19 +3090,7 @@ class TestHistoryInjection:
     @pytest.mark.asyncio
     async def test_history_cleared_after_injection(self) -> None:
         """Raw history removed from memory after first turn."""
-        events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            )
-        ]
+        events = [_turn_completed()]
         fake_client = FakeCodexClient(
             events=events,
             resume_error=CodexJsonRpcError(code=-32002, message="Not found"),
@@ -3896,25 +3424,8 @@ class TestHistoryInjection:
                 )
 
         events = [
-            _event_request(
-                99,
-                "item/tool/call",
-                {
-                    "tool": "band_send_message",
-                    "arguments": {},
-                },
-            ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _tool_call_request(99, "band_send_message"),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -3969,17 +3480,7 @@ class TestStructuredErrors:
                     "willRetry": False,
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4068,17 +3569,7 @@ class TestStructuredErrors:
                     "willRetry": False,
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4120,17 +3611,7 @@ class TestEnrichedApprovals:
                 "item/commandExecution/requestApproval",
                 {"command": "npm test"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=first_events)
         adapter = CodexAdapter(
@@ -4184,17 +3665,7 @@ class TestEnrichedApprovals:
                 "item/commandExecution/requestApproval",
                 {"command": "rm -rf tmp"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4390,17 +3861,7 @@ class TestPlanAndLifecycle:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4446,17 +3907,7 @@ class TestPlanAndLifecycle:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4487,17 +3938,7 @@ class TestPlanAndLifecycle:
     async def test_turn_lifecycle_events_emitted(self) -> None:
         """Enriched turn lifecycle events include duration and status."""
         events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4537,17 +3978,7 @@ class TestPlanAndLifecycle:
     async def test_threads_command_lists_mappings(self) -> None:
         """/threads command shows room→thread mappings."""
         events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4591,17 +4022,7 @@ class TestPlanAndLifecycle:
     async def test_thread_archive_clears_mapping(self) -> None:
         """/thread archive removes the thread mapping."""
         events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4649,17 +4070,7 @@ class TestRealtimeStreaming:
                 "item/reasoning/summaryTextDelta",
                 {"delta": "Analyzing the code...", "itemId": "item-1"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4696,17 +4107,7 @@ class TestRealtimeStreaming:
                 "item/reasoning/summaryTextDelta",
                 {"delta": "Thinking...", "itemId": "item-1"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4739,17 +4140,7 @@ class TestRealtimeStreaming:
                 "item/plan/delta",
                 {"delta": "Step 1: Read the test", "itemId": "plan-1"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4797,17 +4188,7 @@ class TestRealtimeStreaming:
                     "phase": "final_answer",
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4858,17 +4239,7 @@ class TestRealtimeStreaming:
                     "phase": "final_answer",
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4914,17 +4285,7 @@ class TestRealtimeStreaming:
                     "phase": "final_answer",
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -4966,17 +4327,7 @@ class TestDiffsAndTokenUsage:
                     "files": ["src/app.py"],
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -5018,17 +4369,7 @@ class TestDiffsAndTokenUsage:
                 "turn/diff/updated",
                 {"diff": "some diff", "files": ["f.py"]},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -5074,17 +4415,7 @@ class TestDiffsAndTokenUsage:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -5128,17 +4459,7 @@ class TestDiffsAndTokenUsage:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -5187,17 +4508,7 @@ class TestDiffsAndTokenUsage:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -5434,17 +4745,7 @@ class TestSessionAutoApproval:
                 "item/commandExecution/requestApproval",
                 {"command": "npm install"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -5488,17 +4789,7 @@ class TestSessionAutoApproval:
                 "item/commandExecution/requestApproval",
                 {"command": "npm publish"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -5539,17 +4830,7 @@ class TestSessionAutoApproval:
                 "item/commandExecution/requestApproval",
                 {"command": "npm install"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -5601,17 +4882,7 @@ class TestCleanup:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -5734,17 +5005,7 @@ class TestReviewFixes:
     async def test_thread_archive_clears_raw_history(self) -> None:
         """/thread archive also clears raw history and injection state."""
         events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -5856,17 +5117,7 @@ class TestAcceptForSession:
                 "item/commandExecution/requestApproval",
                 {"command": "npm test"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -5918,17 +5169,7 @@ class TestAcceptForSession:
                 "item/commandExecution/requestApproval",
                 {"command": "npm install"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -5973,17 +5214,7 @@ class TestNetworkContext:
                     "networkContext": {"domains": ["registry.npmjs.org"]},
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -6035,17 +5266,7 @@ class TestTurnStartedLifecycle:
     async def test_turn_started_lifecycle_event_emitted(self) -> None:
         """Turn started lifecycle event includes input summary."""
         events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -6088,17 +5309,7 @@ class TestContextCompaction:
                 "context/compacted",
                 {"threadId": "thr-1", "turnId": "turn-1"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -6136,17 +5347,7 @@ class TestContextCompaction:
                 "context/compacted",
                 {"threadId": "thr-1", "turnId": "turn-1"},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -6340,17 +5541,7 @@ class TestSessionApprovalValidation:
                 "item/fileChange/requestApproval",
                 {},  # No command field -> session_approval_key returns ""
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -6712,17 +5903,7 @@ class TestSlashCommandCoverage:
                     }
                 },
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -6804,17 +5985,7 @@ class TestMalformedPayloadTolerance:
         """`error` notification where `error` is a string must not crash the turn."""
         events = [
             _event_notification("error", {"error": "oops"}),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -6869,17 +6040,7 @@ class TestMalformedPayloadTolerance:
                 "turn/plan/updated",
                 {"plan": {"steps": "not-a-list"}},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -6953,17 +6114,7 @@ class TestTurnLifecycleEventsDisabled:
         """With emit_turn_lifecycle_events=False, neither started nor completed
         lifecycle task events are emitted."""
         events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -7142,17 +6293,7 @@ class TestDiffByteCap:
                 "turn/diff/updated",
                 {"diff": big_diff, "files": ["src/app.py"]},
             ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -7355,86 +6496,28 @@ class TestReadRoomFileImagePassthrough:
                     ok=True,
                 )
 
-        events = [
-            _event_request(
-                42,
-                "item/tool/call",
-                {"tool": "band_read_room_file", "arguments": {"file_id": "f1"}},
-            ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
-        ]
-        fake_client = FakeCodexClient(events=events)
-        adapter = CodexAdapter(
-            config=CodexAdapterConfig(transport="ws"),
-            client_factory=lambda _config: fake_client,
-        )
-        tools = _ImageTools()
-
-        await adapter.on_started("Codex Agent", "A coding agent")
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            CodexSessionState(),
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-1",
+        turn = await run_codex_turn(
+            events=[
+                _tool_call_request(42, "band_read_room_file", {"file_id": "f1"}),
+                _turn_completed(),
+            ],
+            tools=_ImageTools(),
         )
 
-        response_id, response_payload = fake_client.responses[0]
+        response_id, response_payload = turn.tool_response
         assert response_id == 42
         assert response_payload["success"] is True
-        assert response_payload["contentItems"] == [
+        assert turn.content_items == [
             {"type": "inputImage", "imageUrl": "data:image/png;base64,ZmFrZQ=="}
         ]
 
     @pytest.mark.asyncio
     async def test_non_image_result_stays_input_text(self) -> None:
-        events = [
-            _event_request(
-                42,
-                "item/tool/call",
-                {"tool": "band_read_room_file", "arguments": {"file_id": "f1"}},
-            ),
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "turn-1",
-                        "status": "completed",
-                        "items": [],
-                        "error": None,
-                    }
-                },
-            ),
-        ]
-        fake_client = FakeCodexClient(events=events)
-        adapter = CodexAdapter(
-            config=CodexAdapterConfig(transport="ws"),
-            client_factory=lambda _config: fake_client,
-        )
-        tools = ToolSchemaFakeTools()
-
-        await adapter.on_started("Codex Agent", "A coding agent")
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            CodexSessionState(),
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-1",
+        turn = await run_codex_turn(
+            events=[
+                _tool_call_request(42, "band_read_room_file", {"file_id": "f1"}),
+                _turn_completed(),
+            ]
         )
 
-        response_id, response_payload = fake_client.responses[0]
-        assert response_payload["contentItems"][0]["type"] == "inputText"
+        assert turn.content_items[0]["type"] == "inputText"

--- a/tests/adapters/test_gemini_adapter.py
+++ b/tests/adapters/test_gemini_adapter.py
@@ -299,6 +299,56 @@ class TestCustomTools:
         mock_tools.execute_tool_call.assert_not_called()
 
 
+class TestReadRoomFileImagePassthrough:
+    @pytest.mark.asyncio
+    async def test_image_result_passes_through_as_inline_data(self, mock_tools):
+        mock_tools.execute_tool_call = AsyncMock(
+            return_value={
+                "content": [
+                    {"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}
+                ]
+            }
+        )
+        adapter = GeminiAdapter(provider_key="test-key")
+        function_calls = [
+            types.FunctionCall(
+                name="band_read_room_file", args={"file_id": "f1"}, id="c1"
+            )
+        ]
+
+        parts = await adapter._process_function_calls(function_calls, mock_tools)
+
+        function_response = parts[0].function_response
+        assert function_response is not None
+        assert function_response.parts is not None
+        assert len(function_response.parts) == 1
+        inline_data = function_response.parts[0].inline_data
+        assert inline_data is not None
+        assert inline_data.mime_type == "image/png"
+        assert inline_data.data == b"fake"
+
+    @pytest.mark.asyncio
+    async def test_non_image_result_stays_text(self, mock_tools):
+        mock_tools.execute_tool_call = AsyncMock(
+            return_value={"name": "notes.txt", "content_type": "text/plain"}
+        )
+        adapter = GeminiAdapter(provider_key="test-key")
+        function_calls = [
+            types.FunctionCall(
+                name="band_read_room_file", args={"file_id": "f1"}, id="c1"
+            )
+        ]
+
+        parts = await adapter._process_function_calls(function_calls, mock_tools)
+
+        function_response = parts[0].function_response
+        assert function_response is not None
+        assert function_response.parts is None
+        assert function_response.response == {
+            "output": '{"name": "notes.txt", "content_type": "text/plain"}'
+        }
+
+
 class TestOnCleanup:
     @pytest.mark.asyncio
     async def test_removes_room_history(self):

--- a/tests/adapters/test_gemini_adapter.py
+++ b/tests/adapters/test_gemini_adapter.py
@@ -349,6 +349,73 @@ class TestReadRoomFileImagePassthrough:
         }
 
 
+class TestToolEventRedaction:
+    @pytest.mark.asyncio
+    async def test_read_room_file_image_result_reports_placeholder_not_raw_base64(
+        self, mock_tools
+    ):
+        """The tool_result event for an image band_read_room_file call must
+        report a bounded placeholder, not the raw base64 payload -- the LLM-
+        facing inline_data content block (asserted in
+        TestReadRoomFileImagePassthrough above) is a separate path from what
+        gets reported to the platform-visible event."""
+        import json
+
+        from band.core.types import ToolEventKey
+
+        mock_tools.execute_tool_call = AsyncMock(
+            return_value={
+                "content": [
+                    {"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}
+                ]
+            }
+        )
+        adapter = GeminiAdapter(provider_key="test-key", emit=Emit.TOOL_CALLS)
+        function_calls = [
+            types.FunctionCall(
+                name="band_read_room_file", args={"file_id": "f1"}, id="c1"
+            )
+        ]
+
+        await adapter._process_function_calls(function_calls, mock_tools)
+
+        result_event = mock_tools.send_event.call_args_list[-1]
+        reported = json.loads(result_event.kwargs["content"])
+        assert reported[ToolEventKey.OUTPUT] == "<1 image content block(s)>"
+        assert "ZmFrZQ==" not in result_event.kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_send_room_file_reports_content_placeholder_not_raw_bytes(
+        self, mock_tools
+    ):
+        """The tool_call event for band_send_room_file must report a bounded
+        placeholder for `args`, not the raw file text -- real file bytes
+        (up to ~1MB) have no business in a platform-visible log event."""
+        import json
+
+        from band.core.types import ToolEventKey
+
+        mock_tools.execute_tool_call = AsyncMock(return_value={"status": "success"})
+        adapter = GeminiAdapter(provider_key="test-key", emit=Emit.TOOL_CALLS)
+        raw_content = "the quick brown fox" * 100
+        function_calls = [
+            types.FunctionCall(
+                name="band_send_room_file",
+                args={"content": raw_content, "filename": "notes.txt"},
+                id="c1",
+            )
+        ]
+
+        await adapter._process_function_calls(function_calls, mock_tools)
+
+        call_event = mock_tools.send_event.call_args_list[0]
+        reported = json.loads(call_event.kwargs["content"])
+        assert reported[ToolEventKey.ARGS]["content"] == (
+            f"<{len(raw_content.encode('utf-8'))} byte file content>"
+        )
+        assert raw_content not in call_event.kwargs["content"]
+
+
 class TestOnCleanup:
     @pytest.mark.asyncio
     async def test_removes_room_history(self):

--- a/tests/adapters/test_google_adk_adapter.py
+++ b/tests/adapters/test_google_adk_adapter.py
@@ -11,13 +11,14 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import json
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel, Field
 from band.core.types import ALL_CAPABILITIES, Emit, PlatformMessage
-from band.runtime.tools import AgentTools
+from band.runtime.tools import AgentTools, BandTool
 
 pytest.importorskip("google.adk", reason="google-adk not installed")
 
@@ -841,6 +842,61 @@ class TestExecutionReporting:
         call_args = mock_tools.send_event.call_args
         assert call_args.kwargs["message_type"] == "tool_result"
         assert "band_send_message" in call_args.kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_reports_read_room_file_image_result_as_placeholder(self, mock_tools):
+        """band_read_room_file's image result must not leak its base64 data
+        into a tool_result event. run_async json.dumps a non-str tool
+        result before returning it, so ADK's own __build_response_event
+        wraps that json string as {"result": <that string>} (its spec
+        requires a dict) -- str()ing that wrapper would otherwise embed the
+        full base64 payload."""
+        adapter = GoogleADKAdapter(emit=Emit.TOOL_CALLS)
+
+        image_result = {
+            "content": [
+                {
+                    "type": "image",
+                    "data": "not-really-base64-but-huge-in-real-life",
+                    "mimeType": "image/png",
+                }
+            ]
+        }
+        mock_fr = MagicMock()
+        mock_fr.name = BandTool.READ_ROOM_FILE
+        mock_fr.response = {"result": json.dumps(image_result)}
+        mock_fr.id = "fc-1"
+
+        event = MagicMock()
+        event.get_function_calls.return_value = []
+        event.get_function_responses.return_value = [mock_fr]
+
+        await adapter._report_event(event, mock_tools)
+
+        content = mock_tools.send_event.call_args.kwargs["content"]
+        assert "not-really-base64-but-huge-in-real-life" not in content
+        assert "<1 image content block(s)>" in content
+
+    @pytest.mark.asyncio
+    async def test_reports_send_room_file_args_content_as_placeholder(self, mock_tools):
+        """band_send_room_file's raw file content must not leak into a
+        tool_call event's reported ARGS."""
+        adapter = GoogleADKAdapter(emit=Emit.TOOL_CALLS)
+
+        mock_fc = MagicMock()
+        mock_fc.name = BandTool.SEND_ROOM_FILE
+        mock_fc.args = {"content": "the entire raw file body", "filename": "f.txt"}
+        mock_fc.id = "fc-1"
+
+        event = MagicMock()
+        event.get_function_calls.return_value = [mock_fc]
+        event.get_function_responses.return_value = []
+
+        await adapter._report_event(event, mock_tools)
+
+        content = mock_tools.send_event.call_args.kwargs["content"]
+        assert "the entire raw file body" not in content
+        assert "byte file content" in content
 
     @pytest.mark.asyncio
     async def test_skips_event_without_function_methods(self, mock_tools):

--- a/tests/adapters/test_letta_adapter.py
+++ b/tests/adapters/test_letta_adapter.py
@@ -7,6 +7,7 @@ in ``test_letta_mcp.py``; the shared mock factories in ``lettakit.py``.
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -658,6 +659,54 @@ class TestExecutionReporting:
             if e["message_type"] in ("tool_call", "tool_result")
         ]
         assert len(tool_events) == 0
+
+    @pytest.mark.asyncio
+    async def test_send_room_file_reports_content_placeholder_not_raw_bytes(
+        self,
+    ) -> None:
+        """ToolCall.arguments is a raw JSON string (letta_client's own wire
+        shape); the tool_call event must still redact band_send_room_file's
+        content field, not embed the real file bytes verbatim."""
+        config = LettaAdapterConfig()
+        adapter = LettaAdapter(config=config, emit=Emit.TOOL_CALLS)
+        mock_client = AsyncMock()
+        adapter._client = mock_client
+        adapter._system_prompt = "Test"
+        adapter._mcp.tool_ids = []
+        adapter._mcp.server_id = "mcp-server-1"
+        adapter._rooms["room-1"] = RoomContext(agent_id="agent-1")
+
+        mock_client.agents.messages.create.return_value = make_letta_response(
+            make_tool_call_message(
+                "band_send_room_file",
+                '{"content": "SECRET FILE BYTES", "filename": "f.txt"}',
+            ),
+            make_tool_return_message("band_send_room_file", '{"status": "ok"}'),
+            make_assistant_message("Done"),
+        )
+
+        tools = FakeAgentTools()
+        msg = make_platform_message()
+        history = LettaSessionState()
+
+        await adapter.on_message(
+            msg,
+            tools,
+            history,
+            None,
+            None,
+            is_session_bootstrap=False,
+            room_id="room-1",
+        )
+
+        tool_call_events = [
+            e for e in tools.events_sent if e["message_type"] == "tool_call"
+        ]
+        assert len(tool_call_events) == 1
+        reported_args = json.loads(tool_call_events[0]["content"])["args"]
+        assert "SECRET FILE BYTES" not in json.dumps(reported_args)
+        assert "byte file content" in reported_args["content"]
+        assert reported_args["filename"] == "f.txt"
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/adapters/test_letta_mcp.py
+++ b/tests/adapters/test_letta_mcp.py
@@ -42,6 +42,20 @@ def _stale_tool_error(message: str) -> Exception:
     return err
 
 
+def test_send_tool_names_use_band_tool_enum_member():
+    """SEND_MESSAGE_TOOL_NAMES/SEND_EVENT_TOOL_NAMES's canonical entry must be
+    a BandTool member, not a hardcoded literal duplicate that could silently
+    drift from BandTool if its value ever changed."""
+    from band.integrations.letta.prompts import (
+        SEND_EVENT_TOOL_NAMES,
+        SEND_MESSAGE_TOOL_NAMES,
+    )
+    from band.runtime.tools import BandTool
+
+    assert isinstance(SEND_MESSAGE_TOOL_NAMES[0], BandTool)
+    assert isinstance(SEND_EVENT_TOOL_NAMES[0], BandTool)
+
+
 # ──────────────────────────────────────────────────────────────────────
 # on_started
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/adapters/test_negotiated_file_tools.py
+++ b/tests/adapters/test_negotiated_file_tools.py
@@ -60,7 +60,9 @@ def test_feature_negotiation_rebuilds_cached_file_tool_registrations(
 
     adapter.apply_effective_features(AdapterFeatures())  # type: ignore[attr-defined]
 
-    assert not FILE_TOOL_NAMES & {definition.name for definition in definitions(adapter)}
+    assert not FILE_TOOL_NAMES & {
+        definition.name for definition in definitions(adapter)
+    }
 
 
 def test_tool_results_assert_succeeded_requires_a_successful_readback() -> None:

--- a/tests/adapters/test_negotiated_file_tools.py
+++ b/tests/adapters/test_negotiated_file_tools.py
@@ -1,0 +1,94 @@
+"""Regression coverage for adapters that cache their MCP tool registrations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import Mock
+
+import pytest
+
+from band.adapters.letta import LettaAdapter
+from band.adapters.opencode import OpencodeAdapter
+from band.core.types import AdapterFeatures, Capability
+from band.integrations.acp.client_adapter import ACPClientAdapter
+from band.runtime.tools import FILE_TOOL_NAMES, ToolDefinition
+from tests.e2e.baseline.toolkit.observations import ToolResult, ToolResults
+
+
+def _opencode_definitions(adapter: object) -> list[ToolDefinition]:
+    return adapter._tool_definitions  # type: ignore[attr-defined]
+
+
+def _acp_definitions(adapter: object) -> list[ToolDefinition]:
+    return adapter._tool_definitions  # type: ignore[attr-defined]
+
+
+def _letta_definitions(adapter: object) -> list[ToolDefinition]:
+    return adapter._mcp._tool_definitions  # type: ignore[attr-defined]
+
+
+CachedAdapter = tuple[Callable[[], object], Callable[[object], list[ToolDefinition]]]
+
+
+@pytest.mark.parametrize(
+    ("build", "definitions"),
+    [
+        pytest.param(
+            lambda: OpencodeAdapter(capabilities=Capability.FILES),
+            _opencode_definitions,
+            id="opencode",
+        ),
+        pytest.param(
+            lambda: ACPClientAdapter(command="test-acp", capabilities=Capability.FILES),
+            _acp_definitions,
+            id="acp",
+        ),
+        pytest.param(
+            lambda: LettaAdapter(capabilities=Capability.FILES),
+            _letta_definitions,
+            id="letta",
+        ),
+    ],
+)
+def test_feature_negotiation_rebuilds_cached_file_tool_registrations(
+    build: Callable[[], object],
+    definitions: Callable[[object], list[ToolDefinition]],
+) -> None:
+    """A disabled deployment must not retain tools cached before Agent.start()."""
+    adapter = build()
+    assert FILE_TOOL_NAMES <= {definition.name for definition in definitions(adapter)}
+
+    adapter.apply_effective_features(AdapterFeatures())  # type: ignore[attr-defined]
+
+    assert not FILE_TOOL_NAMES & {definition.name for definition in definitions(adapter)}
+
+
+def test_tool_results_assert_succeeded_requires_a_successful_readback() -> None:
+    """The file E2E must reject a narrated call whose platform operation failed."""
+    results = ToolResults(
+        [
+            ToolResult(
+                name="band_read_room_file",
+                output='{"text": "file-marker"}',
+                tool_call_id="read-1",
+                is_error=False,
+                raw=Mock(),
+            )
+        ]
+    )
+
+    results.assert_succeeded("band_read_room_file", output_contains="file-marker")
+
+    failed = ToolResults(
+        [
+            ToolResult(
+                name="band_read_room_file",
+                output="file not found",
+                tool_call_id="read-2",
+                is_error=True,
+                raw=Mock(),
+            )
+        ]
+    )
+    with pytest.raises(AssertionError, match="returned an error"):
+        failed.assert_succeeded("band_read_room_file")

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -85,6 +85,7 @@ def make_stream_events(
                 event.part = MagicMock()
                 event.part.tool_name = tool_name
                 event.part.args = args
+                event.part.args_as_dict = MagicMock(return_value=args)
                 event.part.tool_call_id = tool_call_id
                 yield event
 
@@ -1224,6 +1225,49 @@ class TestExecutionReporting:
             content='{"name": "band_send_message", "args": {"content": "Hello"}, "tool_call_id": "call-123"}',
             message_type="tool_call",
         )
+
+    @pytest.mark.asyncio
+    async def test_tool_call_event_redacts_send_room_file_content(
+        self, sample_message, mock_tools, mock_pydantic_agent
+    ):
+        """band_send_room_file's content arg can carry up to
+        MAX_SEND_CONTENT_BYTES of real file bytes; the tool_call event must
+        report a bounded placeholder instead of the raw content."""
+        adapter = PydanticAIAdapter(
+            model="openai:gpt-5.4",
+            emit=Emit.TOOL_CALLS,
+        )
+
+        with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
+            await adapter.on_started("TestBot", "Test bot")
+
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(
+                result_messages=[],
+                tool_calls=[
+                    (
+                        "band_send_room_file",
+                        {"content": "SECRET FILE BYTES", "filename": "f.txt"},
+                        "call-123",
+                    )
+                ],
+            )
+        )
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        reported_content = mock_tools.send_event.call_args_list[0].kwargs["content"]
+        assert "SECRET FILE BYTES" not in reported_content
+        assert "byte file content" in reported_content
+        assert '"filename": "f.txt"' in reported_content
 
     @pytest.mark.asyncio
     async def test_emits_tool_result_events_when_enabled(

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -32,6 +32,7 @@ from pydantic_ai import (
 )
 from pydantic_ai.capabilities import ProcessHistory
 from pydantic_ai.messages import (
+    BinaryContent,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -1259,6 +1260,46 @@ class TestExecutionReporting:
         # Verify send_event was called with tool_result
         mock_tools.send_event.assert_any_call(
             content='{"name": "band_send_message", "output": "Message sent successfully", "tool_call_id": "call-123"}',
+            message_type="tool_result",
+        )
+
+    @pytest.mark.asyncio
+    async def test_tool_result_event_redacts_binary_content(
+        self, sample_message, mock_tools, mock_pydantic_agent
+    ):
+        """band_read_room_file's image result is a list[BinaryContent]; str()
+        on that embeds the raw image bytes via BinaryContent.__repr__. The
+        tool_result event must report a bounded placeholder instead."""
+        adapter = PydanticAIAdapter(
+            model="openai:gpt-5.4",
+            emit=Emit.TOOL_CALLS,
+        )
+
+        with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
+            await adapter.on_started("TestBot", "Test bot")
+
+        image = BinaryContent(
+            data=b"\x89PNG\r\n\x1a\n" + b"\x00" * 64, media_type="image/png"
+        )
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(
+                result_messages=[],
+                tool_results=[("band_read_room_file", [image], "call-1")],
+            )
+        )
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        mock_tools.send_event.assert_any_call(
+            content='{"name": "band_read_room_file", "output": "<1 image content block(s)>", "tool_call_id": "call-1"}',
             message_type="tool_result",
         )
 

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -781,6 +781,29 @@ class TestFileTools:
         assert result == {"name": "report.txt", "text": "hello world"}
 
     @pytest.mark.asyncio
+    async def test_read_room_file_image_result_becomes_binary_content(self, file_tools):
+        from pydantic_ai.messages import BinaryContent
+
+        file_tools.read_room_file = AsyncMock(
+            return_value={
+                "content": [
+                    {"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}
+                ]
+            }
+        )
+        functions = await self._tool_functions()
+
+        result = await functions["band_read_room_file"](
+            SimpleNamespace(deps=file_tools), file_id="file-1"
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], BinaryContent)
+        assert result[0].data == b"fake"
+        assert result[0].media_type == "image/png"
+
+    @pytest.mark.asyncio
     async def test_read_room_file_handles_exception(self, file_tools):
         file_tools.read_room_file.side_effect = Exception("not found")
         functions = await self._tool_functions()

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -697,6 +697,138 @@ class TestAdvertisedToolSchemas:
         assert blurbs == {name: get_tool_description(name).strip() for name in blurbs}
 
 
+class TestFileTools:
+    """band_list_room_files/band_read_room_file/band_send_room_file, the
+    hand-written wrappers gated behind Capability.FILES.
+
+    Drives each tool function directly (grabbed off the real, started agent's
+    function toolset) rather than through a full mocked agent run, since the
+    behavior under test is each wrapper's own argument plumbing to
+    AgentToolsProtocol -- not pydantic-ai's tool-calling loop.
+    """
+
+    @pytest.fixture
+    def file_tools(self):
+        """Mock AgentToolsProtocol with the three room-file methods."""
+        tools = MagicMock()
+        tools.list_room_files = AsyncMock(
+            return_value={"data": [{"id": "file-1", "name": "report.txt"}]}
+        )
+        tools.read_room_file = AsyncMock(
+            return_value={"name": "report.txt", "text": "hello world"}
+        )
+        tools.send_room_file = AsyncMock(
+            return_value={"attachment": {"id": "file-2"}, "message_id": "msg-1"}
+        )
+        return tools
+
+    async def _tool_functions(self) -> dict[str, Any]:
+        adapter = PydanticAIAdapter(model="test", capabilities=Capability.FILES)
+        await adapter.on_started(agent_name="Probe", agent_description="probe")
+        return {
+            name: tool.function
+            for name, tool in adapter._agent._function_toolset.tools.items()
+        }
+
+    @pytest.mark.asyncio
+    async def test_agent_has_file_tools_registered_only_with_capability(self):
+        without_files = PydanticAIAdapter(model="test")
+        await without_files.on_started(agent_name="Probe", agent_description="probe")
+        names = set(without_files._agent._function_toolset.tools)
+
+        assert "band_list_room_files" not in names
+        assert "band_read_room_file" not in names
+        assert "band_send_room_file" not in names
+
+        with_files = await self._tool_functions()
+
+        assert "band_list_room_files" in with_files
+        assert "band_read_room_file" in with_files
+        assert "band_send_room_file" in with_files
+
+    @pytest.mark.asyncio
+    async def test_list_room_files_forwards_cursor(self, file_tools):
+        functions = await self._tool_functions()
+
+        result = await functions["band_list_room_files"](
+            SimpleNamespace(deps=file_tools), cursor="cursor-1"
+        )
+
+        file_tools.list_room_files.assert_called_once_with("cursor-1")
+        assert result == {"data": [{"id": "file-1", "name": "report.txt"}]}
+
+    @pytest.mark.asyncio
+    async def test_list_room_files_handles_exception(self, file_tools):
+        file_tools.list_room_files.side_effect = Exception("backend unavailable")
+        functions = await self._tool_functions()
+
+        result = await functions["band_list_room_files"](
+            SimpleNamespace(deps=file_tools), cursor=None
+        )
+
+        assert "Error listing room files" in result
+        assert "backend unavailable" in result
+
+    @pytest.mark.asyncio
+    async def test_read_room_file_forwards_file_id(self, file_tools):
+        functions = await self._tool_functions()
+
+        result = await functions["band_read_room_file"](
+            SimpleNamespace(deps=file_tools), file_id="file-1"
+        )
+
+        file_tools.read_room_file.assert_called_once_with("file-1")
+        assert result == {"name": "report.txt", "text": "hello world"}
+
+    @pytest.mark.asyncio
+    async def test_read_room_file_handles_exception(self, file_tools):
+        file_tools.read_room_file.side_effect = Exception("not found")
+        functions = await self._tool_functions()
+
+        result = await functions["band_read_room_file"](
+            SimpleNamespace(deps=file_tools), file_id="missing"
+        )
+
+        assert "Error reading room file" in result
+        assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_send_room_file_forwards_args_in_protocol_order(self, file_tools):
+        """Regression pin: the wrapper's own signature order (content, filename,
+        mentions, caption) differs from the positional order AgentToolsProtocol
+        wants (content, filename, caption, mentions) -- assert the call site
+        reorders correctly rather than passing mentions where caption goes."""
+        functions = await self._tool_functions()
+
+        result = await functions["band_send_room_file"](
+            SimpleNamespace(deps=file_tools),
+            content="file body",
+            filename="notes.txt",
+            mentions=["Alice", "Bob"],
+            caption="here's a file",
+        )
+
+        file_tools.send_room_file.assert_called_once_with(
+            "file body", "notes.txt", "here's a file", ["Alice", "Bob"]
+        )
+        assert result == {"attachment": {"id": "file-2"}, "message_id": "msg-1"}
+
+    @pytest.mark.asyncio
+    async def test_send_room_file_handles_exception(self, file_tools):
+        file_tools.send_room_file.side_effect = Exception("upload failed")
+        functions = await self._tool_functions()
+
+        result = await functions["band_send_room_file"](
+            SimpleNamespace(deps=file_tools),
+            content="body",
+            filename="notes.txt",
+            mentions=["Alice"],
+        )
+
+        assert "Error sending room file 'notes.txt'" in result
+        assert "upload failed" in result
+
+
 class TestOnMessage:
     """Tests for on_message() method."""
 

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -8,6 +8,7 @@ usage, and cleanup.
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from datetime import datetime, timezone
 from functools import partial
@@ -729,6 +730,19 @@ class TestReadRoomFileImagePassthrough:
 
         assert _result_text(result) == "<3 image content block(s)>"
 
+    def test_malformed_image_data_returns_error_result(self):
+        """A decode_image_block failure (invalid base64) must degrade to an
+        error result, not raise uncaught out of stream()'s async generator --
+        this runs after _execute's own try/except already succeeded, so
+        _tool_result needs its own boundary around the decode step."""
+        tool_use = {"toolUseId": "t1", "name": "band_read_room_file", "input": {}}
+        value = {"content": [{"type": "image", "data": "A", "mimeType": "image/png"}]}
+
+        result = _tool_result(tool_use, value=value, ok=True)
+
+        assert result["status"] == "error"
+        assert "text" in result["content"][0]
+
     def test_result_text_keeps_images_at_their_original_position(self):
         """A combined image placeholder must appear where the first image
         block occurred among text/json blocks, not get shoved to the end."""
@@ -744,3 +758,37 @@ class TestReadRoomFileImagePassthrough:
         }
 
         assert _result_text(result) == "before\n<2 image content block(s)>\nafter"
+
+
+class TestSendRoomFileArgsRedaction:
+    @pytest.mark.asyncio
+    async def test_tool_call_event_redacts_content_not_raw_bytes(self, tools):
+        """band_send_room_file's tool_call event must report a bounded
+        placeholder for content, not the raw file bytes -- generic ARGS
+        reporting has no idea this one tool's content argument can carry up
+        to MAX_SEND_CONTENT_BYTES of real file data."""
+        adapter = StrandsAdapter(
+            model=ScriptedStrandsModel(
+                (
+                    ToolTurn(
+                        "band_send_room_file",
+                        {"content": "raw file bytes", "filename": "notes.txt"},
+                    ),
+                )
+            ),
+            capabilities=Capability.FILES,
+            emit=Emit.TOOL_CALLS,
+        )
+        await adapter.on_started("Bot", "A bot")
+
+        await _run_message(adapter, tools)
+
+        tool_calls = [
+            json.loads(e["content"])
+            for e in tools.events_sent
+            if e["message_type"] == "tool_call"
+        ]
+        [send_room_file_call] = [
+            c for c in tool_calls if c["name"] == "band_send_room_file"
+        ]
+        assert send_room_file_call["args"]["content"] == "<14 byte file content>"

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -27,7 +27,12 @@ from strands.types.exceptions import EventLoopException  # noqa: E402
 from strands.types.streaming import StreamEvent  # noqa: E402
 from strands.types.tools import ToolChoice, ToolSpec  # noqa: E402
 
-from band.adapters.strands import CustomToolBridge, StrandsAdapter, _tool_result  # noqa: E402
+from band.adapters.strands import (  # noqa: E402
+    CustomToolBridge,
+    StrandsAdapter,
+    _result_text,
+    _tool_result,
+)
 from band.converters.strands import StrandsHistoryConverter  # noqa: E402
 from band.core.protocols import AgentToolsProtocol  # noqa: E402
 from band.core.types import (  # noqa: E402
@@ -707,3 +712,35 @@ class TestReadRoomFileImagePassthrough:
 
         assert result["status"] == "error"
         assert "text" in result["content"][0]
+
+    def test_multi_image_result_reports_one_placeholder_with_total_count(self):
+        """A multi-image result must flatten to one placeholder naming the
+        total count, not one placeholder line per image block."""
+        tool_use = {"toolUseId": "t1", "name": "band_read_room_file", "input": {}}
+        value = {
+            "content": [
+                {"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"},
+                {"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"},
+                {"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"},
+            ]
+        }
+
+        result = _tool_result(tool_use, value=value, ok=True)
+
+        assert _result_text(result) == "<3 image content block(s)>"
+
+    def test_result_text_keeps_images_at_their_original_position(self):
+        """A combined image placeholder must appear where the first image
+        block occurred among text/json blocks, not get shoved to the end."""
+        result = {
+            "toolUseId": "t1",
+            "status": "success",
+            "content": [
+                {"text": "before"},
+                {"image": {"format": "png", "source": {"bytes": b"a"}}},
+                {"image": {"format": "png", "source": {"bytes": b"b"}}},
+                {"text": "after"},
+            ],
+        }
+
+        assert _result_text(result) == "before\n<2 image content block(s)>\nafter"

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -27,7 +27,7 @@ from strands.types.exceptions import EventLoopException  # noqa: E402
 from strands.types.streaming import StreamEvent  # noqa: E402
 from strands.types.tools import ToolChoice, ToolSpec  # noqa: E402
 
-from band.adapters.strands import CustomToolBridge, StrandsAdapter  # noqa: E402
+from band.adapters.strands import CustomToolBridge, StrandsAdapter, _tool_result  # noqa: E402
 from band.converters.strands import StrandsHistoryConverter  # noqa: E402
 from band.core.protocols import AgentToolsProtocol  # noqa: E402
 from band.core.types import (  # noqa: E402
@@ -672,3 +672,38 @@ class TestCleanup:
         await adapter.on_cleanup(ROOM)
 
         assert ROOM not in adapter._message_history
+
+
+class TestReadRoomFileImagePassthrough:
+    def test_image_result_becomes_image_content_block(self):
+        tool_use = {"toolUseId": "t1", "name": "band_read_room_file", "input": {}}
+        value = {
+            "content": [{"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}]
+        }
+
+        result = _tool_result(tool_use, value=value, ok=True)
+
+        assert result["content"] == [
+            {"image": {"format": "png", "source": {"bytes": b"fake"}}}
+        ]
+
+    def test_non_image_result_stays_text(self):
+        tool_use = {"toolUseId": "t1", "name": "band_read_room_file", "input": {}}
+        value = {"name": "notes.txt", "content_type": "text/plain"}
+
+        result = _tool_result(tool_use, value=value, ok=True)
+
+        assert result["content"] == [
+            {"text": '{"name": "notes.txt", "content_type": "text/plain"}'}
+        ]
+
+    def test_image_shaped_value_on_error_stays_text(self):
+        """An error path (ok=False) must never be treated as an image result,
+        even if the error value happens to look MCP-content-shaped."""
+        tool_use = {"toolUseId": "t1", "name": "band_read_room_file", "input": {}}
+        value = {"content": [{"type": "image", "data": "x", "mimeType": "image/png"}]}
+
+        result = _tool_result(tool_use, value=value, ok=False)
+
+        assert result["status"] == "error"
+        assert "text" in result["content"][0]

--- a/tests/e2e/baseline/settings.py
+++ b/tests/e2e/baseline/settings.py
@@ -209,6 +209,28 @@ class LLMModels(BaseSettings):
         return self
 
 
+class DeploymentFeatures(BaseSettings):
+    """Which optional platform features the connected Band deployment serves.
+
+    Declared, not probed -- the same reason ``Backends.opencode_bash_asks`` is:
+    the platform only reports a flag through an authenticated ``/me`` call made
+    after an agent exists, and a collection-time gate has neither.
+    """
+
+    model_config = SettingsConfigDict(
+        env_ignore_empty=True,
+        env_prefix="E2E_",
+        extra="ignore",
+        case_sensitive=False,
+    )
+
+    # ``ff_file_transfer`` is on-prem-only and off everywhere on SaaS today, so
+    # ``prune_unsupported`` drops ``Capability.FILES`` before a file tool ever
+    # reaches the model and the file/image cells cannot pass there. Opt in when
+    # the run targets a deployment that has the flag on.
+    file_transfer: bool = False  # E2E_FILE_TRANSFER
+
+
 class BaselineSettings(BaseSettings):
     """Top-level baseline toolkit config, composed from per-concern groups."""
 
@@ -229,3 +251,4 @@ class BaselineSettings(BaseSettings):
     llm_credentials: LLMCredentials = Field(default_factory=LLMCredentials)
     llm_models: LLMModels = Field(default_factory=LLMModels)
     backends: Backends = Field(default_factory=Backends)
+    deployment: DeploymentFeatures = Field(default_factory=DeploymentFeatures)

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -11,6 +11,9 @@ regression.
 
 from __future__ import annotations
 
+import random
+from collections.abc import Awaitable, Callable
+
 import pytest
 from tests.e2e.baseline.flaky import flaky_infra
 
@@ -21,15 +24,19 @@ from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, per_adapter
 from tests.e2e.baseline.smoke.samples.sample_agents import (
     CONTACTS_AGENT,
     FILES_AGENT,
+    IMAGE_COLORS,
     MEMORY_AGENT,
     file_round_trip_instruction,
+    image_round_trip_instruction,
     list_contacts_instruction,
     recall_memory_instruction,
     retrieve_memory_instruction,
+    solid_color_png,
     store_memory_instruction,
     unique_marker,
 )
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
+from tests.e2e.baseline.toolkit.judge import Verdict, format_transcript
 from tests.e2e.baseline.toolkit.observations import ContactTool, FileTool
 from tests.e2e.baseline.toolkit.provisioning import (
     AdapterCell,
@@ -37,6 +44,8 @@ from tests.e2e.baseline.toolkit.provisioning import (
     ResourceManager,
 )
 from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+JudgeFn = Callable[..., Awaitable[Verdict]]
 
 
 @per_adapter(supports={Capability.MEMORY}, **MEMORY_AGENT)
@@ -231,6 +240,99 @@ async def test_file_round_trip_across_files_adapters(
     results.assert_succeeded(FileTool.LIST.value)
     results.assert_succeeded(FileTool.READ.value, output_contains=marker)
     replies.assert_contains_any([marker])
+
+
+# Adapters with a verified real image-vision-passthrough fix -- keep this in
+# sync with IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS in
+# tests/framework_conformance/test_adapter_conformance.py (that's the unit-level
+# source of truth; this list exists only because @per_adapter selects from the
+# separate tests.baseline.adapter.Adapter enum, a different registry). Differs
+# from that set by: -crewai_flow (its E2E builder is a hardcoded echo flow with
+# no Band tool loop, so there's no tool call for this to drive), -parlant (not
+# in Adapter at all -- confirmed unsupportable, no matrix cell), +copilot_acp
+# (wraps ACPClientAdapter, which shares the same already-fixed MCP engine as
+# opencode but isn't tracked in the unit-level set since it's not its own
+# ADAPTER_CONFIGS entry there).
+IMAGE_PASSTHROUGH_ADAPTERS = (
+    Adapter.CLAUDE_SDK,
+    Adapter.ANTHROPIC,
+    Adapter.OPENCODE,
+    Adapter.GEMINI,
+    Adapter.LANGGRAPH,
+    Adapter.AGNO,
+    Adapter.STRANDS,
+    Adapter.COPILOT_SDK,
+    Adapter.COPILOT_ACP,
+    Adapter.CODEX,
+    Adapter.PYDANTIC_AI,
+    Adapter.CREWAI,
+    Adapter.LETTA,
+)
+
+
+@per_adapter(*IMAGE_PASSTHROUGH_ADAPTERS, **FILES_AGENT)
+@pytest.mark.timeout(extra=120)  # upload -> list -> read -> vision reply
+@pytest.mark.asyncio(loop_scope="session")
+async def test_image_vision_passthrough_across_adapters(
+    agent: ProvisionedAgent,
+    resource_manager: ResourceManager,
+    reply_capture: CaptureFactory,
+    judge: JudgeFn,
+) -> None:
+    """Each adapter with a verified image-passthrough fix can actually SEE an
+    image a peer shared in the room, not just degrade it to descriptive text.
+
+    The platform's file-upload endpoint is agent-scoped (no user-side upload),
+    so a peer agent -- not UserOps -- plays "someone already shared a file
+    here": PeerActor.send_file uploads a solid-color PNG built by
+    solid_color_png() (pure stdlib, no Pillow dependency) and mentions the
+    agent under test. The color is randomized per run and judged against
+    ground truth, so a model can't pass by reflexively guessing a common
+    default without actually looking at the pixels.
+    """
+    color = random.choice(sorted(IMAGE_COLORS))
+    image = solid_color_png(color)
+
+    bystander = await resource_manager.provision_agent(
+        f"image-sender-{agent.adapter_id}"
+    )
+    room_id = await resource_manager.provision_room(
+        title=f"e2e-cap-image-{agent.adapter_id}",
+        participants=[agent.id, bystander.id],
+    )
+    async with reply_capture(room_id) as capture:
+        mid = await resource_manager.peer(bystander).send_file(
+            room_id,
+            image,
+            filename="swatch.png",
+            content_type="image/png",
+            caption=image_round_trip_instruction(),
+            mention_id=agent.id,
+            mention_name=agent.name,
+        )
+        replies = await capture.wait_for_reply(mid, agent.id)
+        calls = await capture.tool_calls(sender_id=agent.id)
+        results = await capture.tool_results(sender_id=agent.id)
+
+    calls.assert_fired(FileTool.LIST.value)
+    calls.assert_fired(FileTool.READ.value)
+    results.assert_succeeded(FileTool.LIST.value)
+    results.assert_succeeded(FileTool.READ.value)
+
+    verdict = await judge(
+        criteria=(
+            f"An agent was shown an image whose single dominant color is "
+            f"{color} (RGB {IMAGE_COLORS[color]}). It was asked to identify "
+            "that color in one word and reply with just it. Pass if the "
+            "reply names that exact color or an unambiguous close synonym "
+            "(e.g. 'crimson' for red, 'violet' for purple). Fail if the "
+            "reply names a clearly different color, describes the image as "
+            "unreadable or inaccessible, or otherwise shows it did not "
+            "actually see the image content."
+        ),
+        transcript=replies,
+    )
+    assert verdict.passed, f"{verdict.reasoning}\n{format_transcript(replies)}"
 
 
 @per_adapter(without={Capability.MEMORY})

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -209,6 +209,7 @@ async def test_list_contacts_across_contacts_adapters(
 
 
 @per_adapter(supports={Capability.FILES}, **FILES_AGENT)
+@flaky_infra("retry a transient live-turn timeout; assertion failures fail loud")
 @pytest.mark.timeout(extra=120)  # upload -> list -> read is a multi-tool turn
 @pytest.mark.asyncio(loop_scope="session")
 async def test_file_round_trip_across_files_adapters(
@@ -271,6 +272,7 @@ IMAGE_PASSTHROUGH_ADAPTERS = (
 
 
 @per_adapter(*IMAGE_PASSTHROUGH_ADAPTERS, **FILES_AGENT)
+@flaky_infra("retry a transient live-turn timeout; assertion failures fail loud")
 @pytest.mark.timeout(extra=120)  # upload -> list -> read -> vision reply
 @pytest.mark.asyncio(loop_scope="session")
 async def test_image_vision_passthrough_across_adapters(

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -1,4 +1,4 @@
-"""Grid tests for adapters that expose memory or contacts capabilities.
+"""Grid tests for adapters that expose memory, contacts, or files capabilities.
 
 Every cell comes from a capability filter, never a hard-coded adapter list:
 ``supports={Capability.MEMORY}`` selects the memory-capable adapters and
@@ -20,7 +20,9 @@ from band.core.types import Capability
 from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, per_adapter
 from tests.e2e.baseline.smoke.samples.sample_agents import (
     CONTACTS_AGENT,
+    FILES_AGENT,
     MEMORY_AGENT,
+    file_round_trip_instruction,
     list_contacts_instruction,
     recall_memory_instruction,
     retrieve_memory_instruction,
@@ -28,7 +30,7 @@ from tests.e2e.baseline.smoke.samples.sample_agents import (
     unique_marker,
 )
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
-from tests.e2e.baseline.toolkit.observations import ContactTool
+from tests.e2e.baseline.toolkit.observations import ContactTool, FileTool
 from tests.e2e.baseline.toolkit.provisioning import (
     AdapterCell,
     ProvisionedAgent,
@@ -195,6 +197,40 @@ async def test_list_contacts_across_contacts_adapters(
         calls = await capture.tool_calls(sender_id=agent.id)
 
     calls.assert_fired(ContactTool.LIST.value)
+
+
+@per_adapter(supports={Capability.FILES}, **FILES_AGENT)
+@pytest.mark.timeout(extra=120)  # upload -> list -> read is a multi-tool turn
+@pytest.mark.asyncio(loop_scope="session")
+async def test_file_round_trip_across_files_adapters(
+    agent: ProvisionedAgent,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Each files-capable adapter can send, discover, and read a room file."""
+    marker = unique_marker("file")
+    room_id = await resource_manager.provision_room(
+        title=f"e2e-cap-files-{agent.adapter_id}", participants=[agent.id]
+    )
+    async with reply_capture(room_id) as capture:
+        mid = await user_ops.send_message(
+            room_id,
+            file_round_trip_instruction(marker),
+            mention_id=agent.id,
+            mention_name=agent.name,
+        )
+        replies = await capture.wait_for_reply(mid, agent.id)
+        calls = await capture.tool_calls(sender_id=agent.id)
+        results = await capture.tool_results(sender_id=agent.id)
+
+    calls.assert_fired(FileTool.SEND.value)
+    calls.assert_fired(FileTool.LIST.value)
+    calls.assert_fired(FileTool.READ.value)
+    results.assert_succeeded(FileTool.SEND.value)
+    results.assert_succeeded(FileTool.LIST.value)
+    results.assert_succeeded(FileTool.READ.value, output_contains=marker)
+    replies.assert_contains_any([marker])
 
 
 @per_adapter(without={Capability.MEMORY})

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -261,11 +261,13 @@ async def test_file_round_trip_across_files_adapters(
 # source of truth; this list exists only because @per_adapter selects from the
 # separate tests.baseline.adapter.Adapter enum, a different registry). Differs
 # from that set by: -crewai_flow (its E2E builder is a hardcoded echo flow with
-# no Band tool loop, so there's no tool call for this to drive), -parlant (not
-# in Adapter at all -- confirmed unsupportable, no matrix cell), +copilot_acp
-# (wraps ACPClientAdapter, which shares the same already-fixed MCP engine as
-# opencode but isn't tracked in the unit-level set since it's not its own
-# ADAPTER_CONFIGS entry there).
+# no Band tool loop, so there's no tool call for this to drive), +copilot_acp
+# and +letta (both wrap/share the same already-fixed MCP engine as opencode,
+# so the unit-level set excludes them as having no probe of their own, but
+# the E2E matrix gives each a real live cell). parlant isn't in Adapter at
+# all -- confirmed unsupportable, no matrix cell either way.
+# test_image_passthrough_adapters_matches_unit_level_set below asserts this
+# relationship instead of leaving it to this comment alone.
 IMAGE_PASSTHROUGH_ADAPTERS = (
     Adapter.CLAUDE_SDK,
     Adapter.ANTHROPIC,
@@ -281,6 +283,13 @@ IMAGE_PASSTHROUGH_ADAPTERS = (
     Adapter.CREWAI,
     Adapter.LETTA,
 )
+
+
+# The cross-check against IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS lives in
+# tests/framework_conformance/test_adapter_conformance.py, not here: every
+# test in this package is gated on E2E_TESTS_ENABLED (see
+# tests/e2e/baseline/conftest.py), which would skip a pure offline
+# list-equality check right along with the live ones.
 
 
 @per_adapter(*IMAGE_PASSTHROUGH_ADAPTERS, **FILES_AGENT)

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -35,6 +35,7 @@ from tests.e2e.baseline.smoke.samples.sample_agents import (
     store_memory_instruction,
     unique_marker,
 )
+from tests.e2e.baseline.settings import BaselineSettings
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
 from tests.e2e.baseline.toolkit.judge import Verdict, format_transcript
 from tests.e2e.baseline.toolkit.observations import ContactTool, FileTool
@@ -42,11 +43,20 @@ from tests.e2e.baseline.toolkit.provisioning import (
     AdapterCell,
     ProvisionedAgent,
     ResourceManager,
-    file_transfer_enabled,
 )
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
 JudgeFn = Callable[..., Awaitable[Verdict]]
+
+# The file/image cells need a deployment with ``ff_file_transfer`` on; without
+# it ``Capability.FILES`` is pruned before a file tool ever reaches the model,
+# so they cannot pass. Skips rather than fails (the ``GITHUB_TOKEN`` hosted-auth
+# smoke's rationale): on SaaS the flag is off by design, not misconfiguration,
+# and no key can turn it on -- this is optional extra coverage over the matrix.
+requires_file_transfer = pytest.mark.skipif(
+    not BaselineSettings().deployment.file_transfer,
+    reason="E2E_FILE_TRANSFER is not true (ff_file_transfer is on-prem-only)",
+)
 
 
 @per_adapter(supports={Capability.MEMORY}, **MEMORY_AGENT)
@@ -210,6 +220,7 @@ async def test_list_contacts_across_contacts_adapters(
 
 
 @per_adapter(supports={Capability.FILES}, **FILES_AGENT)
+@requires_file_transfer
 @flaky_infra("retry a transient live-turn timeout; assertion failures fail loud")
 @pytest.mark.timeout(extra=120)  # upload -> list -> read is a multi-tool turn
 @pytest.mark.asyncio(loop_scope="session")
@@ -220,8 +231,6 @@ async def test_file_round_trip_across_files_adapters(
     reply_capture: CaptureFactory,
 ) -> None:
     """Each files-capable adapter can send, discover, and read a room file."""
-    if not await file_transfer_enabled(agent, resource_manager.settings):
-        pytest.skip("ff_file_transfer is off on this deployment (on-prem-only flag)")
     marker = unique_marker("file")
     room_id = await resource_manager.provision_room(
         title=f"e2e-cap-files-{agent.adapter_id}", participants=[agent.id]
@@ -275,6 +284,7 @@ IMAGE_PASSTHROUGH_ADAPTERS = (
 
 
 @per_adapter(*IMAGE_PASSTHROUGH_ADAPTERS, **FILES_AGENT)
+@requires_file_transfer
 @flaky_infra("retry a transient live-turn timeout; assertion failures fail loud")
 @pytest.mark.timeout(extra=120)  # upload -> list -> read -> vision reply
 @pytest.mark.asyncio(loop_scope="session")
@@ -295,8 +305,6 @@ async def test_image_vision_passthrough_across_adapters(
     ground truth, so a model can't pass by reflexively guessing a common
     default without actually looking at the pixels.
     """
-    if not await file_transfer_enabled(agent, resource_manager.settings):
-        pytest.skip("ff_file_transfer is off on this deployment (on-prem-only flag)")
     color = random.choice(sorted(IMAGE_COLORS))
     image = solid_color_png(color)
 

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -42,6 +42,7 @@ from tests.e2e.baseline.toolkit.provisioning import (
     AdapterCell,
     ProvisionedAgent,
     ResourceManager,
+    file_transfer_enabled,
 )
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
@@ -219,6 +220,8 @@ async def test_file_round_trip_across_files_adapters(
     reply_capture: CaptureFactory,
 ) -> None:
     """Each files-capable adapter can send, discover, and read a room file."""
+    if not await file_transfer_enabled(agent, resource_manager.settings):
+        pytest.skip("ff_file_transfer is off on this deployment (on-prem-only flag)")
     marker = unique_marker("file")
     room_id = await resource_manager.provision_room(
         title=f"e2e-cap-files-{agent.adapter_id}", participants=[agent.id]
@@ -292,6 +295,8 @@ async def test_image_vision_passthrough_across_adapters(
     ground truth, so a model can't pass by reflexively guessing a common
     default without actually looking at the pixels.
     """
+    if not await file_transfer_enabled(agent, resource_manager.settings):
+        pytest.skip("ff_file_transfer is off on this deployment (on-prem-only flag)")
     color = random.choice(sorted(IMAGE_COLORS))
     image = solid_color_png(color)
 

--- a/tests/e2e/baseline/smoke/samples/sample_agents.py
+++ b/tests/e2e/baseline/smoke/samples/sample_agents.py
@@ -54,6 +54,11 @@ def contacts_features() -> AdapterFeatures:
     return AdapterFeatures(capabilities={Capability.CONTACTS}, emit={Emit.TOOL_CALLS})
 
 
+def files_features() -> AdapterFeatures:
+    """Expose room-file tools and persist their calls for capability smokes."""
+    return AdapterFeatures(capabilities={Capability.FILES}, emit={Emit.TOOL_CALLS})
+
+
 def usage_features() -> AdapterFeatures:
     """Features for the cost/token smokes: emit each turn's token usage as a
     ``usage`` event so the ``Usage`` observation layer is populated."""
@@ -103,6 +108,7 @@ MEMORY_SECRETARY_PROMPT = (
 TOOL_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT}
 MEMORY_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT, "features": memory_features()}
 CONTACTS_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT, "features": contacts_features()}
+FILES_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT, "features": files_features()}
 MEMORY_SECRETARY_AGENT = {
     "prompt": MEMORY_SECRETARY_PROMPT,
     "features": memory_features(),
@@ -155,6 +161,17 @@ def liveness_probe(marker: str) -> str:
 def unique_marker(prefix: str) -> str:
     """A high-entropy token to assert verbatim in event/memory content."""
     return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def file_round_trip_instruction(marker: str) -> str:
+    """Drive one real text-file send, discovery, and read-back in a room."""
+    return (
+        "Use band_send_room_file to upload a text file named evidence.txt whose "
+        f"entire content is the exact token {marker}. Include at least one room "
+        "participant in its mentions. Then use band_list_room_files to find that "
+        "file and band_read_room_file with its returned id. Finally, use "
+        f"band_send_message to reply with the exact token {marker}."
+    )
 
 
 def emit_event_instruction(event_type: MessageType, marker: str) -> str:

--- a/tests/e2e/baseline/smoke/samples/sample_agents.py
+++ b/tests/e2e/baseline/smoke/samples/sample_agents.py
@@ -19,7 +19,9 @@ way to produce it -- so a precise instruction is the only way to comply.
 
 from __future__ import annotations
 
+import struct
 import uuid
+import zlib
 
 
 from band.core.types import AdapterFeatures, Capability, Emit, MessageType
@@ -171,6 +173,64 @@ def file_round_trip_instruction(marker: str) -> str:
         "participant in its mentions. Then use band_list_room_files to find that "
         "file and band_read_room_file with its returned id. Finally, use "
         f"band_send_message to reply with the exact token {marker}."
+    )
+
+
+# Visually distinct, single-word-nameable colors for the image vision-passthrough
+# smoke. Randomizing per run (see IMAGE_COLORS usage) means a model can't pass by
+# reflexively guessing a common default (e.g. "blue") without actually seeing the
+# uploaded pixels -- the judge is told the true color as ground truth.
+IMAGE_COLORS: dict[str, tuple[int, int, int]] = {
+    "red": (220, 20, 20),
+    "green": (20, 180, 20),
+    "orange": (240, 140, 20),
+    "purple": (140, 20, 200),
+    "yellow": (230, 210, 20),
+    "cyan": (20, 200, 210),
+}
+
+
+def solid_color_png(color_name: str, *, size: int = 64) -> bytes:
+    """A minimal, real, valid solid-color PNG -- pure stdlib (no Pillow, which
+    is only a crewai-extra dependency, not available in every lane's venv).
+
+    ``color_name`` must be a key of ``IMAGE_COLORS``. Encodes an 8-bit RGB
+    image (color type 2, no filtering) with a single IDAT chunk -- the
+    smallest structure a real PNG decoder (and a real vision model) accepts.
+    """
+    rgb = IMAGE_COLORS[color_name]
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + tag
+            + data
+            + struct.pack(">I", zlib.crc32(tag + data))
+        )
+
+    signature = b"\x89PNG\r\n\x1a\n"
+    ihdr = struct.pack(">IIBBBBB", size, size, 8, 2, 0, 0, 0)
+    raw_row = b"\x00" + bytes(rgb) * size  # filter-type-0 byte + RGB pixels
+    raw = raw_row * size
+    idat = zlib.compress(raw)
+    return signature + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
+
+
+def image_round_trip_instruction() -> str:
+    """Drive discovery and vision passthrough of an image a peer already
+    shared in the room: list, read, then report what color it saw.
+
+    No marker/color hint in the wording -- the whole point is that the model
+    must actually look at the image, not echo a string. The judge checks the
+    reply against the real uploaded color (known to the test, not the model)
+    as ground truth.
+    """
+    return (
+        "A peer already shared an image file in this room. Use "
+        "band_list_room_files to find it, then band_read_room_file with its "
+        "returned id to view it. Look at the image and identify its single "
+        "dominant color in one word. Then use band_send_message to reply "
+        "with just that color word."
     )
 
 

--- a/tests/e2e/baseline/smoke/samples/sample_agents.py
+++ b/tests/e2e/baseline/smoke/samples/sample_agents.py
@@ -166,13 +166,24 @@ def unique_marker(prefix: str) -> str:
 
 
 def file_round_trip_instruction(marker: str) -> str:
-    """Drive one real text-file send, discovery, and read-back in a room."""
+    """Drive one real text-file send, discovery, and read-back in a room.
+
+    Numbered steps plus an explicit anti-shortcut clause: a smaller model
+    otherwise pattern-matches "reply with the exact token" (step 4) as the
+    whole task and jumps straight to a single band_send_message, skipping
+    the file round-trip entirely -- observed live against gpt-5.4-mini and
+    claude-haiku-4-5.
+    """
     return (
-        "Use band_send_room_file to upload a text file named evidence.txt whose "
-        f"entire content is the exact token {marker}. Include at least one room "
-        "participant in its mentions. Then use band_list_room_files to find that "
-        "file and band_read_room_file with its returned id. Finally, use "
-        f"band_send_message to reply with the exact token {marker}."
+        "Complete these four tool calls in order, then stop -- do not reply "
+        "or take any other action until all four are done:\n"
+        f"1. Call band_send_room_file to upload a text file named "
+        f"evidence.txt whose entire content is the exact token {marker}. "
+        "Include at least one room participant in its mentions.\n"
+        "2. Call band_list_room_files to find that file.\n"
+        "3. Call band_read_room_file with its returned id.\n"
+        f"4. Only after steps 1-3 are done, call band_send_message to reply "
+        f"with the exact token {marker}."
     )
 
 

--- a/tests/e2e/baseline/toolkit/builders.py
+++ b/tests/e2e/baseline/toolkit/builders.py
@@ -144,7 +144,7 @@ def _build_langgraph(
     )
 
 
-@adapter(Adapter.PYDANTIC_AI, requires=[Dep.OPENAI], supports=_LLM_TOOL_LOOP)
+@adapter(Adapter.PYDANTIC_AI, requires=[Dep.OPENAI], supports=_FILE_CAPABLE)
 def _build_pydantic_ai(
     s: BaselineSettings,
     *,
@@ -232,7 +232,7 @@ def _build_google_adk(
     )
 
 
-@adapter(Adapter.CREWAI, requires=[Dep.OPENAI, Dep.CREWAI], supports=_LLM_TOOL_LOOP)
+@adapter(Adapter.CREWAI, requires=[Dep.OPENAI, Dep.CREWAI], supports=_FILE_CAPABLE)
 def _build_crewai(
     s: BaselineSettings,
     *,

--- a/tests/e2e/baseline/toolkit/builders.py
+++ b/tests/e2e/baseline/toolkit/builders.py
@@ -35,11 +35,14 @@ from tests.e2e.baseline.toolkit.adapters import (
 from tests.e2e.baseline.toolkit.deps import Dep
 from tests.e2e.baseline.toolkit.tools import ToolSpec
 
-_LLM_TOOL_LOOP = (Capability.MEMORY, Capability.CONTACTS)
-_FILE_CAPABLE = (*_LLM_TOOL_LOOP, Capability.FILES)
+# Spelled out rather than derived from the Capability enum: an adapter's
+# `supports` is a claim the capability-scoped matrices select on, so a newly
+# added capability should be a deliberate per-adapter decision, not one every
+# adapter here silently starts claiming.
+_EVERY_CAPABILITY = (Capability.MEMORY, Capability.CONTACTS, Capability.FILES)
 
 
-@adapter(Adapter.ANTHROPIC, requires=[Dep.ANTHROPIC], supports=_FILE_CAPABLE)
+@adapter(Adapter.ANTHROPIC, requires=[Dep.ANTHROPIC], supports=_EVERY_CAPABILITY)
 def _build_anthropic(
     s: BaselineSettings,
     *,
@@ -58,7 +61,7 @@ def _build_anthropic(
     )
 
 
-@adapter(Adapter.CLAUDE_SDK, requires=[Dep.ANTHROPIC], supports=_FILE_CAPABLE)
+@adapter(Adapter.CLAUDE_SDK, requires=[Dep.ANTHROPIC], supports=_EVERY_CAPABILITY)
 def _build_claude_sdk(
     s: BaselineSettings,
     *,
@@ -81,7 +84,7 @@ def _build_claude_sdk(
     # Singular BYOK replaces Copilot-hosted inference and needs only the
     # Anthropic provider key; GitHub auth is deliberately disabled below.
     requires=[Dep.ANTHROPIC],
-    supports=_FILE_CAPABLE,
+    supports=_EVERY_CAPABILITY,
 )
 def _build_copilot_sdk(
     s: BaselineSettings,
@@ -113,7 +116,7 @@ def _build_copilot_sdk(
     )
 
 
-@adapter(Adapter.LANGGRAPH, requires=[Dep.OPENAI], supports=_FILE_CAPABLE)
+@adapter(Adapter.LANGGRAPH, requires=[Dep.OPENAI], supports=_EVERY_CAPABILITY)
 def _build_langgraph(
     s: BaselineSettings,
     *,
@@ -144,7 +147,7 @@ def _build_langgraph(
     )
 
 
-@adapter(Adapter.PYDANTIC_AI, requires=[Dep.OPENAI], supports=_FILE_CAPABLE)
+@adapter(Adapter.PYDANTIC_AI, requires=[Dep.OPENAI], supports=_EVERY_CAPABILITY)
 def _build_pydantic_ai(
     s: BaselineSettings,
     *,
@@ -168,7 +171,7 @@ def _build_pydantic_ai(
     )
 
 
-@adapter(Adapter.STRANDS, requires=[Dep.OPENAI], supports=_FILE_CAPABLE)
+@adapter(Adapter.STRANDS, requires=[Dep.OPENAI], supports=_EVERY_CAPABILITY)
 def _build_strands(
     s: BaselineSettings,
     *,
@@ -194,7 +197,7 @@ def _build_strands(
     )
 
 
-@adapter(Adapter.GEMINI, requires=[Dep.GOOGLE], supports=_FILE_CAPABLE)
+@adapter(Adapter.GEMINI, requires=[Dep.GOOGLE], supports=_EVERY_CAPABILITY)
 def _build_gemini(
     s: BaselineSettings,
     *,
@@ -213,7 +216,7 @@ def _build_gemini(
     )
 
 
-@adapter(Adapter.GOOGLE_ADK, requires=[Dep.GOOGLE], supports=_FILE_CAPABLE)
+@adapter(Adapter.GOOGLE_ADK, requires=[Dep.GOOGLE], supports=_EVERY_CAPABILITY)
 def _build_google_adk(
     s: BaselineSettings,
     *,
@@ -232,7 +235,7 @@ def _build_google_adk(
     )
 
 
-@adapter(Adapter.CREWAI, requires=[Dep.OPENAI, Dep.CREWAI], supports=_FILE_CAPABLE)
+@adapter(Adapter.CREWAI, requires=[Dep.OPENAI, Dep.CREWAI], supports=_EVERY_CAPABILITY)
 def _build_crewai(
     s: BaselineSettings,
     *,
@@ -253,7 +256,7 @@ def _build_crewai(
     )
 
 
-@adapter(Adapter.AGNO, requires=[Dep.ANTHROPIC], supports=_FILE_CAPABLE)
+@adapter(Adapter.AGNO, requires=[Dep.ANTHROPIC], supports=_EVERY_CAPABILITY)
 def _build_agno(
     s: BaselineSettings,
     *,
@@ -364,7 +367,7 @@ def _build_codex(
 @adapter(
     Adapter.OPENCODE,
     requires=[Dep.OPENCODE_SERVER],
-    supports=_FILE_CAPABLE,
+    supports=_EVERY_CAPABILITY,
     runs_tool_loop=False,
 )
 def _build_opencode(
@@ -431,7 +434,7 @@ def copilot_acp_env(s: BaselineSettings, copilot_home: str) -> dict[str, str]:
 @adapter(
     Adapter.COPILOT_ACP,
     requires=[Dep.COPILOT_CLI, Dep.ANTHROPIC],
-    supports=_FILE_CAPABLE,
+    supports=_EVERY_CAPABILITY,
     runs_tool_loop=False,
 )
 def _build_copilot_acp(

--- a/tests/e2e/baseline/toolkit/builders.py
+++ b/tests/e2e/baseline/toolkit/builders.py
@@ -36,9 +36,10 @@ from tests.e2e.baseline.toolkit.deps import Dep
 from tests.e2e.baseline.toolkit.tools import ToolSpec
 
 _LLM_TOOL_LOOP = (Capability.MEMORY, Capability.CONTACTS)
+_FILE_CAPABLE = (*_LLM_TOOL_LOOP, Capability.FILES)
 
 
-@adapter(Adapter.ANTHROPIC, requires=[Dep.ANTHROPIC], supports=_LLM_TOOL_LOOP)
+@adapter(Adapter.ANTHROPIC, requires=[Dep.ANTHROPIC], supports=_FILE_CAPABLE)
 def _build_anthropic(
     s: BaselineSettings,
     *,
@@ -57,7 +58,7 @@ def _build_anthropic(
     )
 
 
-@adapter(Adapter.CLAUDE_SDK, requires=[Dep.ANTHROPIC], supports=_LLM_TOOL_LOOP)
+@adapter(Adapter.CLAUDE_SDK, requires=[Dep.ANTHROPIC], supports=_FILE_CAPABLE)
 def _build_claude_sdk(
     s: BaselineSettings,
     *,
@@ -80,7 +81,7 @@ def _build_claude_sdk(
     # Singular BYOK replaces Copilot-hosted inference and needs only the
     # Anthropic provider key; GitHub auth is deliberately disabled below.
     requires=[Dep.ANTHROPIC],
-    supports=_LLM_TOOL_LOOP,
+    supports=_FILE_CAPABLE,
 )
 def _build_copilot_sdk(
     s: BaselineSettings,
@@ -112,7 +113,7 @@ def _build_copilot_sdk(
     )
 
 
-@adapter(Adapter.LANGGRAPH, requires=[Dep.OPENAI], supports=_LLM_TOOL_LOOP)
+@adapter(Adapter.LANGGRAPH, requires=[Dep.OPENAI], supports=_FILE_CAPABLE)
 def _build_langgraph(
     s: BaselineSettings,
     *,
@@ -167,7 +168,7 @@ def _build_pydantic_ai(
     )
 
 
-@adapter(Adapter.STRANDS, requires=[Dep.OPENAI], supports=_LLM_TOOL_LOOP)
+@adapter(Adapter.STRANDS, requires=[Dep.OPENAI], supports=_FILE_CAPABLE)
 def _build_strands(
     s: BaselineSettings,
     *,
@@ -193,7 +194,7 @@ def _build_strands(
     )
 
 
-@adapter(Adapter.GEMINI, requires=[Dep.GOOGLE], supports=_LLM_TOOL_LOOP)
+@adapter(Adapter.GEMINI, requires=[Dep.GOOGLE], supports=_FILE_CAPABLE)
 def _build_gemini(
     s: BaselineSettings,
     *,
@@ -212,7 +213,7 @@ def _build_gemini(
     )
 
 
-@adapter(Adapter.GOOGLE_ADK, requires=[Dep.GOOGLE], supports=_LLM_TOOL_LOOP)
+@adapter(Adapter.GOOGLE_ADK, requires=[Dep.GOOGLE], supports=_FILE_CAPABLE)
 def _build_google_adk(
     s: BaselineSettings,
     *,
@@ -252,7 +253,7 @@ def _build_crewai(
     )
 
 
-@adapter(Adapter.AGNO, requires=[Dep.ANTHROPIC], supports=_LLM_TOOL_LOOP)
+@adapter(Adapter.AGNO, requires=[Dep.ANTHROPIC], supports=_FILE_CAPABLE)
 def _build_agno(
     s: BaselineSettings,
     *,
@@ -338,7 +339,12 @@ def codex_config_kwargs(s: BaselineSettings, *, prompt: str | None) -> dict[str,
     return config_kwargs
 
 
-@adapter(Adapter.CODEX, requires=[Dep.CODEX_CLI, Dep.CODEX_CWD], runs_tool_loop=False)
+@adapter(
+    Adapter.CODEX,
+    requires=[Dep.CODEX_CLI, Dep.CODEX_CWD],
+    supports=[Capability.FILES],
+    runs_tool_loop=False,
+)
 def _build_codex(
     s: BaselineSettings,
     *,
@@ -358,7 +364,7 @@ def _build_codex(
 @adapter(
     Adapter.OPENCODE,
     requires=[Dep.OPENCODE_SERVER],
-    supports=_LLM_TOOL_LOOP,
+    supports=_FILE_CAPABLE,
     runs_tool_loop=False,
 )
 def _build_opencode(
@@ -425,7 +431,7 @@ def copilot_acp_env(s: BaselineSettings, copilot_home: str) -> dict[str, str]:
 @adapter(
     Adapter.COPILOT_ACP,
     requires=[Dep.COPILOT_CLI, Dep.ANTHROPIC],
-    supports=_LLM_TOOL_LOOP,
+    supports=_FILE_CAPABLE,
     runs_tool_loop=False,
 )
 def _build_copilot_acp(
@@ -483,12 +489,12 @@ def _build_copilot_acp(
     )
 
 
-# Letta advertises no platform capabilities here yet: its tools live on the MCP
-# server, and the memory matrix cells assert the band memory-tool loop. The
-# self-hosted MCP server *can* serve memory tools (include_memory follows
-# Capability.MEMORY), so advertising MEMORY once proven live is a candidate
-# follow-up rather than a design limit.
-@adapter(Adapter.LETTA, requires=[Dep.LETTA], runs_tool_loop=False)
+@adapter(
+    Adapter.LETTA,
+    requires=[Dep.LETTA],
+    supports=[Capability.FILES],
+    runs_tool_loop=False,
+)
 def _build_letta(
     s: BaselineSettings,
     *,

--- a/tests/e2e/baseline/toolkit/observations/__init__.py
+++ b/tests/e2e/baseline/toolkit/observations/__init__.py
@@ -37,6 +37,7 @@ from tests.e2e.baseline.toolkit.observations.memories import (
 from tests.e2e.baseline.toolkit.observations.replies import Replies
 from tests.e2e.baseline.toolkit.observations.tool_calls import (
     ContactTool,
+    FileTool,
     MemoryTool,
     MemoryToolCalls,
     ToolCall,
@@ -49,6 +50,7 @@ __all__ = [
     "ContactTool",
     "Errors",
     "Events",
+    "FileTool",
     "Memories",
     "MemoryObservation",
     "MemoryTool",

--- a/tests/e2e/baseline/toolkit/observations/tool_calls.py
+++ b/tests/e2e/baseline/toolkit/observations/tool_calls.py
@@ -36,6 +36,7 @@ from band_rest import ChatMessage
 from band.core.types import MessageType
 from band.runtime.tools import (
     CONTACT_TOOL_NAMES,
+    FILE_TOOL_NAMES,
     MEMORY_TOOL_NAMES,
     READ_ONLY_TOOL_NAMES,
 )
@@ -85,6 +86,21 @@ if {tool.value for tool in ContactTool} != set(CONTACT_TOOL_NAMES):
     raise ValueError(
         "ContactTool drifted from band.runtime.tools.CONTACT_TOOL_NAMES: "
         f"{set(CONTACT_TOOL_NAMES) ^ {tool.value for tool in ContactTool}}"
+    )
+
+
+class FileTool(StrEnum):
+    """Canonical room-file platform-tool names for capability scenarios."""
+
+    LIST = "band_list_room_files"
+    READ = "band_read_room_file"
+    SEND = "band_send_room_file"
+
+
+if {tool.value for tool in FileTool} != set(FILE_TOOL_NAMES):
+    raise ValueError(
+        "FileTool drifted from band.runtime.tools.FILE_TOOL_NAMES: "
+        f"{set(FILE_TOOL_NAMES) ^ {tool.value for tool in FileTool}}"
     )
 
 

--- a/tests/e2e/baseline/toolkit/observations/tool_results.py
+++ b/tests/e2e/baseline/toolkit/observations/tool_results.py
@@ -113,7 +113,9 @@ class ToolResults(list[ToolResult]):
         """Assert at least one result was captured."""
         assert_nonempty(len(self), label=what or "a tool_result event")
 
-    def assert_succeeded(self, name: str, *, output_contains: str | None = None) -> None:
+    def assert_succeeded(
+        self, name: str, *, output_contains: str | None = None
+    ) -> None:
         """Assert a named tool returned successfully, optionally with content."""
         matching = [result for result in self if result.name.lower() == name.lower()]
         if not matching:
@@ -123,9 +125,7 @@ class ToolResults(list[ToolResult]):
             )
         failures = [result.output for result in matching if result.is_error]
         if failures:
-            raise AssertionError(
-                f"tool {name!r} returned an error: {failures}"
-            )
+            raise AssertionError(f"tool {name!r} returned an error: {failures}")
         if output_contains is not None and not any(
             output_contains in result.output for result in matching
         ):

--- a/tests/e2e/baseline/toolkit/observations/tool_results.py
+++ b/tests/e2e/baseline/toolkit/observations/tool_results.py
@@ -113,6 +113,28 @@ class ToolResults(list[ToolResult]):
         """Assert at least one result was captured."""
         assert_nonempty(len(self), label=what or "a tool_result event")
 
+    def assert_succeeded(self, name: str, *, output_contains: str | None = None) -> None:
+        """Assert a named tool returned successfully, optionally with content."""
+        matching = [result for result in self if result.name.lower() == name.lower()]
+        if not matching:
+            observed = [result.name for result in self] or ["<none>"]
+            raise AssertionError(
+                f"expected tool result for {name!r}, but observed: {observed}"
+            )
+        failures = [result.output for result in matching if result.is_error]
+        if failures:
+            raise AssertionError(
+                f"tool {name!r} returned an error: {failures}"
+            )
+        if output_contains is not None and not any(
+            output_contains in result.output for result in matching
+        ):
+            observed = [result.output for result in matching]
+            raise AssertionError(
+                f"no successful result for {name!r} contained {output_contains!r}; "
+                f"observed: {observed}"
+            )
+
     def assert_json_output(self) -> None:
         """Assert every captured result's ``output`` is one well-formed JSON
         document.

--- a/tests/e2e/baseline/toolkit/provisioning.py
+++ b/tests/e2e/baseline/toolkit/provisioning.py
@@ -36,6 +36,7 @@ from band_rest import (
 
 from band.agent import Agent
 from band.core.simple_adapter import SimpleAdapter
+from band.runtime.capabilities import FeatureFlag
 
 from tests.e2e.baseline.settings import BaselineSettings
 from tests.e2e.baseline.toolkit.user_ops import UserOps
@@ -133,6 +134,23 @@ def agent_rest_client(
     ``ReplyCapture`` reuses one client per agent to bound how many are opened.
     """
     return AsyncRestClient(api_key=agent.api_key, base_url=settings.endpoints.rest_url)
+
+
+async def file_transfer_enabled(
+    agent: ProvisionedAgent, settings: BaselineSettings
+) -> bool:
+    """Whether the connected deployment has ``ff_file_transfer`` on, per
+    ``agent``'s own ``/me`` response.
+
+    On-prem-only flag, off everywhere on SaaS today (see
+    docs/capability-negotiation.md) -- FILES/image E2E tests check this and
+    skip rather than fail loud, since ``Capability.FILES`` gets silently
+    pruned by ``prune_unsupported()`` before any file tool ever reaches the
+    model when it's off, which isn't a code bug to chase.
+    """
+    client = agent_rest_client(agent, settings)
+    me = await client.agent_api_identity.get_agent_me()
+    return bool(me.data.feature_flags.get(FeatureFlag.FILE_TRANSFER))
 
 
 class PeerActor:

--- a/tests/e2e/baseline/toolkit/provisioning.py
+++ b/tests/e2e/baseline/toolkit/provisioning.py
@@ -36,7 +36,6 @@ from band_rest import (
 
 from band.agent import Agent
 from band.core.simple_adapter import SimpleAdapter
-from band.runtime.capabilities import FeatureFlag
 
 from tests.e2e.baseline.settings import BaselineSettings
 from tests.e2e.baseline.toolkit.user_ops import UserOps
@@ -136,23 +135,6 @@ def agent_rest_client(
     return AsyncRestClient(api_key=agent.api_key, base_url=settings.endpoints.rest_url)
 
 
-async def file_transfer_enabled(
-    agent: ProvisionedAgent, settings: BaselineSettings
-) -> bool:
-    """Whether the connected deployment has ``ff_file_transfer`` on, per
-    ``agent``'s own ``/me`` response.
-
-    On-prem-only flag, off everywhere on SaaS today (see
-    docs/capability-negotiation.md) -- FILES/image E2E tests check this and
-    skip rather than fail loud, since ``Capability.FILES`` gets silently
-    pruned by ``prune_unsupported()`` before any file tool ever reaches the
-    model when it's off, which isn't a code bug to chase.
-    """
-    client = agent_rest_client(agent, settings)
-    me = await client.agent_api_identity.get_agent_me()
-    return bool(me.data.feature_flags.get(FeatureFlag.FILE_TRANSFER))
-
-
 class PeerActor:
     """Drive a provisioned peer agent — the agent-side twin of ``UserOps``.
 
@@ -204,19 +186,8 @@ class PeerActor:
         """Upload ``body`` as an attachment and post it as this peer; return the
         message id.
 
-        Mirrors AgentTools.send_room_file's own upload call
-        (src/band/runtime/tools.py) -- same headers, same attach-then-message
-        two-step -- since the platform's file-upload endpoint is agent-scoped
-        (Agent API only; there is no user-side upload endpoint), so a live
-        vision-passthrough scenario needs a peer agent to play "someone already
-        shared a file here," not the test's own UserOps driver.
-
-        Raises a clear RuntimeError, not a bare band_rest NotFoundError, on a
-        404: the platform returns the identical 404 both when the room truly
-        doesn't exist and when this deployment simply has ``ff_file_transfer``
-        off (an on-prem-only flag -- see CLAUDE.md's Adapter Feature Flags
-        section) -- AgentTools.send_room_file (runtime/tools.py) makes the
-        same translation for exactly this ambiguity.
+        Uploading is Agent-API-only (there is no ``human_api_files``), so a peer
+        agent — never ``UserOps`` — has to play the uploader.
         """
         try:
             upload = await self._client.agent_api_files.upload_agent_chat_file(
@@ -234,11 +205,9 @@ class PeerActor:
             raise RuntimeError(
                 f"Uploading a file to room {room_id} as peer {self._peer.name} "
                 "got 404 Not Found. Either the room doesn't exist, or this "
-                "Band deployment doesn't have ff_file_transfer enabled (an "
-                "on-prem-only feature flag, off on SaaS today -- see "
-                "CLAUDE.md's Adapter Feature Flags section). A file/image "
-                "E2E test can only pass against a deployment with that flag "
-                "on; see the local-platform-testing skill to stand one up."
+                "deployment has ff_file_transfer off (an on-prem-only flag, "
+                "off on SaaS today) — see the local-platform-testing skill to "
+                "stand up a deployment with it on."
             ) from error
         response = await self._client.agent_api_messages.create_agent_chat_message(
             room_id,

--- a/tests/e2e/baseline/toolkit/provisioning.py
+++ b/tests/e2e/baseline/toolkit/provisioning.py
@@ -31,6 +31,7 @@ from band_rest import (
     AsyncRestClient,
     ChatMessageRequest,
     ChatMessageRequestMentionsItem,
+    NotFoundError,
 )
 
 from band.agent import Agent
@@ -191,18 +192,36 @@ class PeerActor:
         (Agent API only; there is no user-side upload endpoint), so a live
         vision-passthrough scenario needs a peer agent to play "someone already
         shared a file here," not the test's own UserOps driver.
+
+        Raises a clear RuntimeError, not a bare band_rest NotFoundError, on a
+        404: the platform returns the identical 404 both when the room truly
+        doesn't exist and when this deployment simply has ``ff_file_transfer``
+        off (an on-prem-only flag -- see CLAUDE.md's Adapter Feature Flags
+        section) -- AgentTools.send_room_file (runtime/tools.py) makes the
+        same translation for exactly this ambiguity.
         """
-        upload = await self._client.agent_api_files.upload_agent_chat_file(
-            chat_id=room_id,
-            request=body,
-            request_options={
-                "additional_headers": {
-                    "x-file-name": filename,
-                    "x-file-sha256": hashlib.sha256(body).hexdigest(),
-                    "content-type": content_type,
-                }
-            },
-        )
+        try:
+            upload = await self._client.agent_api_files.upload_agent_chat_file(
+                chat_id=room_id,
+                request=body,
+                request_options={
+                    "additional_headers": {
+                        "x-file-name": filename,
+                        "x-file-sha256": hashlib.sha256(body).hexdigest(),
+                        "content-type": content_type,
+                    }
+                },
+            )
+        except NotFoundError as error:
+            raise RuntimeError(
+                f"Uploading a file to room {room_id} as peer {self._peer.name} "
+                "got 404 Not Found. Either the room doesn't exist, or this "
+                "Band deployment doesn't have ff_file_transfer enabled (an "
+                "on-prem-only feature flag, off on SaaS today -- see "
+                "CLAUDE.md's Adapter Feature Flags section). A file/image "
+                "E2E test can only pass against a deployment with that flag "
+                "on; see the local-platform-testing skill to stand one up."
+            ) from error
         response = await self._client.agent_api_messages.create_agent_chat_message(
             room_id,
             message=ChatMessageRequest(

--- a/tests/e2e/baseline/toolkit/provisioning.py
+++ b/tests/e2e/baseline/toolkit/provisioning.py
@@ -12,6 +12,7 @@ recognise its own resources by prefix and never touch a non-test agent.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import uuid
 from collections.abc import AsyncGenerator, Iterator, Sequence
@@ -166,6 +167,50 @@ class PeerActor:
                 mentions=[
                     ChatMessageRequestMentionsItem(id=mention_id, name=mention_name)
                 ],
+            ),
+        )
+        return response.data.id
+
+    async def send_file(
+        self,
+        room_id: str,
+        body: bytes,
+        *,
+        filename: str,
+        content_type: str,
+        caption: str,
+        mention_id: str,
+        mention_name: str,
+    ) -> str:
+        """Upload ``body`` as an attachment and post it as this peer; return the
+        message id.
+
+        Mirrors AgentTools.send_room_file's own upload call
+        (src/band/runtime/tools.py) -- same headers, same attach-then-message
+        two-step -- since the platform's file-upload endpoint is agent-scoped
+        (Agent API only; there is no user-side upload endpoint), so a live
+        vision-passthrough scenario needs a peer agent to play "someone already
+        shared a file here," not the test's own UserOps driver.
+        """
+        upload = await self._client.agent_api_files.upload_agent_chat_file(
+            chat_id=room_id,
+            request=body,
+            request_options={
+                "additional_headers": {
+                    "x-file-name": filename,
+                    "x-file-sha256": hashlib.sha256(body).hexdigest(),
+                    "content-type": content_type,
+                }
+            },
+        )
+        response = await self._client.agent_api_messages.create_agent_chat_message(
+            room_id,
+            message=ChatMessageRequest(
+                content=caption,
+                mentions=[
+                    ChatMessageRequestMentionsItem(id=mention_id, name=mention_name)
+                ],
+                attachment_ids=[upload.data.id],
             ),
         )
         return response.data.id

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -121,7 +121,8 @@ async def pydantic_ai_probe_tools() -> dict[str, Any]:
     from band.core.types import Capability
 
     adapter = PydanticAIAdapter(
-        model="test", capabilities=Capability.CONTACTS | Capability.MEMORY
+        model="test",
+        capabilities=Capability.CONTACTS | Capability.MEMORY | Capability.FILES,
     )
     await adapter.on_started(agent_name="Probe", agent_description="probe")
     return {

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -103,12 +103,16 @@ class AdapterConfig:
 
 
 def _all_capabilities() -> Any:
-    """Every capability, so a probe sees the whole platform tool surface."""
-    from band.core.types import AdapterFeatures, Capability
+    """Every capability, so a probe sees the whole platform tool surface.
 
-    return AdapterFeatures(
-        capabilities={Capability.CONTACTS, Capability.MEMORY},
-    )
+    Reuses the real ``ALL_CAPABILITIES`` constant rather than listing members
+    by name, so a newly added capability is covered here automatically
+    instead of silently sitting outside every probe until someone remembers
+    to add it.
+    """
+    from band.core.types import ALL_CAPABILITIES, AdapterFeatures
+
+    return AdapterFeatures(capabilities=ALL_CAPABILITIES)
 
 
 async def pydantic_ai_probe_tools() -> dict[str, Any]:

--- a/tests/framework_conformance/test_adapter_conformance.py
+++ b/tests/framework_conformance/test_adapter_conformance.py
@@ -324,3 +324,25 @@ class TestImagePassthroughMatrix:
 
     def test_every_exclusion_carries_a_reason(self) -> None:
         assert all(excluded.reason for excluded in IMAGE_PASSTHROUGH_EXCLUSIONS)
+
+    def test_e2e_matrix_list_matches_this_unit_level_set(self) -> None:
+        """IMAGE_PASSTHROUGH_ADAPTERS (the E2E matrix's own adapter list,
+        tests/e2e/baseline/smoke/matrix/test_capability_matrix.py) must stay
+        derived from this set, not hand-maintained separately -- otherwise a
+        future adapter gaining image-passthrough support here could leave
+        the E2E smoke silently never added for it, and CI would stay green
+        while coverage quietly regressed. The two lists differ by design
+        (see the comment above IMAGE_PASSTHROUGH_ADAPTERS): -crewai_flow (no
+        Band tool loop to drive a file round-trip), +copilot_acp and +letta
+        (both share opencode's already-fixed MCP engine, so they're excluded
+        from *this* unit-level set as having no probe of their own, but get
+        a real E2E cell each)."""
+        from tests.e2e.baseline.smoke.matrix.test_capability_matrix import (
+            IMAGE_PASSTHROUGH_ADAPTERS,
+        )
+
+        expected = (
+            IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS - {Adapter.CREWAI_FLOW.value}
+        ) | {Adapter.COPILOT_ACP.value, Adapter.LETTA.value}
+
+        assert {a.value for a in IMAGE_PASSTHROUGH_ADAPTERS} == expected

--- a/tests/framework_conformance/test_adapter_conformance.py
+++ b/tests/framework_conformance/test_adapter_conformance.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import pytest
 
-from band.core.exceptions import BandConfigError
 from band.core.types import Capability
+from tests.baseline.adapter import Adapter
+from tests.e2e.baseline.agents import ExcludedAdapter
 
 
 class TestAdapterConfigIntegrity:
@@ -228,131 +229,98 @@ class TestAdapterFeaturesContract:
         assert adapter.features.capabilities == cls.SUPPORTED_CAPABILITIES
 
 
-# Every adapter used to hand-roll one wrapper function/class per platform
-# tool instead of deriving its tool surface from the central registry
-# (iter_tool_definitions/get_openai_tool_schemas/get_anthropic_tool_schemas).
-# Capability.FILES needed three new hand-written wrappers on each --
-# claude_sdk-style adapters get it generically, but parlant, pydantic_ai, and
-# crewai/crewai_flow (which share integrations/crewai/tools.py) all grew real
-# band_list_room_files/band_read_room_file/band_send_room_file wrappers.
-# Empty now; kept as the seam a genuinely new hand-rolled adapter joins.
-FILES_CAPABILITY_PENDING_FRAMEWORK_IDS: frozenset[str] = frozenset()
-
-
 class TestFilesCapabilityMatrix:
-    """Capability.FILES adoption matrix across every registered adapter.
+    """Every registered adapter accepts Capability.FILES.
 
-    Turns Capability.FILES on for every adapter in ADAPTER_CONFIGS: an
-    adapter not in FILES_CAPABILITY_PENDING_FRAMEWORK_IDS must accept it
-    (schema exposure is generic there -- see the shared registry in
-    band.runtime.tools); one still pending must reject it with
-    BandConfigError until it grows real tool wrappers. Adding a new adapter
-    to ADAPTER_CONFIGS without a decision either way fails this test.
+    Registry-driven adapters get the file tools generically (the shared
+    registry in band.runtime.tools); parlant, pydantic_ai and
+    crewai/crewai_flow hand-roll one wrapper per platform tool and grew real
+    band_list_room_files/band_read_room_file/band_send_room_file wrappers to
+    match. A new adapter that skips that work fails here.
     """
 
-    def test_supports_or_is_pending(self, adapter_config):
-        pending = adapter_config.framework_id in FILES_CAPABILITY_PENDING_FRAMEWORK_IDS
-        if pending:
-            with pytest.raises(BandConfigError):
-                adapter_config.adapter_factory(capabilities=Capability.FILES)
-        else:
-            adapter = adapter_config.adapter_factory(capabilities=Capability.FILES)
-            assert Capability.FILES in adapter.features.capabilities
+    def test_accepts_files_capability(self, adapter_config):
+        adapter = adapter_config.adapter_factory(capabilities=Capability.FILES)
+
+        assert Capability.FILES in adapter.features.capabilities
 
 
-# Of the adapters that support Capability.FILES at all (i.e. NOT in
-# FILES_CAPABILITY_PENDING_FRAMEWORK_IDS above), only these have been verified
-# end-to-end to pass an image band_read_room_file result through as real MCP
-# vision/image content instead of degrading it to a json.dumps'd text block:
-# - claude_sdk: tests/integrations/claude_sdk/test_tools.py
-#   (_is_mcp_content_result / _make_result passthrough)
-# - anthropic: tests/adapters/test_anthropic_adapter.py
-#   (_image_tool_result_content, real Anthropic ImageBlockParam content)
-# - opencode: shares the MCP engine's fix (band.integrations.mcp.engine
-#   is_mcp_content_result / _mcp_content_blocks), verified in
-#   tests/mcp/test_engine.py -- the ACP client adapter and the published
-#   band-mcp CLI share the same engine fix but are not adapters in
-#   ADAPTER_CONFIGS, so they don't get their own row here.
-# - gemini: tests/adapters/test_gemini_adapter.py (TestReadRoomFileImagePassthrough,
-#   real google.genai FunctionResponsePart/FunctionResponseBlob inline_data content).
-#   google_adk is NOT here despite sharing google.genai types: google-adk 1.10.0's
-#   own __build_response_event() calls Part.from_function_response() without a
-#   parts= kwarg, so no tool return value can reach a multimodal FunctionResponse
-#   through ADK's normal flow -- a framework limitation, not an adapter gap.
-# - langgraph: tests/integrations/langgraph/test_langchain_tools.py (real
-#   langchain_core ImageContentBlock, {"type": "image", "mime_type", "base64"}).
-# - agno: tests/adapters/agno/test_adapter.py::TestBandEntrypointBinding (real
-#   agno.tools.function.ToolResult(images=[agno.media.Image(...)])).
-# - strands: tests/adapters/test_strands_adapter.py::TestReadRoomFileImagePassthrough
-#   (real strands.types.tools.ToolResultContent image block, Bedrock-native shape).
-# - copilot_sdk: tests/adapters/copilot_sdk/test_tool_bridging.py::
-#   TestReadRoomFileImagePassthrough (real copilot.tools.ToolBinaryResult via
-#   ToolResult.binary_results_for_llm, the SDK's own MCP-image-result shape).
-# - codex: tests/adapters/test_codex_adapter.py::TestReadRoomFileImagePassthrough
-#   (real DynamicToolCallOutputContentItem "inputImage" variant, verified from the
-#   installed codex-cli's own generated JSON schema). One caveat: imageUrl carries
-#   a data: URI -- whether the Rust-side codex-rs binary actually accepts a data:
-#   URI (vs. only fetching http(s)) isn't verifiable from this repo's installed
-#   Python packages, so this is wire-shape-verified, not live-behavior-confirmed.
-# - pydantic_ai: tests/adapters/test_pydantic_ai_adapter.py::TestFileTools
-#   (real pydantic_ai.messages.BinaryContent(data=bytes, media_type=str),
-#   returned directly from the tool -- pydantic-ai's own documented
-#   multimodal-tool-result channel, ToolReturnPart.content).
-# - crewai / crewai_flow: tests/integrations/test_crewai_tools.py::TestFileTools
-#   (CrewAI's own "VISION_IMAGE:<media_type>:<base64_data>" sentinel string,
-#   parsed by StepExecutor._execute_native_tool_calls -- the default
-#   native-tool-calling execution path -- into a real image_url content block
-#   before the LLM sees it; verified against the installed crewai package,
-#   not documented publicly). Both adapters share integrations/crewai/tools.py,
-#   so one fix (vision_sentinel()) covers both.
-# google_adk stays out for the reason above. letta needs no adapter-side row: it
-# routes tool execution entirely through the already-fixed MCP engine (it never
-# calls execute_tool_call), so the image fix is already live for it via the
-# opencode/ACP-client row -- the one unverifiable hop is Letta's own backend
-# turning an MCP ImageContent into its ToolReturn.tool_return image part, which
-# isn't observable from the installed letta_client package. parlant stays out:
-# verified that parlant.core.tools.ToolResult has no multimodal field, and
-# Parlant's own MCP integration (mcp_result_to_tool_result_data()) discards
-# image content blocks before they ever reach ToolResult.data -- a confirmed
-# framework limitation, not an adapter gap.
-IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS = frozenset(
-    {
-        "claude_sdk",
-        "anthropic",
-        "opencode",
-        "gemini",
-        "langgraph",
-        "agno",
-        "strands",
-        "copilot_sdk",
-        "codex",
-        "pydantic_ai",
-        "crewai",
-        "crewai_flow",
-    }
+# Image passthrough (a band_read_room_file image result reaching the model as
+# real vision content, not a json.dumps'd text block) is the default
+# expectation; these are the adapters that deliberately don't have it, and
+# why. Stating the exceptions rather than the 12 that comply means a newly
+# registered adapter is expected to comply, and the probe-registry guard in
+# test_files_image_passthrough_matrix fails loudly until it does.
+#
+# Two distinct kinds of exception, deliberately not flattened together:
+#   - a framework that *cannot* carry image content at all, and
+#   - one that gets passthrough elsewhere, so has no adapter-local path to probe.
+IMAGE_PASSTHROUGH_EXCLUSIONS = (
+    ExcludedAdapter(
+        Adapter.GOOGLE_ADK,
+        "google-adk's own __build_response_event() calls "
+        "Part.from_function_response() without a parts= kwarg, so no tool "
+        "return value can reach a multimodal FunctionResponse -- a framework "
+        "limitation, not an adapter gap",
+    ),
+    ExcludedAdapter(
+        Adapter.LETTA,
+        "routes tool execution through the shared MCP engine rather than "
+        "execute_tool_call, so it inherits opencode's fix and has no "
+        "adapter-local path to probe",
+    ),
+    ExcludedAdapter(
+        Adapter.COPILOT_ACP,
+        "wraps the ACP client adapter, which shares the same MCP engine fix; "
+        "not a separate ADAPTER_CONFIGS entry, so it has no probe of its own",
+    ),
 )
+
+# parlant is absent from the Adapter enum entirely (NON_AGENT_ADAPTERS), so it
+# can't be listed above -- but it is equally unsupportable:
+# parlant.core.tools.ToolResult has no multimodal field, and Parlant's own MCP
+# integration (mcp_result_to_tool_result_data()) discards image content blocks
+# before they ever reach ToolResult.data.
+#
+# Derived from the Adapter enum, not ADAPTER_CONFIGS: the enum is a plain
+# StrEnum that every lane sees identically, while ADAPTER_CONFIGS silently
+# drops configs whose framework isn't installed (9 of 15 under dev-crewai /
+# dev-parlant), which would make this constant mean different things per lane.
+IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS = frozenset(
+    adapter.value for adapter in Adapter
+) - {excluded.adapter.value for excluded in IMAGE_PASSTHROUGH_EXCLUSIONS}
+
+# Where each supported adapter's behavioural proof lives. The mechanism differs
+# per framework, so it can't be exercised generically through ADAPTER_CONFIGS --
+# test_files_image_passthrough_matrix drives one probe per adapter instead.
+#   claude_sdk    tests/integrations/claude_sdk/test_tools.py (MCP passthrough)
+#   anthropic     test_anthropic_adapter.py (ImageBlockParam)
+#   opencode      tests/mcp/test_engine.py (the shared MCP engine's ImageContent)
+#   gemini        test_gemini_adapter.py (FunctionResponseBlob inline_data)
+#   langgraph     test_langchain_tools.py (langchain_core ImageContentBlock)
+#   agno          tests/adapters/agno/test_adapter.py (agno.media.Image)
+#   strands       test_strands_adapter.py (ToolResultContent image block)
+#   copilot_sdk   copilot_sdk/test_tool_bridging.py (ToolBinaryResult)
+#   codex         test_codex_adapter.py ("inputImage" content item -- wire-shape
+#                 verified against codex-cli's generated schema; whether
+#                 codex-rs accepts the data: URI isn't checkable from Python)
+#   pydantic_ai   test_pydantic_ai_adapter.py (messages.BinaryContent)
+#   crewai(_flow) test_crewai_tools.py (CrewAI's VISION_IMAGE: sentinel, parsed
+#                 by StepExecutor; both adapters share one vision_sentinel())
 
 
 class TestImagePassthroughMatrix:
-    """Registry-consistency guard for IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS.
+    """Registry-consistency guard for the image-passthrough expectation.
 
-    The real behavioral proof for each entry lives in that framework's own
-    test file (cited above), since the passthrough mechanism differs per
-    adapter (Anthropic's ImageBlockParam vs. the MCP engine's ImageContent)
-    and can't be exercised generically through ADAPTER_CONFIGS. This matrix
-    instead guards the *bookkeeping*: every listed framework_id must be a
-    real registered adapter, and none of them may also be on the
-    Capability.FILES pending list -- a framework can't have verified image
-    passthrough for a capability it doesn't even support.
+    Guards the bookkeeping only -- that every adapter expected to support
+    image passthrough is a real registered adapter. The behavioural proof
+    lives in the per-framework probes (see the citations above).
     """
 
-    def test_every_entry_actually_supports_files(self) -> None:
-        assert IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS.isdisjoint(
-            FILES_CAPABILITY_PENDING_FRAMEWORK_IDS
-        )
+    def test_every_supported_id_is_a_registered_adapter(self) -> None:
+        known_ids = {adapter.value for adapter in Adapter}
 
-    def test_every_entry_is_a_registered_adapter(self) -> None:
-        from tests.framework_configs.adapters import ADAPTER_CONFIGS
-
-        known_ids = {config.framework_id for config in ADAPTER_CONFIGS}
         assert IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS <= known_ids
+
+    def test_every_exclusion_carries_a_reason(self) -> None:
+        assert all(excluded.reason for excluded in IMAGE_PASSTHROUGH_EXCLUSIONS)

--- a/tests/framework_conformance/test_adapter_conformance.py
+++ b/tests/framework_conformance/test_adapter_conformance.py
@@ -261,3 +261,51 @@ class TestFilesCapabilityMatrix:
         else:
             adapter = adapter_config.adapter_factory(capabilities=Capability.FILES)
             assert Capability.FILES in adapter.features.capabilities
+
+
+# Of the adapters that support Capability.FILES at all (i.e. NOT in
+# FILES_CAPABILITY_PENDING_FRAMEWORK_IDS above), only these have been verified
+# end-to-end to pass an image band_read_room_file result through as real MCP
+# vision/image content instead of degrading it to a json.dumps'd text block:
+# - claude_sdk: tests/integrations/claude_sdk/test_tools.py
+#   (_is_mcp_content_result / _make_result passthrough)
+# - anthropic: tests/adapters/test_anthropic_adapter.py
+#   (_image_tool_result_content, real Anthropic ImageBlockParam content)
+# - opencode: shares the MCP engine's fix (band.integrations.mcp.engine
+#   is_mcp_content_result / _mcp_content_blocks), verified in
+#   tests/mcp/test_engine.py -- the ACP client adapter and the published
+#   band-mcp CLI share the same engine fix but are not adapters in
+#   ADAPTER_CONFIGS, so they don't get their own row here.
+# Every other Capability.FILES adapter (langgraph, gemini, google_adk, agno,
+# strands, codex, copilot_sdk) still degrades an image to text -- verifying
+# and fixing each one is real per-SDK research, tracked as follow-up, not yet
+# done. Add a framework_id here only once it has a real passthrough test like
+# the ones cited above.
+IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS = frozenset(
+    {"claude_sdk", "anthropic", "opencode"}
+)
+
+
+class TestImagePassthroughMatrix:
+    """Registry-consistency guard for IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS.
+
+    The real behavioral proof for each entry lives in that framework's own
+    test file (cited above), since the passthrough mechanism differs per
+    adapter (Anthropic's ImageBlockParam vs. the MCP engine's ImageContent)
+    and can't be exercised generically through ADAPTER_CONFIGS. This matrix
+    instead guards the *bookkeeping*: every listed framework_id must be a
+    real registered adapter, and none of them may also be on the
+    Capability.FILES pending list -- a framework can't have verified image
+    passthrough for a capability it doesn't even support.
+    """
+
+    def test_every_entry_actually_supports_files(self) -> None:
+        assert IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS.isdisjoint(
+            FILES_CAPABILITY_PENDING_FRAMEWORK_IDS
+        )
+
+    def test_every_entry_is_a_registered_adapter(self) -> None:
+        from tests.framework_configs.adapters import ADAPTER_CONFIGS
+
+        known_ids = {config.framework_id for config in ADAPTER_CONFIGS}
+        assert IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS <= known_ids

--- a/tests/framework_conformance/test_adapter_conformance.py
+++ b/tests/framework_conformance/test_adapter_conformance.py
@@ -276,13 +276,19 @@ class TestFilesCapabilityMatrix:
 #   tests/mcp/test_engine.py -- the ACP client adapter and the published
 #   band-mcp CLI share the same engine fix but are not adapters in
 #   ADAPTER_CONFIGS, so they don't get their own row here.
-# Every other Capability.FILES adapter (langgraph, gemini, google_adk, agno,
-# strands, codex, copilot_sdk) still degrades an image to text -- verifying
-# and fixing each one is real per-SDK research, tracked as follow-up, not yet
-# done. Add a framework_id here only once it has a real passthrough test like
-# the ones cited above.
+# - gemini: tests/adapters/test_gemini_adapter.py (TestReadRoomFileImagePassthrough,
+#   real google.genai FunctionResponsePart/FunctionResponseBlob inline_data content).
+#   google_adk is NOT here despite sharing google.genai types: google-adk 1.10.0's
+#   own __build_response_event() calls Part.from_function_response() without a
+#   parts= kwarg, so no tool return value can reach a multimodal FunctionResponse
+#   through ADK's normal flow -- a framework limitation, not an adapter gap.
+# Every other Capability.FILES adapter (langgraph, google_adk, agno, strands,
+# codex, copilot_sdk) still degrades an image to text -- verifying and fixing
+# each one is real per-SDK research, tracked as follow-up, not yet done. Add a
+# framework_id here only once it has a real passthrough test like the ones
+# cited above.
 IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS = frozenset(
-    {"claude_sdk", "anthropic", "opencode"}
+    {"claude_sdk", "anthropic", "opencode", "gemini"}
 )
 
 

--- a/tests/framework_conformance/test_adapter_conformance.py
+++ b/tests/framework_conformance/test_adapter_conformance.py
@@ -282,13 +282,39 @@ class TestFilesCapabilityMatrix:
 #   own __build_response_event() calls Part.from_function_response() without a
 #   parts= kwarg, so no tool return value can reach a multimodal FunctionResponse
 #   through ADK's normal flow -- a framework limitation, not an adapter gap.
-# Every other Capability.FILES adapter (langgraph, google_adk, agno, strands,
-# codex, copilot_sdk) still degrades an image to text -- verifying and fixing
-# each one is real per-SDK research, tracked as follow-up, not yet done. Add a
-# framework_id here only once it has a real passthrough test like the ones
-# cited above.
+# - langgraph: tests/integrations/langgraph/test_langchain_tools.py (real
+#   langchain_core ImageContentBlock, {"type": "image", "mime_type", "base64"}).
+# - agno: tests/adapters/agno/test_adapter.py::TestBandEntrypointBinding (real
+#   agno.tools.function.ToolResult(images=[agno.media.Image(...)])).
+# - strands: tests/adapters/test_strands_adapter.py::TestReadRoomFileImagePassthrough
+#   (real strands.types.tools.ToolResultContent image block, Bedrock-native shape).
+# - copilot_sdk: tests/adapters/copilot_sdk/test_tool_bridging.py::
+#   TestReadRoomFileImagePassthrough (real copilot.tools.ToolBinaryResult via
+#   ToolResult.binary_results_for_llm, the SDK's own MCP-image-result shape).
+# - codex: tests/adapters/test_codex_adapter.py::TestReadRoomFileImagePassthrough
+#   (real DynamicToolCallOutputContentItem "inputImage" variant, verified from the
+#   installed codex-cli's own generated JSON schema). One caveat: imageUrl carries
+#   a data: URI -- whether the Rust-side codex-rs binary actually accepts a data:
+#   URI (vs. only fetching http(s)) isn't verifiable from this repo's installed
+#   Python packages, so this is wire-shape-verified, not live-behavior-confirmed.
+# google_adk stays out for the reason above. letta needs no adapter-side row: it
+# routes tool execution entirely through the already-fixed MCP engine (it never
+# calls execute_tool_call), so the image fix is already live for it via the
+# opencode/ACP-client row -- the one unverifiable hop is Letta's own backend
+# turning an MCP ImageContent into its ToolReturn.tool_return image part, which
+# isn't observable from the installed letta_client package.
 IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS = frozenset(
-    {"claude_sdk", "anthropic", "opencode", "gemini"}
+    {
+        "claude_sdk",
+        "anthropic",
+        "opencode",
+        "gemini",
+        "langgraph",
+        "agno",
+        "strands",
+        "copilot_sdk",
+        "codex",
+    }
 )
 
 

--- a/tests/framework_conformance/test_adapter_conformance.py
+++ b/tests/framework_conformance/test_adapter_conformance.py
@@ -226,16 +226,15 @@ class TestAdapterFeaturesContract:
         assert adapter.features.capabilities == cls.SUPPORTED_CAPABILITIES
 
 
-# Adapters that still hand-roll one wrapper function/class per platform tool
-# (CrewAI's BaseTool subclasses) instead of deriving their tool surface from
-# the central registry (iter_tool_definitions/get_openai_tool_schemas/
-# get_anthropic_tool_schemas). Capability.FILES needs three new hand-written
-# wrappers there, not just a capability declaration -- not yet done. Parlant
-# and pydantic_ai each grew their own three hand-written wrappers
-# (band_list_room_files/band_read_room_file/band_send_room_file, in
-# integrations/parlant/tools.py and adapters/pydantic_ai.py respectively) and
-# are no longer pending. Remove a framework_id here once it grows the same.
-FILES_CAPABILITY_PENDING_FRAMEWORK_IDS = frozenset({"crewai", "crewai_flow"})
+# Every adapter used to hand-roll one wrapper function/class per platform
+# tool instead of deriving its tool surface from the central registry
+# (iter_tool_definitions/get_openai_tool_schemas/get_anthropic_tool_schemas).
+# Capability.FILES needed three new hand-written wrappers on each --
+# claude_sdk-style adapters get it generically, but parlant, pydantic_ai, and
+# crewai/crewai_flow (which share integrations/crewai/tools.py) all grew real
+# band_list_room_files/band_read_room_file/band_send_room_file wrappers.
+# Empty now; kept as the seam a genuinely new hand-rolled adapter joins.
+FILES_CAPABILITY_PENDING_FRAMEWORK_IDS: frozenset[str] = frozenset()
 
 
 class TestFilesCapabilityMatrix:

--- a/tests/framework_conformance/test_adapter_conformance.py
+++ b/tests/framework_conformance/test_adapter_conformance.py
@@ -227,17 +227,15 @@ class TestAdapterFeaturesContract:
 
 
 # Adapters that still hand-roll one wrapper function/class per platform tool
-# (CrewAI's BaseTool subclasses, PydanticAI's @platform_tool functions)
-# instead of deriving their tool surface from the central registry
-# (iter_tool_definitions/get_openai_tool_schemas/get_anthropic_tool_schemas).
-# Capability.FILES needs three new hand-written wrappers there, not just a
-# capability declaration -- not yet done. Parlant grew its own three
-# hand-written wrappers (band_list_room_files/band_read_room_file/
-# band_send_room_file in integrations/parlant/tools.py) and is no longer
-# pending. Remove a framework_id here once it grows the same.
-FILES_CAPABILITY_PENDING_FRAMEWORK_IDS = frozenset(
-    {"crewai", "crewai_flow", "pydantic_ai"}
-)
+# (CrewAI's BaseTool subclasses) instead of deriving their tool surface from
+# the central registry (iter_tool_definitions/get_openai_tool_schemas/
+# get_anthropic_tool_schemas). Capability.FILES needs three new hand-written
+# wrappers there, not just a capability declaration -- not yet done. Parlant
+# and pydantic_ai each grew their own three hand-written wrappers
+# (band_list_room_files/band_read_room_file/band_send_room_file, in
+# integrations/parlant/tools.py and adapters/pydantic_ai.py respectively) and
+# are no longer pending. Remove a framework_id here once it grows the same.
+FILES_CAPABILITY_PENDING_FRAMEWORK_IDS = frozenset({"crewai", "crewai_flow"})
 
 
 class TestFilesCapabilityMatrix:

--- a/tests/framework_conformance/test_adapter_conformance.py
+++ b/tests/framework_conformance/test_adapter_conformance.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 import pytest
 
+from band.core.exceptions import BandConfigError
+from band.core.types import Capability
+
 
 class TestAdapterConfigIntegrity:
     """Validate that AdapterConfig registries stay in sync with adapter source."""
@@ -182,7 +185,6 @@ class TestAdapterFeaturesContract:
 
     def test_supported_capabilities_declared(self, adapter_config):
         """Every adapter class must define SUPPORTED_CAPABILITIES as a frozenset."""
-        from band.core.types import Capability
 
         adapter = adapter_config.adapter_factory()
         cls = type(adapter)
@@ -249,9 +251,6 @@ class TestFilesCapabilityMatrix:
     """
 
     def test_supports_or_is_pending(self, adapter_config):
-        from band.core.exceptions import BandConfigError
-        from band.core.types import Capability
-
         pending = adapter_config.framework_id in FILES_CAPABILITY_PENDING_FRAMEWORK_IDS
         if pending:
             with pytest.raises(BandConfigError):

--- a/tests/framework_conformance/test_adapter_conformance.py
+++ b/tests/framework_conformance/test_adapter_conformance.py
@@ -295,12 +295,27 @@ class TestFilesCapabilityMatrix:
 #   a data: URI -- whether the Rust-side codex-rs binary actually accepts a data:
 #   URI (vs. only fetching http(s)) isn't verifiable from this repo's installed
 #   Python packages, so this is wire-shape-verified, not live-behavior-confirmed.
+# - pydantic_ai: tests/adapters/test_pydantic_ai_adapter.py::TestFileTools
+#   (real pydantic_ai.messages.BinaryContent(data=bytes, media_type=str),
+#   returned directly from the tool -- pydantic-ai's own documented
+#   multimodal-tool-result channel, ToolReturnPart.content).
+# - crewai / crewai_flow: tests/integrations/test_crewai_tools.py::TestFileTools
+#   (CrewAI's own "VISION_IMAGE:<media_type>:<base64_data>" sentinel string,
+#   parsed by StepExecutor._execute_native_tool_calls -- the default
+#   native-tool-calling execution path -- into a real image_url content block
+#   before the LLM sees it; verified against the installed crewai package,
+#   not documented publicly). Both adapters share integrations/crewai/tools.py,
+#   so one fix (vision_sentinel()) covers both.
 # google_adk stays out for the reason above. letta needs no adapter-side row: it
 # routes tool execution entirely through the already-fixed MCP engine (it never
 # calls execute_tool_call), so the image fix is already live for it via the
 # opencode/ACP-client row -- the one unverifiable hop is Letta's own backend
 # turning an MCP ImageContent into its ToolReturn.tool_return image part, which
-# isn't observable from the installed letta_client package.
+# isn't observable from the installed letta_client package. parlant stays out:
+# verified that parlant.core.tools.ToolResult has no multimodal field, and
+# Parlant's own MCP integration (mcp_result_to_tool_result_data()) discards
+# image content blocks before they ever reach ToolResult.data -- a confirmed
+# framework limitation, not an adapter gap.
 IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS = frozenset(
     {
         "claude_sdk",
@@ -312,6 +327,9 @@ IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS = frozenset(
         "strands",
         "copilot_sdk",
         "codex",
+        "pydantic_ai",
+        "crewai",
+        "crewai_flow",
     }
 )
 

--- a/tests/framework_conformance/test_adapter_conformance.py
+++ b/tests/framework_conformance/test_adapter_conformance.py
@@ -212,3 +212,52 @@ class TestAdapterFeaturesContract:
         """Omitting emit= narrates everything the adapter declares support for."""
         adapter = adapter_config.adapter_factory()
         assert adapter.features.emit == type(adapter).SUPPORTED_EMIT
+
+    def test_declared_capabilities_accepted_at_construction(self, adapter_config):
+        """Every capability an adapter claims via SUPPORTED_CAPABILITIES must
+        actually be accepted, not just listed -- guards against a stale
+        SUPPORTED_CAPABILITIES entry whose wiring to the schema-building call
+        site was removed or never passed self.features.capabilities through.
+        """
+        cls = adapter_config.adapter_factory().__class__
+        adapter = adapter_config.adapter_factory(
+            capabilities=cls.SUPPORTED_CAPABILITIES
+        )
+        assert adapter.features.capabilities == cls.SUPPORTED_CAPABILITIES
+
+
+# Adapters that still hand-roll one wrapper function/class per platform tool
+# (CrewAI's BaseTool subclasses, PydanticAI's @platform_tool functions,
+# Parlant's @band_tool functions) instead of deriving their tool surface from
+# the central registry (iter_tool_definitions/get_openai_tool_schemas/
+# get_anthropic_tool_schemas). Capability.FILES needs three new hand-written
+# wrappers there, not just a capability declaration -- not yet done. Remove a
+# framework_id here once it grows real band_list_room_files/band_read_room_file/
+# band_send_room_file wrappers.
+FILES_CAPABILITY_PENDING_FRAMEWORK_IDS = frozenset(
+    {"crewai", "crewai_flow", "pydantic_ai", "parlant"}
+)
+
+
+class TestFilesCapabilityMatrix:
+    """Capability.FILES adoption matrix across every registered adapter.
+
+    Turns Capability.FILES on for every adapter in ADAPTER_CONFIGS: an
+    adapter not in FILES_CAPABILITY_PENDING_FRAMEWORK_IDS must accept it
+    (schema exposure is generic there -- see the shared registry in
+    band.runtime.tools); one still pending must reject it with
+    BandConfigError until it grows real tool wrappers. Adding a new adapter
+    to ADAPTER_CONFIGS without a decision either way fails this test.
+    """
+
+    def test_supports_or_is_pending(self, adapter_config):
+        from band.core.exceptions import BandConfigError
+        from band.core.types import Capability
+
+        pending = adapter_config.framework_id in FILES_CAPABILITY_PENDING_FRAMEWORK_IDS
+        if pending:
+            with pytest.raises(BandConfigError):
+                adapter_config.adapter_factory(capabilities=Capability.FILES)
+        else:
+            adapter = adapter_config.adapter_factory(capabilities=Capability.FILES)
+            assert Capability.FILES in adapter.features.capabilities

--- a/tests/framework_conformance/test_adapter_conformance.py
+++ b/tests/framework_conformance/test_adapter_conformance.py
@@ -227,15 +227,16 @@ class TestAdapterFeaturesContract:
 
 
 # Adapters that still hand-roll one wrapper function/class per platform tool
-# (CrewAI's BaseTool subclasses, PydanticAI's @platform_tool functions,
-# Parlant's @band_tool functions) instead of deriving their tool surface from
-# the central registry (iter_tool_definitions/get_openai_tool_schemas/
-# get_anthropic_tool_schemas). Capability.FILES needs three new hand-written
-# wrappers there, not just a capability declaration -- not yet done. Remove a
-# framework_id here once it grows real band_list_room_files/band_read_room_file/
-# band_send_room_file wrappers.
+# (CrewAI's BaseTool subclasses, PydanticAI's @platform_tool functions)
+# instead of deriving their tool surface from the central registry
+# (iter_tool_definitions/get_openai_tool_schemas/get_anthropic_tool_schemas).
+# Capability.FILES needs three new hand-written wrappers there, not just a
+# capability declaration -- not yet done. Parlant grew its own three
+# hand-written wrappers (band_list_room_files/band_read_room_file/
+# band_send_room_file in integrations/parlant/tools.py) and is no longer
+# pending. Remove a framework_id here once it grows the same.
 FILES_CAPABILITY_PENDING_FRAMEWORK_IDS = frozenset(
-    {"crewai", "crewai_flow", "pydantic_ai", "parlant"}
+    {"crewai", "crewai_flow", "pydantic_ai"}
 )
 
 

--- a/tests/framework_conformance/test_crewai_job_coverage.py
+++ b/tests/framework_conformance/test_crewai_job_coverage.py
@@ -59,8 +59,10 @@ def test_crewai_only_dependency_set_matches_pyproject() -> None:
 def test_detection_finds_the_tests_that_only_the_crewai_venv_can_run() -> None:
     """Guard the guard: if the pattern drifts, the tests above pass empty.
 
-    These are the whole set today — `phase3` for its nest_asyncio cases, the rest
-    for importing crewai itself.
+    These are the whole set today — `phase3` for its nest_asyncio cases,
+    `test_files_image_passthrough_matrix.py` for its guarded `import crewai`
+    (real-package probe, `_CREWAI_AVAILABLE` skip elsewhere), the rest for
+    importing crewai itself.
     """
     pattern = vjc.needs_venv_pattern(frozenset(_CREWAI_ONLY_MODULES.values()))
     needed = vjc.tests_needing_venv(pattern)
@@ -69,6 +71,7 @@ def test_detection_finds_the_tests_that_only_the_crewai_venv_can_run() -> None:
         Path("tests/integrations/test_crewai_flow_real_sdk.py"),
         Path("tests/integrations/test_crewai_real_tools.py"),
         Path("tests/test_capability_gating_e2e.py"),
+        Path("tests/framework_conformance/test_files_image_passthrough_matrix.py"),
     }
 
 

--- a/tests/framework_conformance/test_files_image_passthrough_matrix.py
+++ b/tests/framework_conformance/test_files_image_passthrough_matrix.py
@@ -20,12 +20,14 @@ fails loudly if the two ever name different frameworks.
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+import base64
+from collections.abc import Awaitable, Callable, Iterable
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
-from band.runtime.tools import TOOL_DEFINITIONS
+from band.runtime.tools import READ_ROOM_FILE_TOOL_NAME, TOOL_DEFINITIONS
 from tests.framework_conformance.test_adapter_conformance import (
     IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS,
 )
@@ -59,6 +61,29 @@ _IMAGE_RESULT: dict[str, Any] = {
     "content": [{"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}]
 }
 
+# Derived, never re-typed: a probe asserting on a hand-written "ZmFrZQ==" would
+# still pass if _IMAGE_RESULT changed underneath it.
+_EXPECTED_BASE64: str = _IMAGE_RESULT["content"][0]["data"]
+_EXPECTED_MIME_TYPE: str = _IMAGE_RESULT["content"][0]["mimeType"]
+_EXPECTED_BYTES: bytes = base64.b64decode(_EXPECTED_BASE64)
+
+
+def _is_expected_image(data: bytes | str, mime_type: str) -> bool:
+    """Whether a framework's outgoing image block carries the probe's image.
+
+    ``data`` is whichever encoding that framework's SDK uses -- raw bytes
+    (gemini, agno, pydantic_ai) or the base64 string as-is (anthropic,
+    opencode, copilot_sdk) -- so each probe passes what it found without
+    first normalising it.
+    """
+    expected = _EXPECTED_BYTES if isinstance(data, bytes) else _EXPECTED_BASE64
+    return data == expected and mime_type == _EXPECTED_MIME_TYPE
+
+
+def _tool_named(tools: Iterable[Any], name: str) -> Any:
+    """The one tool a framework built for ``name``."""
+    return next(tool for tool in tools if tool.name == name)
+
 
 class _StubReadRoomFileTools:
     """Minimal AgentToolsProtocol double whose read_room_file/execute_tool_call
@@ -81,11 +106,11 @@ async def _probe_claude_sdk() -> bool:
     from band.integrations.claude_sdk.tools import build_band_sdk_tools
 
     sdk_tools = build_band_sdk_tools(
-        tool_definitions=[TOOL_DEFINITIONS["band_read_room_file"]],
+        tool_definitions=[TOOL_DEFINITIONS[READ_ROOM_FILE_TOOL_NAME]],
         get_tools=lambda _room_id: _StubReadRoomFileTools(),
         include_room_id=False,
     )
-    handler = next(t for t in sdk_tools if t.name == "band_read_room_file").handler
+    handler = _tool_named(sdk_tools, READ_ROOM_FILE_TOOL_NAME).handler
 
     result = await handler({"file_id": "file-1"})
 
@@ -107,7 +132,7 @@ async def _probe_anthropic() -> bool:
         ToolUseBlock(
             type="tool_use",
             id="tool-1",
-            name="band_read_room_file",
+            name=READ_ROOM_FILE_TOOL_NAME,
             input={"file_id": "file-1"},
         )
     ]
@@ -115,11 +140,11 @@ async def _probe_anthropic() -> bool:
     results = await adapter._process_tool_calls(response, tools)
 
     content = results[0]["content"]
-    return (
-        isinstance(content, list)
-        and len(content) == 1
-        and content[0]["type"] == "image"
-        and content[0]["source"]["data"] == "ZmFrZQ=="
+    if not isinstance(content, list) or len(content) != 1:
+        return False
+    block = content[0]
+    return block["type"] == "image" and _is_expected_image(
+        block["source"]["data"], block["source"]["media_type"]
     )
 
 
@@ -135,7 +160,7 @@ async def _probe_opencode() -> bool:
     )
 
     resolver = EmbeddedResolver(get_tools=lambda _chat_id: _StubReadRoomFileTools())
-    definition = TOOL_DEFINITIONS["band_read_room_file"]
+    definition = TOOL_DEFINITIONS[READ_ROOM_FILE_TOOL_NAME]
     registration = build_tool_registration(
         definition,
         extend_with_chat_id(definition.input_model, None),
@@ -146,15 +171,13 @@ async def _probe_opencode() -> bool:
 
     async with create_connected_server_and_client_session(mcp) as session:
         result = await session.call_tool(
-            "band_read_room_file", {"chat_id": "room-1", "file_id": "file-1"}
+            READ_ROOM_FILE_TOOL_NAME, {"chat_id": "room-1", "file_id": "file-1"}
         )
 
-    return (
-        not result.isError
-        and len(result.content) == 1
-        and result.content[0].type == "image"
-        and result.content[0].data == "ZmFrZQ=="
-    )
+    if result.isError or len(result.content) != 1:
+        return False
+    block = result.content[0]
+    return block.type == "image" and _is_expected_image(block.data, block.mimeType)
 
 
 async def _probe_gemini() -> bool:
@@ -169,7 +192,7 @@ async def _probe_gemini() -> bool:
     tools.execute_tool_call = AsyncMock(return_value=_IMAGE_RESULT)
     function_calls = [
         types.FunctionCall(
-            name="band_read_room_file", args={"file_id": "file-1"}, id="c1"
+            name=READ_ROOM_FILE_TOOL_NAME, args={"file_id": "file-1"}, id="c1"
         )
     ]
 
@@ -179,10 +202,8 @@ async def _probe_gemini() -> bool:
     if function_response is None or not function_response.parts:
         return False
     inline_data = function_response.parts[0].inline_data
-    return (
-        inline_data is not None
-        and inline_data.mime_type == "image/png"
-        and inline_data.data == b"fake"
+    return inline_data is not None and _is_expected_image(
+        inline_data.data, inline_data.mime_type
     )
 
 
@@ -203,9 +224,14 @@ async def _probe_langgraph() -> bool:
         )
     }
 
-    result = await wrapped["band_read_room_file"].ainvoke({"file_id": "file-1"})
+    result = await wrapped[READ_ROOM_FILE_TOOL_NAME].ainvoke({"file_id": "file-1"})
 
-    return result == [{"type": "image", "mime_type": "image/png", "base64": "ZmFrZQ=="}]
+    if not isinstance(result, list) or len(result) != 1:
+        return False
+    block = result[0]
+    return block["type"] == "image" and _is_expected_image(
+        block["base64"], block["mime_type"]
+    )
 
 
 async def _probe_agno() -> bool:
@@ -213,28 +239,29 @@ async def _probe_agno() -> bool:
 
     from band.adapters.agno import _bind_room_tools, _make_band_entrypoint
 
-    entry = _make_band_entrypoint("band_read_room_file")
+    entry = _make_band_entrypoint(READ_ROOM_FILE_TOOL_NAME)
     with _bind_room_tools(_StubReadRoomFileTools()):
         result = await entry(file_id="file-1")
 
-    return (
-        isinstance(result, ToolResult)
-        and result.images is not None
-        and len(result.images) == 1
-        and result.images[0].content == b"fake"
-        and result.images[0].mime_type == "image/png"
+    if not isinstance(result, ToolResult) or not result.images:
+        return False
+    image = result.images[0]
+    return len(result.images) == 1 and _is_expected_image(
+        image.content, image.mime_type
     )
 
 
 async def _probe_strands() -> bool:
     from band.adapters.strands import _tool_result
 
-    tool_use = {"toolUseId": "t1", "name": "band_read_room_file", "input": {}}
+    tool_use = {"toolUseId": "t1", "name": READ_ROOM_FILE_TOOL_NAME, "input": {}}
 
     result = _tool_result(tool_use, value=_IMAGE_RESULT, ok=True)
 
+    # Strands names the format bare ("png"), not as a mime type.
+    expected_format = _EXPECTED_MIME_TYPE.removeprefix("image/")
     return result["content"] == [
-        {"image": {"format": "png", "source": {"bytes": b"fake"}}}
+        {"image": {"format": expected_format, "source": {"bytes": _EXPECTED_BYTES}}}
     ]
 
 
@@ -260,17 +287,15 @@ async def _probe_copilot_sdk() -> bool:
     result = await adapter._execute_bridged_tool(
         "room-1",
         ToolInvocation(
-            tool_call_id="c1", tool_name="band_read_room_file", arguments={}
+            tool_call_id="c1", tool_name=READ_ROOM_FILE_TOOL_NAME, arguments={}
         ),
     )
 
     binary = result.binary_results_for_llm
-    return (
-        binary is not None
-        and len(binary) == 1
-        and binary[0].data == "ZmFrZQ=="
-        and binary[0].mime_type == "image/png"
-        and binary[0].type == "image"
+    if not binary or len(binary) != 1:
+        return False
+    return binary[0].type == "image" and _is_expected_image(
+        binary[0].data, binary[0].mime_type
     )
 
 
@@ -279,9 +304,8 @@ async def _probe_codex() -> bool:
 
     content_items = _image_content_items(_IMAGE_RESULT)
 
-    return content_items == [
-        {"type": "inputImage", "imageUrl": "data:image/png;base64,ZmFrZQ=="}
-    ]
+    data_uri = f"data:{_EXPECTED_MIME_TYPE};base64,{_EXPECTED_BASE64}"
+    return content_items == [{"type": "inputImage", "imageUrl": data_uri}]
 
 
 async def _probe_pydantic_ai() -> bool:
@@ -290,9 +314,7 @@ async def _probe_pydantic_ai() -> bool:
 
     adapter = PydanticAIAdapter(model="test", capabilities=Capability.FILES)
     await adapter.on_started(agent_name="Probe", agent_description="probe")
-    read_room_file = adapter._agent._function_toolset.tools["band_read_room_file"]
-
-    from types import SimpleNamespace
+    read_room_file = adapter._agent._function_toolset.tools[READ_ROOM_FILE_TOOL_NAME]
 
     result = await read_room_file.function(
         SimpleNamespace(deps=_StubReadRoomFileTools()), file_id="file-1"
@@ -301,7 +323,7 @@ async def _probe_pydantic_ai() -> bool:
     if not isinstance(result, list) or len(result) != 1:
         return False
     binary = result[0]
-    return binary.data == b"fake" and binary.media_type == "image/png"
+    return _is_expected_image(binary.data, binary.media_type)
 
 
 async def _probe_crewai() -> bool:
@@ -319,7 +341,7 @@ async def _probe_crewai() -> bool:
         reporter=NoopReporter(),
         capabilities=frozenset({Capability.FILES}),
     )
-    read_room_file = next(t for t in tools if t.name == "band_read_room_file")
+    read_room_file = _tool_named(tools, READ_ROOM_FILE_TOOL_NAME)
 
     result = read_room_file._run(file_id="file-1")
 

--- a/tests/framework_conformance/test_files_image_passthrough_matrix.py
+++ b/tests/framework_conformance/test_files_image_passthrough_matrix.py
@@ -36,11 +36,19 @@ _IMAGE_RESULT: dict[str, Any] = {
 
 
 class _StubReadRoomFileTools:
-    """Minimal AgentToolsProtocol double whose read_room_file always returns
-    the fixed image result -- only what each probe's dispatch path calls."""
+    """Minimal AgentToolsProtocol double whose read_room_file/execute_tool_call
+    always return the fixed image result -- only what each probe's dispatch
+    path calls (MCP-based probes call read_room_file; generic-dispatch probes
+    like agno call execute_tool_call)."""
 
     async def read_room_file(self, file_id: str) -> dict[str, Any]:
         del file_id
+        return _IMAGE_RESULT
+
+    async def execute_tool_call(
+        self, tool_name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        del tool_name, arguments
         return _IMAGE_RESULT
 
 
@@ -153,11 +161,114 @@ async def _probe_gemini() -> bool:
     )
 
 
+async def _probe_langgraph() -> bool:
+    from unittest.mock import AsyncMock, MagicMock
+
+    from band.core.types import AdapterFeatures, Capability
+    from band.integrations.langgraph.langchain_tools import agent_tools_to_langchain
+
+    tools = MagicMock()
+    tools.is_hub_room = False
+    tools.execute_tool_call = AsyncMock(return_value=_IMAGE_RESULT)
+    wrapped = {
+        tool.name: tool
+        for tool in agent_tools_to_langchain(
+            tools,
+            features=AdapterFeatures(capabilities=frozenset({Capability.FILES})),
+        )
+    }
+
+    result = await wrapped["band_read_room_file"].ainvoke({"file_id": "file-1"})
+
+    return result == [{"type": "image", "mime_type": "image/png", "base64": "ZmFrZQ=="}]
+
+
+async def _probe_agno() -> bool:
+    from agno.tools.function import ToolResult
+
+    from band.adapters.agno import _bind_room_tools, _make_band_entrypoint
+
+    entry = _make_band_entrypoint("band_read_room_file")
+    with _bind_room_tools(_StubReadRoomFileTools()):
+        result = await entry(file_id="file-1")
+
+    return (
+        isinstance(result, ToolResult)
+        and result.images is not None
+        and len(result.images) == 1
+        and result.images[0].content == b"fake"
+        and result.images[0].mime_type == "image/png"
+    )
+
+
+async def _probe_strands() -> bool:
+    from band.adapters.strands import _tool_result
+
+    tool_use = {"toolUseId": "t1", "name": "band_read_room_file", "input": {}}
+
+    result = _tool_result(tool_use, value=_IMAGE_RESULT, ok=True)
+
+    return result["content"] == [
+        {"image": {"format": "png", "source": {"bytes": b"fake"}}}
+    ]
+
+
+async def _probe_copilot_sdk() -> bool:
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from copilot import ToolInvocation
+
+    from band.adapters.copilot_sdk import CopilotSDKAdapter
+    from band.runtime.tools import ToolCallOutcome
+
+    room_tools = MagicMock()
+    room_tools.execute_tool_call_structured = AsyncMock(
+        return_value=ToolCallOutcome(value=_IMAGE_RESULT, ok=True)
+    )
+    adapter = CopilotSDKAdapter.__new__(CopilotSDKAdapter)
+    adapter.features = SimpleNamespace(emit=())
+    adapter._custom_tools = []
+    adapter._turn_state = {}
+    adapter._room_tools = {"room-1": room_tools}
+
+    result = await adapter._execute_bridged_tool(
+        "room-1",
+        ToolInvocation(
+            tool_call_id="c1", tool_name="band_read_room_file", arguments={}
+        ),
+    )
+
+    binary = result.binary_results_for_llm
+    return (
+        binary is not None
+        and len(binary) == 1
+        and binary[0].data == "ZmFrZQ=="
+        and binary[0].mime_type == "image/png"
+        and binary[0].type == "image"
+    )
+
+
+async def _probe_codex() -> bool:
+    from band.adapters.codex import _image_content_items
+
+    content_items = _image_content_items(_IMAGE_RESULT)
+
+    return content_items == [
+        {"type": "inputImage", "imageUrl": "data:image/png;base64,ZmFrZQ=="}
+    ]
+
+
 IMAGE_PASSTHROUGH_PROBES: dict[str, Callable[[], Awaitable[bool]]] = {
     "claude_sdk": _probe_claude_sdk,
     "anthropic": _probe_anthropic,
     "opencode": _probe_opencode,
     "gemini": _probe_gemini,
+    "langgraph": _probe_langgraph,
+    "agno": _probe_agno,
+    "strands": _probe_strands,
+    "copilot_sdk": _probe_copilot_sdk,
+    "codex": _probe_codex,
 }
 
 

--- a/tests/framework_conformance/test_files_image_passthrough_matrix.py
+++ b/tests/framework_conformance/test_files_image_passthrough_matrix.py
@@ -27,7 +27,7 @@ from typing import Any
 
 import pytest
 
-from band.runtime.tools import READ_ROOM_FILE_TOOL_NAME, TOOL_DEFINITIONS
+from band.runtime.tools import BandTool, TOOL_DEFINITIONS
 from tests.framework_conformance.test_adapter_conformance import (
     IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS,
 )
@@ -71,10 +71,8 @@ _EXPECTED_BYTES: bytes = base64.b64decode(_EXPECTED_BASE64)
 def _is_expected_image(data: bytes | str, mime_type: str) -> bool:
     """Whether a framework's outgoing image block carries the probe's image.
 
-    ``data`` is whichever encoding that framework's SDK uses -- raw bytes
-    (gemini, agno, pydantic_ai) or the base64 string as-is (anthropic,
-    opencode, copilot_sdk) -- so each probe passes what it found without
-    first normalising it.
+    ``data`` arrives in whichever encoding that framework's SDK uses, so a
+    probe passes what it found rather than normalising first.
     """
     expected = _EXPECTED_BYTES if isinstance(data, bytes) else _EXPECTED_BASE64
     return data == expected and mime_type == _EXPECTED_MIME_TYPE
@@ -106,11 +104,11 @@ async def _probe_claude_sdk() -> bool:
     from band.integrations.claude_sdk.tools import build_band_sdk_tools
 
     sdk_tools = build_band_sdk_tools(
-        tool_definitions=[TOOL_DEFINITIONS[READ_ROOM_FILE_TOOL_NAME]],
+        tool_definitions=[TOOL_DEFINITIONS[BandTool.READ_ROOM_FILE]],
         get_tools=lambda _room_id: _StubReadRoomFileTools(),
         include_room_id=False,
     )
-    handler = _tool_named(sdk_tools, READ_ROOM_FILE_TOOL_NAME).handler
+    handler = _tool_named(sdk_tools, BandTool.READ_ROOM_FILE).handler
 
     result = await handler({"file_id": "file-1"})
 
@@ -132,7 +130,7 @@ async def _probe_anthropic() -> bool:
         ToolUseBlock(
             type="tool_use",
             id="tool-1",
-            name=READ_ROOM_FILE_TOOL_NAME,
+            name=BandTool.READ_ROOM_FILE,
             input={"file_id": "file-1"},
         )
     ]
@@ -160,7 +158,7 @@ async def _probe_opencode() -> bool:
     )
 
     resolver = EmbeddedResolver(get_tools=lambda _chat_id: _StubReadRoomFileTools())
-    definition = TOOL_DEFINITIONS[READ_ROOM_FILE_TOOL_NAME]
+    definition = TOOL_DEFINITIONS[BandTool.READ_ROOM_FILE]
     registration = build_tool_registration(
         definition,
         extend_with_chat_id(definition.input_model, None),
@@ -171,7 +169,7 @@ async def _probe_opencode() -> bool:
 
     async with create_connected_server_and_client_session(mcp) as session:
         result = await session.call_tool(
-            READ_ROOM_FILE_TOOL_NAME, {"chat_id": "room-1", "file_id": "file-1"}
+            BandTool.READ_ROOM_FILE, {"chat_id": "room-1", "file_id": "file-1"}
         )
 
     if result.isError or len(result.content) != 1:
@@ -192,7 +190,7 @@ async def _probe_gemini() -> bool:
     tools.execute_tool_call = AsyncMock(return_value=_IMAGE_RESULT)
     function_calls = [
         types.FunctionCall(
-            name=READ_ROOM_FILE_TOOL_NAME, args={"file_id": "file-1"}, id="c1"
+            name=BandTool.READ_ROOM_FILE, args={"file_id": "file-1"}, id="c1"
         )
     ]
 
@@ -224,7 +222,7 @@ async def _probe_langgraph() -> bool:
         )
     }
 
-    result = await wrapped[READ_ROOM_FILE_TOOL_NAME].ainvoke({"file_id": "file-1"})
+    result = await wrapped[BandTool.READ_ROOM_FILE].ainvoke({"file_id": "file-1"})
 
     if not isinstance(result, list) or len(result) != 1:
         return False
@@ -239,7 +237,7 @@ async def _probe_agno() -> bool:
 
     from band.adapters.agno import _bind_room_tools, _make_band_entrypoint
 
-    entry = _make_band_entrypoint(READ_ROOM_FILE_TOOL_NAME)
+    entry = _make_band_entrypoint(BandTool.READ_ROOM_FILE)
     with _bind_room_tools(_StubReadRoomFileTools()):
         result = await entry(file_id="file-1")
 
@@ -254,7 +252,7 @@ async def _probe_agno() -> bool:
 async def _probe_strands() -> bool:
     from band.adapters.strands import _tool_result
 
-    tool_use = {"toolUseId": "t1", "name": READ_ROOM_FILE_TOOL_NAME, "input": {}}
+    tool_use = {"toolUseId": "t1", "name": BandTool.READ_ROOM_FILE, "input": {}}
 
     result = _tool_result(tool_use, value=_IMAGE_RESULT, ok=True)
 
@@ -287,7 +285,7 @@ async def _probe_copilot_sdk() -> bool:
     result = await adapter._execute_bridged_tool(
         "room-1",
         ToolInvocation(
-            tool_call_id="c1", tool_name=READ_ROOM_FILE_TOOL_NAME, arguments={}
+            tool_call_id="c1", tool_name=BandTool.READ_ROOM_FILE, arguments={}
         ),
     )
 
@@ -314,7 +312,7 @@ async def _probe_pydantic_ai() -> bool:
 
     adapter = PydanticAIAdapter(model="test", capabilities=Capability.FILES)
     await adapter.on_started(agent_name="Probe", agent_description="probe")
-    read_room_file = adapter._agent._function_toolset.tools[READ_ROOM_FILE_TOOL_NAME]
+    read_room_file = adapter._agent._function_toolset.tools[BandTool.READ_ROOM_FILE]
 
     result = await read_room_file.function(
         SimpleNamespace(deps=_StubReadRoomFileTools()), file_id="file-1"
@@ -341,7 +339,7 @@ async def _probe_crewai() -> bool:
         reporter=NoopReporter(),
         capabilities=frozenset({Capability.FILES}),
     )
-    read_room_file = _tool_named(tools, READ_ROOM_FILE_TOOL_NAME)
+    read_room_file = _tool_named(tools, BandTool.READ_ROOM_FILE)
 
     result = read_room_file._run(file_id="file-1")
 
@@ -366,9 +364,7 @@ IMAGE_PASSTHROUGH_PROBES: dict[str, Callable[[], Awaitable[bool]]] = {
 
 
 def test_probe_registry_matches_supported_framework_ids() -> None:
-    """The probe set is the live proof behind
-    IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS -- the two must name exactly
-    the same frameworks, or one of them has drifted from the other."""
+    """The probes are the live proof behind the supported-framework set."""
     assert set(IMAGE_PASSTHROUGH_PROBES) == IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS
 
 

--- a/tests/framework_conformance/test_files_image_passthrough_matrix.py
+++ b/tests/framework_conformance/test_files_image_passthrough_matrix.py
@@ -352,12 +352,12 @@ def test_probe_registry_matches_supported_framework_ids() -> None:
 
 def _framework_param(framework_id: str) -> Any:
     available = _SOMETIMES_MISSING.get(framework_id, True)
-    if not available:
-        return pytest.param(
-            framework_id,
-            marks=pytest.mark.skip(reason=f"{framework_id} not installed in this venv"),
-        )
-    return pytest.param(framework_id)
+    return pytest.param(
+        framework_id,
+        marks=pytest.mark.skipif(
+            not available, reason=f"{framework_id} not installed in this venv"
+        ),
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/framework_conformance/test_files_image_passthrough_matrix.py
+++ b/tests/framework_conformance/test_files_image_passthrough_matrix.py
@@ -30,6 +30,31 @@ from tests.framework_conformance.test_adapter_conformance import (
     IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS,
 )
 
+try:
+    import crewai  # noqa: F401
+
+    _CREWAI_AVAILABLE = True
+except ImportError:
+    _CREWAI_AVAILABLE = False
+
+try:
+    import pydantic_ai  # noqa: F401
+
+    _PYDANTIC_AI_AVAILABLE = True
+except ImportError:
+    _PYDANTIC_AI_AVAILABLE = False
+
+# crewai and pydantic-ai aren't both installed in every lane's venv (a
+# three-way conflict group with parlant -- see docs/dependency-conflicts.md):
+# dev-crewai lacks pydantic-ai, dev-parlant lacks both. These framework_ids
+# need a per-lane skip the other probes (all in every lane's `dev` baseline)
+# don't.
+_SOMETIMES_MISSING: dict[str, bool] = {
+    "crewai": _CREWAI_AVAILABLE,
+    "crewai_flow": _CREWAI_AVAILABLE,
+    "pydantic_ai": _PYDANTIC_AI_AVAILABLE,
+}
+
 _IMAGE_RESULT: dict[str, Any] = {
     "content": [{"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}]
 }
@@ -259,6 +284,48 @@ async def _probe_codex() -> bool:
     ]
 
 
+async def _probe_pydantic_ai() -> bool:
+    from band.adapters.pydantic_ai import PydanticAIAdapter
+    from band.core.types import Capability
+
+    adapter = PydanticAIAdapter(model="test", capabilities=Capability.FILES)
+    await adapter.on_started(agent_name="Probe", agent_description="probe")
+    read_room_file = adapter._agent._function_toolset.tools["band_read_room_file"]
+
+    from types import SimpleNamespace
+
+    result = await read_room_file.function(
+        SimpleNamespace(deps=_StubReadRoomFileTools()), file_id="file-1"
+    )
+
+    if not isinstance(result, list) or len(result) != 1:
+        return False
+    binary = result[0]
+    return binary.data == b"fake" and binary.media_type == "image/png"
+
+
+async def _probe_crewai() -> bool:
+    from band.integrations.crewai.tools import (
+        CrewAIToolContext,
+        NoopReporter,
+        build_band_crewai_tools,
+        vision_sentinel,
+    )
+    from band.core.types import Capability
+
+    context = CrewAIToolContext(room_id="room-1", tools=_StubReadRoomFileTools())
+    tools = build_band_crewai_tools(
+        get_context=lambda: context,
+        reporter=NoopReporter(),
+        capabilities=frozenset({Capability.FILES}),
+    )
+    read_room_file = next(t for t in tools if t.name == "band_read_room_file")
+
+    result = read_room_file._run(file_id="file-1")
+
+    return result == vision_sentinel(_IMAGE_RESULT)
+
+
 IMAGE_PASSTHROUGH_PROBES: dict[str, Callable[[], Awaitable[bool]]] = {
     "claude_sdk": _probe_claude_sdk,
     "anthropic": _probe_anthropic,
@@ -269,6 +336,10 @@ IMAGE_PASSTHROUGH_PROBES: dict[str, Callable[[], Awaitable[bool]]] = {
     "strands": _probe_strands,
     "copilot_sdk": _probe_copilot_sdk,
     "codex": _probe_codex,
+    "pydantic_ai": _probe_pydantic_ai,
+    "crewai": _probe_crewai,
+    # crewai_flow shares integrations/crewai/tools.py with crewai -- same probe.
+    "crewai_flow": _probe_crewai,
 }
 
 
@@ -279,8 +350,21 @@ def test_probe_registry_matches_supported_framework_ids() -> None:
     assert set(IMAGE_PASSTHROUGH_PROBES) == IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS
 
 
+def _framework_param(framework_id: str) -> Any:
+    available = _SOMETIMES_MISSING.get(framework_id, True)
+    if not available:
+        return pytest.param(
+            framework_id,
+            marks=pytest.mark.skip(reason=f"{framework_id} not installed in this venv"),
+        )
+    return pytest.param(framework_id)
+
+
 @pytest.mark.asyncio
-@pytest.mark.parametrize("framework_id", sorted(IMAGE_PASSTHROUGH_PROBES))
+@pytest.mark.parametrize(
+    "framework_id",
+    [_framework_param(fid) for fid in sorted(IMAGE_PASSTHROUGH_PROBES)],
+)
 async def test_image_result_passes_through_as_real_content(framework_id: str) -> None:
     probe = IMAGE_PASSTHROUGH_PROBES[framework_id]
 

--- a/tests/framework_conformance/test_files_image_passthrough_matrix.py
+++ b/tests/framework_conformance/test_files_image_passthrough_matrix.py
@@ -124,10 +124,40 @@ async def _probe_opencode() -> bool:
     )
 
 
+async def _probe_gemini() -> bool:
+    from unittest.mock import AsyncMock, MagicMock
+
+    from google.genai import types
+
+    from band.adapters.gemini import GeminiAdapter
+
+    adapter = GeminiAdapter(provider_key="test-key")
+    tools = MagicMock()
+    tools.execute_tool_call = AsyncMock(return_value=_IMAGE_RESULT)
+    function_calls = [
+        types.FunctionCall(
+            name="band_read_room_file", args={"file_id": "file-1"}, id="c1"
+        )
+    ]
+
+    parts = await adapter._process_function_calls(function_calls, tools)
+
+    function_response = parts[0].function_response
+    if function_response is None or not function_response.parts:
+        return False
+    inline_data = function_response.parts[0].inline_data
+    return (
+        inline_data is not None
+        and inline_data.mime_type == "image/png"
+        and inline_data.data == b"fake"
+    )
+
+
 IMAGE_PASSTHROUGH_PROBES: dict[str, Callable[[], Awaitable[bool]]] = {
     "claude_sdk": _probe_claude_sdk,
     "anthropic": _probe_anthropic,
     "opencode": _probe_opencode,
+    "gemini": _probe_gemini,
 }
 
 

--- a/tests/framework_conformance/test_files_image_passthrough_matrix.py
+++ b/tests/framework_conformance/test_files_image_passthrough_matrix.py
@@ -1,0 +1,149 @@
+"""Live matrix proving each IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS entry
+actually passes an image band_read_room_file result through as real
+vision/image content -- not just that the bookkeeping constant lists it.
+
+Each probe drives the framework's real tool-dispatch code path with a fake
+tools object whose read_room_file returns the exact MCP-image-content shape
+AgentTools.read_room_file produces for a small previewable image, and asserts
+the framework's own outgoing tool-result shape is a real image block rather
+than a json.dumps'd text blob. Deeper framework-specific coverage (the
+non-image degrade-to-text path, error handling, custom-tool interaction)
+stays in each framework's own test file -- this matrix exists to answer one
+question, uniformly, for every framework that claims support: does a real
+image actually get through.
+
+To add a framework here: write a probe, add it to IMAGE_PASSTHROUGH_PROBES,
+and add the framework_id to IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS in
+test_adapter_conformance.py -- test_probe_registry_matches_supported_framework_ids
+fails loudly if the two ever name different frameworks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import pytest
+
+from band.runtime.tools import TOOL_DEFINITIONS
+from tests.framework_conformance.test_adapter_conformance import (
+    IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS,
+)
+
+_IMAGE_RESULT: dict[str, Any] = {
+    "content": [{"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}]
+}
+
+
+class _StubReadRoomFileTools:
+    """Minimal AgentToolsProtocol double whose read_room_file always returns
+    the fixed image result -- only what each probe's dispatch path calls."""
+
+    async def read_room_file(self, file_id: str) -> dict[str, Any]:
+        del file_id
+        return _IMAGE_RESULT
+
+
+async def _probe_claude_sdk() -> bool:
+    from band.integrations.claude_sdk.tools import build_band_sdk_tools
+
+    sdk_tools = build_band_sdk_tools(
+        tool_definitions=[TOOL_DEFINITIONS["band_read_room_file"]],
+        get_tools=lambda _room_id: _StubReadRoomFileTools(),
+        include_room_id=False,
+    )
+    handler = next(t for t in sdk_tools if t.name == "band_read_room_file").handler
+
+    result = await handler({"file_id": "file-1"})
+
+    return result == _IMAGE_RESULT
+
+
+async def _probe_anthropic() -> bool:
+    from unittest.mock import AsyncMock, MagicMock
+
+    from anthropic.types import ToolUseBlock
+
+    from band.adapters.anthropic import AnthropicAdapter
+
+    adapter = AnthropicAdapter(emit=())
+    tools = MagicMock()
+    tools.execute_tool_call = AsyncMock(return_value=_IMAGE_RESULT)
+    response = MagicMock()
+    response.content = [
+        ToolUseBlock(
+            type="tool_use",
+            id="tool-1",
+            name="band_read_room_file",
+            input={"file_id": "file-1"},
+        )
+    ]
+
+    results = await adapter._process_tool_calls(response, tools)
+
+    content = results[0]["content"]
+    return (
+        isinstance(content, list)
+        and len(content) == 1
+        and content[0]["type"] == "image"
+        and content[0]["source"]["data"] == "ZmFrZQ=="
+    )
+
+
+async def _probe_opencode() -> bool:
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    from band.integrations.mcp.engine import (
+        EmbeddedResolver,
+        EngineSpec,
+        build_engine,
+        build_tool_registration,
+        extend_with_chat_id,
+    )
+
+    resolver = EmbeddedResolver(get_tools=lambda _chat_id: _StubReadRoomFileTools())
+    definition = TOOL_DEFINITIONS["band_read_room_file"]
+    registration = build_tool_registration(
+        definition,
+        extend_with_chat_id(definition.input_model, None),
+        resolver=resolver,
+        strip_chat_id=True,
+    )
+    mcp = build_engine(EngineSpec(name="probe-opencode", tools=(registration,)))
+
+    async with create_connected_server_and_client_session(mcp) as session:
+        result = await session.call_tool(
+            "band_read_room_file", {"chat_id": "room-1", "file_id": "file-1"}
+        )
+
+    return (
+        not result.isError
+        and len(result.content) == 1
+        and result.content[0].type == "image"
+        and result.content[0].data == "ZmFrZQ=="
+    )
+
+
+IMAGE_PASSTHROUGH_PROBES: dict[str, Callable[[], Awaitable[bool]]] = {
+    "claude_sdk": _probe_claude_sdk,
+    "anthropic": _probe_anthropic,
+    "opencode": _probe_opencode,
+}
+
+
+def test_probe_registry_matches_supported_framework_ids() -> None:
+    """The probe set is the live proof behind
+    IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS -- the two must name exactly
+    the same frameworks, or one of them has drifted from the other."""
+    assert set(IMAGE_PASSTHROUGH_PROBES) == IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("framework_id", sorted(IMAGE_PASSTHROUGH_PROBES))
+async def test_image_result_passes_through_as_real_content(framework_id: str) -> None:
+    probe = IMAGE_PASSTHROUGH_PROBES[framework_id]
+
+    assert await probe(), (
+        f"{framework_id} did not pass an image band_read_room_file result "
+        "through as real image content"
+    )

--- a/tests/framework_conformance/test_files_image_passthrough_matrix.py
+++ b/tests/framework_conformance/test_files_image_passthrough_matrix.py
@@ -368,6 +368,32 @@ def test_probe_registry_matches_supported_framework_ids() -> None:
     assert set(IMAGE_PASSTHROUGH_PROBES) == IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS
 
 
+@pytest.mark.skipif(not _CREWAI_AVAILABLE, reason="crewai not installed in this venv")
+def test_crewai_platform_tool_name_is_plain_str() -> None:
+    """CrewAI's real BaseTool doesn't validate field defaults, so a bare
+    BandTool (StrEnum) default would leave tool.name a BandTool instance at
+    runtime instead of the str the field is typed as -- str(spec.name) at
+    the PlatformTool definition must keep it a plain str."""
+    from band.core.types import Capability
+    from band.integrations.crewai.tools import (
+        CrewAIToolContext,
+        NoopReporter,
+        build_band_crewai_tools,
+    )
+
+    context = CrewAIToolContext(room_id="room-1", tools=_StubReadRoomFileTools())
+    tools = build_band_crewai_tools(
+        get_context=lambda: context,
+        reporter=NoopReporter(),
+        capabilities=frozenset({Capability.FILES}),
+    )
+
+    for tool in tools:
+        assert type(tool.name) is str, (
+            f"{tool.name!r} is {type(tool.name)}, not plain str"
+        )
+
+
 def _framework_param(framework_id: str) -> Any:
     available = _SOMETIMES_MISSING.get(framework_id, True)
     return pytest.param(

--- a/tests/framework_conformance/test_tool_name_drift.py
+++ b/tests/framework_conformance/test_tool_name_drift.py
@@ -163,7 +163,7 @@ class TestLangGraphToolDrift:
 
 
 class TestCrewAIToolDrift:
-    """CrewAI platform tools (integrations/crewai/tools.py).
+    """CrewAI platform tools (integrations/crewai/catalog.py).
 
     Both ``CrewAIAdapter`` and ``CrewAIFlowAdapter`` consume one set of
     wrappers, declared as ``@band_tool`` bodies rather than string literals,
@@ -175,7 +175,7 @@ class TestCrewAIToolDrift:
         missing = ALL_TOOL_NAMES - {spec.name for spec in PLATFORM_TOOLS}
         assert not missing, (
             f"CrewAI adapter is missing tool bodies for: {sorted(missing)}. "
-            "Add a @band_tool body in integrations/crewai/tools.py."
+            "Add a @band_tool body in integrations/crewai/catalog.py."
         )
 
 

--- a/tests/framework_conformance/test_tool_name_drift.py
+++ b/tests/framework_conformance/test_tool_name_drift.py
@@ -33,6 +33,8 @@ from band.runtime.tools import (
     iter_tool_definitions,
 )
 
+from band.integrations.crewai.tools import PLATFORM_TOOLS
+
 if _HAS_CLAUDE_SDK:
     from band.integrations.claude_sdk.tools import build_band_sdk_tools
 
@@ -161,30 +163,19 @@ class TestLangGraphToolDrift:
 
 
 class TestCrewAIToolDrift:
-    """CrewAI tool classes (integrations/crewai/tools.py).
+    """CrewAI platform tools (integrations/crewai/tools.py).
 
-    The BaseTool subclasses were moved out of ``adapters/crewai.py`` into the
-    shared ``integrations/crewai/tools.py`` module so that both the legacy
-    ``CrewAIAdapter`` and the new ``CrewAIFlowAdapter`` consume one set of
-    wrappers. The drift check now scans the shared module.
+    Both ``CrewAIAdapter`` and ``CrewAIFlowAdapter`` consume one set of
+    wrappers, declared as ``@band_tool`` bodies rather than string literals,
+    so the drift check reads the registry those decorators build.
     """
 
-    _FILE = SRC_ROOT / "integrations" / "crewai" / "tools.py"
-
     def test_all_tools_registered(self):
-        """Every non-file tool in TOOL_MODELS has a CrewAI tool class.
-
-        File tools are excluded: CrewAI hand-wraps each Band tool as its own
-        ``BaseTool`` subclass, so exposing ``Capability.FILES`` here needs a
-        real new wrapper per tool, not just a capability declaration -- not
-        yet done.
-        """
-        source = self._FILE.read_text()
-        found = _extract_tool_names(source)
-        missing = ALL_TOOL_NAMES - FILE_TOOL_NAMES - found
+        """Every tool in TOOL_MODELS has a CrewAI ``@band_tool`` body."""
+        missing = ALL_TOOL_NAMES - {spec.name for spec in PLATFORM_TOOLS}
         assert not missing, (
-            f"CrewAI adapter is missing tool classes for: {sorted(missing)}. "
-            f"Add tool classes in _register_tools()."
+            f"CrewAI adapter is missing tool bodies for: {sorted(missing)}. "
+            "Add a @band_tool body in integrations/crewai/tools.py."
         )
 
 

--- a/tests/integrations/claude_sdk/test_tools.py
+++ b/tests/integrations/claude_sdk/test_tools.py
@@ -27,7 +27,6 @@ from pydantic import BaseModel
 
 from band.integrations.claude_sdk.tools import (
     _format_success_payload,
-    _is_mcp_content_result,
     _make_result,
     build_band_sdk_tools,
 )
@@ -37,20 +36,6 @@ _IMAGE_RESULT = {
     "content": [{"type": "image", "data": "YmFzZTY0", "mimeType": "image/png"}]
 }
 _TEXT_RESULT = {"name": "notes.txt", "content_type": "text/plain", "text": "hi"}
-
-
-class TestIsMcpContentResult:
-    def test_true_for_image_content_block(self) -> None:
-        assert _is_mcp_content_result(_IMAGE_RESULT)
-
-    def test_false_for_plain_dict(self) -> None:
-        assert not _is_mcp_content_result(_TEXT_RESULT)
-
-    def test_false_for_non_dict(self) -> None:
-        assert not _is_mcp_content_result("just a string")
-
-    def test_false_for_content_list_without_type_keys(self) -> None:
-        assert not _is_mcp_content_result({"content": [{"no_type": 1}]})
 
 
 class TestMakeResultAlwaysEncodes:

--- a/tests/integrations/langgraph/test_langchain_tools.py
+++ b/tests/integrations/langgraph/test_langchain_tools.py
@@ -146,6 +146,42 @@ def test_add_participant_schema_exposes_identifier_and_role() -> None:
 
 
 @pytest.mark.asyncio
+async def test_read_room_file_image_result_becomes_image_content_block() -> None:
+    tools = make_tools()
+    tools.execute_tool_call = AsyncMock(
+        return_value={
+            "content": [{"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}]
+        }
+    )
+    wrapped = by_name(
+        agent_tools_to_langchain(
+            tools, features=AdapterFeatures(capabilities=frozenset({Capability.FILES}))
+        )
+    )
+
+    result = await wrapped["band_read_room_file"].ainvoke({"file_id": "f1"})
+
+    assert result == [{"type": "image", "mime_type": "image/png", "base64": "ZmFrZQ=="}]
+
+
+@pytest.mark.asyncio
+async def test_read_room_file_non_image_result_stays_raw() -> None:
+    tools = make_tools()
+    tools.execute_tool_call = AsyncMock(
+        return_value={"name": "notes.txt", "content_type": "text/plain"}
+    )
+    wrapped = by_name(
+        agent_tools_to_langchain(
+            tools, features=AdapterFeatures(capabilities=frozenset({Capability.FILES}))
+        )
+    )
+
+    result = await wrapped["band_read_room_file"].ainvoke({"file_id": "f1"})
+
+    assert result == {"name": "notes.txt", "content_type": "text/plain"}
+
+
+@pytest.mark.asyncio
 async def test_wrapper_errors_are_returned_to_model() -> None:
     tools = make_tools()
     tools.execute_tool_call.side_effect = RuntimeError("platform unavailable")

--- a/tests/integrations/parlant/test_tools.py
+++ b/tests/integrations/parlant/test_tools.py
@@ -607,6 +607,33 @@ class TestParlantToolFunctions:
         assert "503" in result.data
 
     @pytest.mark.asyncio
+    async def test_send_message_mention_hint_survives_session_teardown_race(
+        self, parlant_tools, mock_tools, mock_context
+    ):
+        """A room torn down between the tool body's own lookup and the
+        mention-hint failure handler's re-lookup must not crash the call.
+
+        guard_failures re-fetches session tools independently when building
+        the mention hint; if the session vanished in between, that re-fetch
+        returns None and must fall back to the plain error, not attribute
+        error out on None.participants.
+        """
+        set_session_tools(mock_context.session_id, mock_tools)
+
+        def _fail_and_tear_down_session(*args, **kwargs):
+            set_session_tools(mock_context.session_id, None)
+            raise BandToolError("Backend rejected message: 503 Service Unavailable")
+
+        mock_tools.send_message.side_effect = _fail_and_tear_down_session
+
+        send_message = parlant_tools["band_send_message"]
+        # Must NOT raise AttributeError from None.participants
+        result = await send_message(mock_context, "Hello", "Alice")
+
+        assert "Error sending message" in result.data
+        assert "503" in result.data
+
+    @pytest.mark.asyncio
     async def test_send_event_calls_tools_send_event(
         self, parlant_tools, mock_tools, mock_context
     ):

--- a/tests/integrations/parlant/test_tools.py
+++ b/tests/integrations/parlant/test_tools.py
@@ -182,6 +182,9 @@ class TestCreateParlantTools:
         assert "band_remove_contact" in tool_names
         assert "band_list_contact_requests" in tool_names
         assert "band_respond_contact_request" in tool_names
+        assert "band_list_room_files" in tool_names
+        assert "band_read_room_file" in tool_names
+        assert "band_send_room_file" in tool_names
 
     def test_tools_have_descriptions(self):
         """Should have descriptions for all tools."""
@@ -373,6 +376,53 @@ class TestCreateParlantTools:
         assert "band_list_contact_requests" not in tool_names
         assert "band_respond_contact_request" not in tool_names
 
+    def test_excludes_file_tools_without_capability(self):
+        """File tools excluded when FILES capability is absent."""
+        tools = create_parlant_tools(features=AdapterFeatures())
+        tool_names = [t.tool.name for t in tools]
+
+        assert "band_list_room_files" not in tool_names
+        assert "band_read_room_file" not in tool_names
+        assert "band_send_room_file" not in tool_names
+
+    def test_includes_file_tools_with_capability(self):
+        """File tools included when FILES capability is present."""
+        tools = create_parlant_tools(
+            features=AdapterFeatures(capabilities={Capability.FILES})
+        )
+        tool_names = [t.tool.name for t in tools]
+
+        assert "band_list_room_files" in tool_names
+        assert "band_read_room_file" in tool_names
+        assert "band_send_room_file" in tool_names
+
+    def test_includes_file_tools_when_no_features(self):
+        """File tools included when features is None (backward compat)."""
+        tools = create_parlant_tools(features=None)
+        tool_names = [t.tool.name for t in tools]
+
+        assert "band_list_room_files" in tool_names
+        assert "band_send_room_file" in tool_names
+
+    def test_send_room_file_mentions_param_notes_comma_separated_shape(self):
+        """mentions is a comma-separated string in Parlant, not the master's list[str]."""
+        tools = create_parlant_tools()
+
+        entry = next(t for t in tools if t.tool.name == "band_send_room_file")
+        description = entry.tool.parameters["mentions"][1].description
+
+        assert description is not None
+        assert "comma" in description
+
+    def test_read_room_file_tool_has_file_id_parameter(self):
+        """read_room_file should have a file_id parameter."""
+        tools = create_parlant_tools()
+
+        entry = next(t for t in tools if t.tool.name == "band_read_room_file")
+        param_names = list(entry.tool.parameters.keys())
+
+        assert "file_id" in param_names
+
     def test_includes_contact_tools_with_capability(self):
         """Contact tools included when CONTACTS capability is present."""
         tools = create_parlant_tools(
@@ -430,6 +480,33 @@ class TestParlantToolFunctions:
             return_value=[{"name": "User1", "type": "User"}]
         )
         tools.create_chatroom = AsyncMock(return_value="new-room-123")
+        tools.list_room_files = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "id": "file-1",
+                        "name": "report.txt",
+                        "content_type": "text/plain",
+                        "bytes": 42,
+                    }
+                ],
+                "next_cursor": None,
+            }
+        )
+        tools.read_room_file = AsyncMock(
+            return_value={
+                "name": "report.txt",
+                "content_type": "text/plain",
+                "bytes": 42,
+                "text": "hello world",
+            }
+        )
+        tools.send_room_file = AsyncMock(
+            return_value={
+                "attachment": {"id": "file-2", "name": "notes.txt"},
+                "message_id": "msg-1",
+            }
+        )
         return tools
 
     @pytest.fixture
@@ -673,3 +750,143 @@ class TestParlantToolFunctions:
         result = await send_message(mock_context, "Hello", "Alice")
 
         assert "Error sending message: Connection failed" in result.data
+
+    @pytest.mark.asyncio
+    async def test_list_room_files_returns_formatted_list(
+        self, parlant_tools, mock_tools, mock_context
+    ):
+        """Should return formatted list of room files."""
+        set_session_tools(mock_context.session_id, mock_tools)
+
+        list_room_files = parlant_tools["band_list_room_files"]
+        result = await list_room_files(mock_context, "")
+
+        mock_tools.list_room_files.assert_called_once_with(None)
+        assert "report.txt" in result.data
+        assert "file-1" in result.data
+
+    @pytest.mark.asyncio
+    async def test_list_room_files_passes_cursor(
+        self, parlant_tools, mock_tools, mock_context
+    ):
+        """Should forward a non-empty cursor to the underlying tool."""
+        set_session_tools(mock_context.session_id, mock_tools)
+
+        list_room_files = parlant_tools["band_list_room_files"]
+        await list_room_files(mock_context, "cursor-1")
+
+        mock_tools.list_room_files.assert_called_once_with("cursor-1")
+
+    @pytest.mark.asyncio
+    async def test_list_room_files_handles_empty_result(
+        self, parlant_tools, mock_tools, mock_context
+    ):
+        """Should handle an empty room-file list."""
+        mock_tools.list_room_files.return_value = {"data": [], "next_cursor": None}
+        set_session_tools(mock_context.session_id, mock_tools)
+
+        list_room_files = parlant_tools["band_list_room_files"]
+        result = await list_room_files(mock_context, "")
+
+        assert "No files found in this room" in result.data
+
+    @pytest.mark.asyncio
+    async def test_read_room_file_returns_text(
+        self, parlant_tools, mock_tools, mock_context
+    ):
+        """Should return the file's decoded text."""
+        set_session_tools(mock_context.session_id, mock_tools)
+
+        read_room_file = parlant_tools["band_read_room_file"]
+        result = await read_room_file(mock_context, "file-1")
+
+        mock_tools.read_room_file.assert_called_once_with("file-1")
+        assert "hello world" in result.data
+
+    @pytest.mark.asyncio
+    async def test_read_room_file_describes_image_instead_of_inlining(
+        self, parlant_tools, mock_tools, mock_context
+    ):
+        """An image result must be described, not passed through as bytes."""
+        mock_tools.read_room_file.return_value = {
+            "content": [{"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}]
+        }
+        set_session_tools(mock_context.session_id, mock_tools)
+
+        read_room_file = parlant_tools["band_read_room_file"]
+        result = await read_room_file(mock_context, "file-1")
+
+        assert "image/png" in result.data
+        assert "ZmFrZQ==" not in result.data
+
+    @pytest.mark.asyncio
+    async def test_read_room_file_describes_non_previewable_file(
+        self, parlant_tools, mock_tools, mock_context
+    ):
+        """A too-large/non-previewable file returns its description, not bytes."""
+        mock_tools.read_room_file.return_value = {
+            "name": "archive.zip",
+            "content_type": "application/zip",
+            "bytes": 999_999,
+            "description": "File not shown inline: exceeds the inline text limit.",
+        }
+        set_session_tools(mock_context.session_id, mock_tools)
+
+        read_room_file = parlant_tools["band_read_room_file"]
+        result = await read_room_file(mock_context, "file-1")
+
+        assert "archive.zip" in result.data
+        assert "not shown inline" in result.data
+
+    @pytest.mark.asyncio
+    async def test_send_room_file_calls_tools_send_room_file(
+        self, parlant_tools, mock_tools, mock_context
+    ):
+        """Should call tools.send_room_file with parsed mentions."""
+        set_session_tools(mock_context.session_id, mock_tools)
+
+        send_room_file = parlant_tools["band_send_room_file"]
+        result = await send_room_file(
+            mock_context, "file body", "notes.txt", "Alice, Bob", "here's a file"
+        )
+
+        mock_tools.send_room_file.assert_called_once_with(
+            "file body", "notes.txt", "here's a file", ["Alice", "Bob"]
+        )
+        assert "notes.txt" in result.data
+        assert "file-2" in result.data
+
+    @pytest.mark.asyncio
+    async def test_send_room_file_requires_mentions(
+        self, parlant_tools, mock_tools, mock_context
+    ):
+        """Should return error when no mentions provided."""
+        mock_tools.agent_id = "self"
+        mock_tools.participants = [
+            {"id": "user-1", "handle": "@alice"},
+            {"id": "self", "handle": "@self"},
+        ]
+        set_session_tools(mock_context.session_id, mock_tools)
+
+        send_room_file = parlant_tools["band_send_room_file"]
+        result = await send_room_file(mock_context, "body", "notes.txt", "", "")
+
+        assert "At least one mention is required" in result.data
+        assert "@alice" in result.data
+        mock_tools.send_room_file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_room_file_translates_band_tool_error(
+        self, parlant_tools, mock_tools, mock_context
+    ):
+        """BandToolError from underlying tool must surface as ToolResult, not crash."""
+        mock_tools.send_room_file.side_effect = BandToolError(
+            "Filename must use plain printable ASCII characters"
+        )
+        set_session_tools(mock_context.session_id, mock_tools)
+
+        send_room_file = parlant_tools["band_send_room_file"]
+        result = await send_room_file(mock_context, "body", "café.txt", "Alice", "")
+
+        assert "Error sending room file" in result.data
+        assert "ASCII" in result.data

--- a/tests/integrations/parlant/test_tools.py
+++ b/tests/integrations/parlant/test_tools.py
@@ -779,6 +779,40 @@ class TestParlantToolFunctions:
         assert "Error sending message: Connection failed" in result.data
 
     @pytest.mark.asyncio
+    async def test_tool_returns_error_on_malformed_call_arguments(
+        self, parlant_tools, mock_context
+    ):
+        """A signature mismatch in guard_failures's own bind() step -- before
+        the call-handling try starts, so there's no call.arguments yet to
+        build the usual failure message from -- must return a ToolResult,
+        not propagate a raw TypeError out of the tool coroutine."""
+        send_message = parlant_tools["band_send_message"]
+
+        result = await send_message(mock_context)  # missing content/mentions
+
+        assert result.data.startswith("Error calling band_send_message:")
+
+    @pytest.mark.asyncio
+    async def test_tool_logs_result_on_success(
+        self, parlant_tools, mock_tools, mock_context, caplog
+    ):
+        """guard_failures must log a per-call outcome, not just the initial
+        'called' line -- operators grep these logs for tool-level
+        confirmation (e.g. that a specific branch was hit)."""
+        set_session_tools(mock_context.session_id, mock_tools)
+        send_message = parlant_tools["band_send_message"]
+
+        with caplog.at_level("INFO"):
+            await send_message(mock_context, "Hello", "Alice")
+
+        result_logs = [
+            r
+            for r in caplog.records
+            if r.getMessage().startswith("[Parlant Tool] band_send_message ->")
+        ]
+        assert len(result_logs) == 1
+
+    @pytest.mark.asyncio
     async def test_list_room_files_returns_formatted_list(
         self, parlant_tools, mock_tools, mock_context
     ):

--- a/tests/integrations/test_crewai_real_tools.py
+++ b/tests/integrations/test_crewai_real_tools.py
@@ -44,6 +44,25 @@ def test_platform_tools_build_against_the_real_base_tool() -> None:
     assert "band_send_message" in {tool.name for tool in tools}
 
 
+def test_file_tools_build_against_the_real_base_tool() -> None:
+    """The three room-file tool models also resolve and instantiate for real --
+    same "not fully defined" failure mode this file exists to catch."""
+    from band.core.types import Capability
+
+    tools = build_band_crewai_tools(
+        get_context=lambda: None,
+        reporter=NoopReporter(),
+        features=AdapterFeatures(capabilities={Capability.FILES}),
+    )
+
+    names = {tool.name for tool in tools}
+    assert {
+        "band_list_room_files",
+        "band_read_room_file",
+        "band_send_room_file",
+    }.issubset(names)
+
+
 def test_a_mocked_crewai_window_does_not_poison_a_later_real_build() -> None:
     """Faking crewai for one test must leave the next one a working real package.
 

--- a/tests/integrations/test_crewai_tools.py
+++ b/tests/integrations/test_crewai_tools.py
@@ -534,6 +534,29 @@ class TestFileTools:
         assert result["status"] == "success"
         tools_obj.read_room_file.assert_awaited_once_with("file-1")
 
+    def test_read_room_file_image_result_becomes_vision_sentinel(self, builder_mod):
+        """CrewAI's own StepExecutor rewrites a VISION_IMAGE:<media_type>:<b64>
+        tool-result string into a real image_url content block -- pin that
+        band_read_room_file emits exactly that sentinel for an image result."""
+        from band.core.types import Capability
+
+        image_result = {
+            "content": [{"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}]
+        }
+        tools_obj = MagicMock()
+        tools_obj.read_room_file = AsyncMock(return_value=image_result)
+        context = builder_mod.CrewAIToolContext(room_id="room-1", tools=tools_obj)
+        tools = builder_mod.build_band_crewai_tools(
+            get_context=lambda: context,
+            reporter=builder_mod.NoopReporter(),
+            capabilities=frozenset({Capability.FILES}),
+        )
+        read_room_file = next(t for t in tools if t.name == "band_read_room_file")
+
+        result = read_room_file._run(file_id="file-1")
+
+        assert result == builder_mod.vision_sentinel(image_result)
+
     def test_send_room_file_forwards_args_in_protocol_order(self, builder_mod):
         """AgentToolsProtocol.send_room_file wants (content, filename, caption,
         mentions) positionally -- pin the reorder from the tool's own kwargs."""

--- a/tests/integrations/test_crewai_tools.py
+++ b/tests/integrations/test_crewai_tools.py
@@ -557,6 +557,39 @@ class TestFileTools:
 
         assert result == builder_mod.vision_sentinel(image_result)
 
+    def test_read_room_file_image_result_reports_placeholder_not_base64(
+        self, builder_mod
+    ):
+        """The full base64 sentinel must reach CrewAI's StepExecutor, but the
+        platform tool_result event must not carry that same base64 blob."""
+        from band.core.types import AdapterFeatures, Capability, Emit
+        from band.runtime.tools import image_block_placeholder
+
+        image_result = {
+            "content": [{"type": "image", "data": "ZmFrZQ==", "mimeType": "image/png"}]
+        }
+        tools_obj = MagicMock()
+        tools_obj.read_room_file = AsyncMock(return_value=image_result)
+        tools_obj.send_event = AsyncMock()
+        context = builder_mod.CrewAIToolContext(room_id="room-1", tools=tools_obj)
+        reporter = builder_mod.EmitToolCallsReporter(
+            AdapterFeatures(emit=frozenset({Emit.TOOL_CALLS}))
+        )
+        tools = builder_mod.build_band_crewai_tools(
+            get_context=lambda: context,
+            reporter=reporter,
+            capabilities=frozenset({Capability.FILES}),
+        )
+        read_room_file = next(t for t in tools if t.name == "band_read_room_file")
+
+        result = read_room_file._run(file_id="file-1")
+
+        assert result == builder_mod.vision_sentinel(image_result)
+        result_event = tools_obj.send_event.call_args_list[-1].kwargs
+        reported_output = json.loads(result_event["content"])["output"]
+        assert reported_output == image_block_placeholder(1)
+        assert "ZmFrZQ==" not in reported_output
+
     def test_send_room_file_forwards_args_in_protocol_order(self, builder_mod):
         """AgentToolsProtocol.send_room_file wants (content, filename, caption,
         mentions) positionally -- pin the reorder from the tool's own kwargs."""

--- a/tests/integrations/test_crewai_tools.py
+++ b/tests/integrations/test_crewai_tools.py
@@ -68,7 +68,9 @@ def platform_args_schemas(builder_mod):
     tools = builder_mod.build_band_crewai_tools(
         get_context=lambda: None,
         reporter=builder_mod.NoopReporter(),
-        capabilities=frozenset({Capability.CONTACTS, Capability.MEMORY}),
+        capabilities=frozenset(
+            {Capability.CONTACTS, Capability.MEMORY, Capability.FILES}
+        ),
     )
     return {tool.name: tool.args_schema for tool in tools}
 
@@ -133,6 +135,23 @@ class TestToolSetComposition:
         assert memory_names.issubset(names)
         assert len(tools) == 12
 
+    def test_capability_files_adds_three(self, builder_mod):
+        from band.core.types import Capability
+
+        tools = builder_mod.build_band_crewai_tools(
+            get_context=lambda: None,
+            reporter=builder_mod.NoopReporter(),
+            capabilities=frozenset({Capability.FILES}),
+        )
+        names = {t.name for t in tools}
+        file_names = {
+            "band_list_room_files",
+            "band_read_room_file",
+            "band_send_room_file",
+        }
+        assert file_names.issubset(names)
+        assert len(tools) == 10
+
     def test_both_capabilities(self, builder_mod):
         from band.core.types import Capability
 
@@ -142,6 +161,18 @@ class TestToolSetComposition:
             capabilities=frozenset({Capability.CONTACTS, Capability.MEMORY}),
         )
         assert len(tools) == 17  # 7 base + 5 contacts + 5 memory
+
+    def test_all_three_capabilities(self, builder_mod):
+        from band.core.types import Capability
+
+        tools = builder_mod.build_band_crewai_tools(
+            get_context=lambda: None,
+            reporter=builder_mod.NoopReporter(),
+            capabilities=frozenset(
+                {Capability.CONTACTS, Capability.MEMORY, Capability.FILES}
+            ),
+        )
+        assert len(tools) == 20  # 7 base + 5 contacts + 5 memory + 3 files
 
     def test_custom_tools_appended(self, builder_mod):
         from pydantic import BaseModel
@@ -440,6 +471,146 @@ class TestToolSetComposition:
         assert "@john" in result["message"]
         # The agent's own handle is excluded from the available options.
         assert "@john/weather-agent" not in result["message"]
+
+
+# --- File tools ---
+
+
+class TestFileTools:
+    def test_list_room_files_forwards_cursor(self, builder_mod):
+        from band.core.types import Capability
+
+        tools_obj = MagicMock()
+        tools_obj.list_room_files = AsyncMock(
+            return_value={"data": [{"id": "file-1"}], "next_cursor": None}
+        )
+        context = builder_mod.CrewAIToolContext(room_id="room-1", tools=tools_obj)
+        tools = builder_mod.build_band_crewai_tools(
+            get_context=lambda: context,
+            reporter=builder_mod.NoopReporter(),
+            capabilities=frozenset({Capability.FILES}),
+        )
+        list_room_files = next(t for t in tools if t.name == "band_list_room_files")
+
+        result = json.loads(list_room_files._run(cursor="cursor-1"))
+
+        assert result["status"] == "success"
+        tools_obj.list_room_files.assert_awaited_once_with("cursor-1")
+
+    def test_list_room_files_default_cursor_is_none(self, builder_mod):
+        from band.core.types import Capability
+
+        tools_obj = MagicMock()
+        tools_obj.list_room_files = AsyncMock(return_value={"data": []})
+        context = builder_mod.CrewAIToolContext(room_id="room-1", tools=tools_obj)
+        tools = builder_mod.build_band_crewai_tools(
+            get_context=lambda: context,
+            reporter=builder_mod.NoopReporter(),
+            capabilities=frozenset({Capability.FILES}),
+        )
+        list_room_files = next(t for t in tools if t.name == "band_list_room_files")
+
+        list_room_files._run()
+
+        tools_obj.list_room_files.assert_awaited_once_with(None)
+
+    def test_read_room_file_forwards_file_id(self, builder_mod):
+        from band.core.types import Capability
+
+        tools_obj = MagicMock()
+        tools_obj.read_room_file = AsyncMock(
+            return_value={"name": "report.txt", "text": "hello"}
+        )
+        context = builder_mod.CrewAIToolContext(room_id="room-1", tools=tools_obj)
+        tools = builder_mod.build_band_crewai_tools(
+            get_context=lambda: context,
+            reporter=builder_mod.NoopReporter(),
+            capabilities=frozenset({Capability.FILES}),
+        )
+        read_room_file = next(t for t in tools if t.name == "band_read_room_file")
+
+        result = json.loads(read_room_file._run(file_id="file-1"))
+
+        assert result["status"] == "success"
+        tools_obj.read_room_file.assert_awaited_once_with("file-1")
+
+    def test_send_room_file_forwards_args_in_protocol_order(self, builder_mod):
+        """AgentToolsProtocol.send_room_file wants (content, filename, caption,
+        mentions) positionally -- pin the reorder from the tool's own kwargs."""
+        from band.core.types import Capability
+
+        tools_obj = MagicMock()
+        tools_obj.send_room_file = AsyncMock(
+            return_value={"attachment": {"id": "file-2"}, "message_id": "msg-1"}
+        )
+        context = builder_mod.CrewAIToolContext(room_id="room-1", tools=tools_obj)
+        tools = builder_mod.build_band_crewai_tools(
+            get_context=lambda: context,
+            reporter=builder_mod.NoopReporter(),
+            capabilities=frozenset({Capability.FILES}),
+        )
+        send_room_file = next(t for t in tools if t.name == "band_send_room_file")
+
+        result = json.loads(
+            send_room_file._run(
+                content="file body",
+                filename="notes.txt",
+                mentions=["Alice", "Bob"],
+                caption="here's a file",
+            )
+        )
+
+        assert result["status"] == "success"
+        tools_obj.send_room_file.assert_awaited_once_with(
+            "file body", "notes.txt", "here's a file", ["Alice", "Bob"]
+        )
+
+    def test_send_room_file_mentions_accepts_lenient_string_shape(self, builder_mod):
+        """Smaller models emit mentions as a JSON-string or bracketed string,
+        same leniency need as band_send_message -- see normalize_mentions_lenient."""
+        from band.core.types import Capability
+
+        tools_obj = MagicMock()
+        tools_obj.send_room_file = AsyncMock(
+            return_value={"attachment": {}, "message_id": "msg-1"}
+        )
+        context = builder_mod.CrewAIToolContext(room_id="room-1", tools=tools_obj)
+        tools = builder_mod.build_band_crewai_tools(
+            get_context=lambda: context,
+            reporter=builder_mod.NoopReporter(),
+            capabilities=frozenset({Capability.FILES}),
+        )
+        send_room_file = next(t for t in tools if t.name == "band_send_room_file")
+
+        send_room_file._run(
+            content="body", filename="notes.txt", mentions="@alice, @bob"
+        )
+
+        tools_obj.send_room_file.assert_awaited_once_with(
+            "body", "notes.txt", "", ["@alice", "@bob"]
+        )
+
+    def test_send_room_file_failure_returns_error_status(self, builder_mod):
+        from band.core.types import Capability
+
+        tools_obj = MagicMock()
+        tools_obj.send_room_file = AsyncMock(side_effect=RuntimeError("upload failed"))
+        context = builder_mod.CrewAIToolContext(room_id="room-1", tools=tools_obj)
+        tools = builder_mod.build_band_crewai_tools(
+            get_context=lambda: context,
+            reporter=builder_mod.NoopReporter(),
+            capabilities=frozenset({Capability.FILES}),
+        )
+        send_room_file = next(t for t in tools if t.name == "band_send_room_file")
+
+        result = json.loads(
+            send_room_file._run(
+                content="body", filename="notes.txt", mentions=["Alice"]
+            )
+        )
+
+        assert result["status"] == "error"
+        assert "upload failed" in result["message"]
 
 
 # --- Reporter behavior ---

--- a/tests/integrations/test_crewai_tools.py
+++ b/tests/integrations/test_crewai_tools.py
@@ -646,6 +646,46 @@ class TestFileTools:
             "body", "notes.txt", "", ["@alice", "@bob"]
         )
 
+    def test_send_room_file_reports_content_placeholder_not_raw_bytes(
+        self, builder_mod
+    ):
+        """The full content must still reach send_room_file, but the
+        tool_call event must not carry that same raw payload."""
+        from band.core.types import AdapterFeatures, Capability, Emit
+        from band.runtime.tools import file_content_placeholder
+
+        tools_obj = MagicMock()
+        tools_obj.send_room_file = AsyncMock(
+            return_value={"attachment": {"id": "file-2"}, "message_id": "msg-1"}
+        )
+        tools_obj.send_event = AsyncMock()
+        context = builder_mod.CrewAIToolContext(room_id="room-1", tools=tools_obj)
+        reporter = builder_mod.EmitToolCallsReporter(
+            AdapterFeatures(emit=frozenset({Emit.TOOL_CALLS}))
+        )
+        tools = builder_mod.build_band_crewai_tools(
+            get_context=lambda: context,
+            reporter=reporter,
+            capabilities=frozenset({Capability.FILES}),
+        )
+        send_room_file = next(t for t in tools if t.name == "band_send_room_file")
+
+        # Multi-byte characters pin that the placeholder reports UTF-8 byte
+        # length (what MAX_SEND_CONTENT_BYTES actually measures), not
+        # len(content)'s character count.
+        content = "raw file body 你好 " * 1000
+        send_room_file._run(content=content, filename="notes.txt", mentions=["Alice"])
+
+        tools_obj.send_room_file.assert_awaited_once_with(
+            content, "notes.txt", "", ["Alice"]
+        )
+        call_event = tools_obj.send_event.call_args_list[0].kwargs
+        reported_args = json.loads(call_event["content"])["args"]
+        assert reported_args["content"] == file_content_placeholder(
+            len(content.encode("utf-8"))
+        )
+        assert content not in json.dumps(reported_args)
+
     def test_send_room_file_failure_returns_error_status(self, builder_mod):
         from band.core.types import Capability
 

--- a/tests/integrations/test_crewai_tools.py
+++ b/tests/integrations/test_crewai_tools.py
@@ -310,6 +310,49 @@ class TestToolSetComposition:
         assert result["status"] == "success"
         tools_obj.lookup_peers.assert_awaited_once_with(2, 25)
 
+    def test_lookup_peers_reports_serialized_result_for_raw_model_return(
+        self, builder_mod
+    ):
+        """lookup_peers (and the other six read-only tools that call
+        call.tools.X directly, bypassing execute_tool_call's own
+        serialization boundary) must still emit a tool_result event when the
+        platform method returns a raw Pydantic/Fern model. report_result's
+        json.dumps has no default=str, so an unserialized model previously
+        raised inside report_result -- caught by its own try/except and only
+        logged as a warning -- silently dropping the tool_result event."""
+        from band.core.types import AdapterFeatures, Emit
+
+        class FakePeersResponse:
+            def __init__(self, data):
+                self._data = data
+
+            def model_dump(self):
+                return self._data
+
+        tools_obj = MagicMock()
+        tools_obj.lookup_peers = AsyncMock(
+            return_value=FakePeersResponse({"peers": [{"id": "p1"}]})
+        )
+        tools_obj.send_event = AsyncMock()
+        context = builder_mod.CrewAIToolContext(room_id="room-1", tools=tools_obj)
+        features = AdapterFeatures(emit=frozenset({Emit.TOOL_CALLS}))
+        tools = builder_mod.build_band_crewai_tools(
+            get_context=lambda: context,
+            reporter=builder_mod.EmitToolCallsReporter(features),
+            capabilities=frozenset(),
+        )
+        lookup_peers = next(t for t in tools if t.name == "band_lookup_peers")
+
+        result = json.loads(lookup_peers._run())
+
+        assert result["status"] == "success"
+        assert result["peers"] == [{"id": "p1"}]
+        result_event = tools_obj.send_event.call_args_list[-1]
+        assert result_event.kwargs["message_type"] == "tool_result"
+        reported = json.loads(result_event.kwargs["content"])
+        assert reported["output"] == {"peers": [{"id": "p1"}]}
+        assert reported["is_error"] is False
+
     def test_send_message_marks_reply_tracker(self, builder_mod):
         """A successful band_send_message flips both ReplyTracker markers so the
         adapter can treat a later empty final answer as benign."""

--- a/tests/mcp/test_engine.py
+++ b/tests/mcp/test_engine.py
@@ -171,6 +171,92 @@ class TestValidateUniqueToolNames:
             validate_unique_tool_names([registration, registration])
 
 
+class _ImageFileAgentTools(FakeAgentTools):
+    """A room whose one file is a previewable image.
+
+    ``FakeAgentTools.read_room_file`` deliberately never fabricates bytes
+    (it returns a description-only result) -- this override supplies the
+    real MCP image-content shape ``AgentTools.read_room_file`` produces for
+    a small previewable image, so the image-passthrough test below exercises
+    the engine against that exact shape without a live platform.
+    """
+
+    async def read_room_file(self, file_id: str) -> dict[str, Any]:
+        return {
+            "content": [
+                {
+                    "type": "image",
+                    "data": "ZmFrZS1pbWFnZS1ieXRlcw==",
+                    "mimeType": "image/png",
+                }
+            ]
+        }
+
+
+class TestReadRoomFileImagePassthrough:
+    """band_read_room_file's image branch must reach the MCP client as a
+    real image content block, not get json.dumps'd into text like every
+    other tool result (see is_mcp_content_result/_mcp_content_blocks)."""
+
+    async def test_image_result_arrives_as_image_content_block(self) -> None:
+        fake = _ImageFileAgentTools(room_id="room-1")
+        resolver = _agent_resolver(fake)
+        definition = TOOL_DEFINITIONS["band_read_room_file"]
+        registration = build_tool_registration(
+            definition,
+            extend_with_chat_id(definition.input_model, None),
+            resolver=resolver,
+            strip_chat_id=True,
+        )
+        mcp = build_engine(EngineSpec(name="test-image", tools=(registration,)))
+
+        async with create_connected_server_and_client_session(mcp) as session:
+            result = await session.call_tool(
+                "band_read_room_file", {"chat_id": "room-1", "file_id": "f1"}
+            )
+
+        assert not result.isError, result.content
+        assert len(result.content) == 1
+        block = result.content[0]
+        assert block.type == "image"
+        assert block.data == "ZmFrZS1pbWFnZS1ieXRlcw=="
+        assert block.mimeType == "image/png"
+
+    async def test_non_image_result_still_arrives_as_text(
+        self, agent_session_factory
+    ) -> None:
+        """A description-only (non-image) read_room_file result keeps the
+        ordinary text-content wire shape -- structured_output=False only
+        changes how the *unstructured* content is built, not which results
+        qualify for the image branch."""
+        fake = FakeAgentTools(
+            room_id="room-1",
+            files=[
+                {
+                    "id": "f1",
+                    "name": "notes.txt",
+                    "content_type": "text/plain",
+                    "bytes": 12,
+                    "sha256": "a" * 64,
+                    "has_thumb": False,
+                }
+            ],
+        )
+        mcp = await agent_session_factory(
+            fake, definitions=[TOOL_DEFINITIONS["band_read_room_file"]]
+        )
+
+        async with create_connected_server_and_client_session(mcp) as session:
+            result = await session.call_tool(
+                "band_read_room_file", {"chat_id": "room-1", "file_id": "f1"}
+            )
+
+        assert not result.isError, result.content
+        assert result.content[0].type == "text"
+        payload = json.loads(result.content[0].text)
+        assert payload["description"].startswith("Fake file 'notes.txt'")
+
+
 @pytest.fixture
 async def agent_session_factory():
     """Yields a builder from a room-scoped FakeAgentTools to a connected

--- a/tests/runtime/test_tools.py
+++ b/tests/runtime/test_tools.py
@@ -50,8 +50,32 @@ from band.runtime.tools import (
     available_mention_handles,
     canonicalize_mcp_tool_name,
     format_tool_validation_error,
+    is_mcp_content_result,
     is_room_posting_tool,
 )
+
+
+class TestIsMcpContentResult:
+    """``is_mcp_content_result`` recognizes ``read_room_file``'s image-branch
+    shape so a consumer that supports real MCP content (claude_sdk, the MCP
+    engine) can pass it through instead of json.dumps-ing it into text."""
+
+    _IMAGE_RESULT = {
+        "content": [{"type": "image", "data": "YmFzZTY0", "mimeType": "image/png"}]
+    }
+    _TEXT_RESULT = {"name": "notes.txt", "content_type": "text/plain", "text": "hi"}
+
+    def test_true_for_image_content_block(self) -> None:
+        assert is_mcp_content_result(self._IMAGE_RESULT)
+
+    def test_false_for_plain_dict(self) -> None:
+        assert not is_mcp_content_result(self._TEXT_RESULT)
+
+    def test_false_for_non_dict(self) -> None:
+        assert not is_mcp_content_result("just a string")
+
+    def test_false_for_content_list_without_type_keys(self) -> None:
+        assert not is_mcp_content_result({"content": [{"no_type": 1}]})
 
 
 @pytest.fixture

--- a/tests/runtime/test_tools.py
+++ b/tests/runtime/test_tools.py
@@ -77,6 +77,11 @@ class TestIsMcpContentResult:
     def test_false_for_content_list_without_type_keys(self) -> None:
         assert not is_mcp_content_result({"content": [{"no_type": 1}]})
 
+    def test_false_for_empty_content_list(self) -> None:
+        """An empty list is vacuously all()-true; every consumer indexes
+        content[0] right after this check, so an empty list must not pass."""
+        assert not is_mcp_content_result({"content": []})
+
 
 @pytest.fixture
 def participants():

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -198,6 +198,27 @@ class TestCapabilityGatedSections:
 
         assert "## Contact Management Tools" not in prompt
 
+    def test_files_section_included_when_enabled(self):
+        """File tool instructions included when Capability.FILES is set."""
+        features = AdapterFeatures(capabilities={Capability.FILES})
+        prompt = render_system_prompt(
+            agent_name="Bot",
+            agent_description="helper",
+            features=features,
+        )
+
+        assert "## Room File Tools" in prompt
+        assert "band_read_room_file" in prompt
+
+    def test_files_section_absent_by_default(self):
+        """File tool instructions absent when no features."""
+        prompt = render_system_prompt(
+            agent_name="Bot",
+            agent_description="helper",
+        )
+
+        assert "## Room File Tools" not in prompt
+
     def test_both_capabilities_included(self):
         """Both sections included when both capabilities enabled."""
         features = AdapterFeatures(
@@ -211,6 +232,22 @@ class TestCapabilityGatedSections:
 
         assert "## Memory Tools" in prompt
         assert "## Contact Management Tools" in prompt
+
+    def test_all_three_capabilities_included(self):
+        """Memory, contact, and file sections all included when all three
+        capabilities are enabled."""
+        features = AdapterFeatures(
+            capabilities={Capability.MEMORY, Capability.CONTACTS, Capability.FILES}
+        )
+        prompt = render_system_prompt(
+            agent_name="Bot",
+            agent_description="helper",
+            features=features,
+        )
+
+        assert "## Memory Tools" in prompt
+        assert "## Contact Management Tools" in prompt
+        assert "## Room File Tools" in prompt
 
     def test_capability_sections_included_without_base_instructions(self):
         """Capability sections still render when include_base_instructions=False --


### PR DESCRIPTION
## Summary

Every registered framework adapter now supports `Capability.FILES` (`band_list_room_files`/`band_read_room_file`/`band_send_room_file`). Of the 16 registered adapters, 14 pass a small previewable image through to the model as real vision content instead of degrading it to a JSON-stringified blob (12 with a direct per-adapter probe, plus `letta` and `copilot_acp`, which inherit the fix transitively through the shared MCP engine and have no adapter-local code path to probe separately). The remaining two, `google_adk` and `parlant`, are confirmed unsupportable by their own frameworks, not unresearched.

Linear: INT-1350

## File support (`Capability.FILES`)

Every registered adapter: `claude_sdk`, `anthropic`, `opencode`, `gemini`, `langgraph`, `google_adk`, `agno`, `strands`, `codex`, `copilot_sdk`, `copilot_acp`, `letta`, `parlant`, `pydantic_ai`, `crewai`, `crewai_flow`.

Two wiring mechanisms:
- **Registry-driven** (`claude_sdk`, `anthropic`, `langgraph`, `gemini`, `google_adk`, `agno`, `strands`, `codex`, `copilot_sdk`, `opencode`, the ACP client adapter): tool schemas already derive generically from `iter_tool_definitions`/`get_openai_tool_schemas`/`get_anthropic_tool_schemas`, so declaring the capability was enough — no new plumbing.
- **Hand-rolled** (`parlant`, `pydantic_ai`, `crewai`/`crewai_flow`, which share `integrations/crewai/`): each mints one wrapper per platform tool instead of deriving from the registry, so each grew hand-written wrappers.
- `letta` routes tool execution entirely through the shared MCP engine (`integrations/mcp/engine.py`) rather than calling `execute_tool_call` directly, so it needed no adapter-side wiring at all.

`render_system_prompt` gained a `FILES_SECTION` so agents are told about the file tools when the capability is enabled.

## Image passthrough (`band_read_room_file` real vision content, not text)

| Adapter | Status |
|---|---|
| `claude_sdk`, `anthropic`, `opencode`, `gemini`, `langgraph`, `agno`, `strands`, `copilot_sdk` | Supported, directly probed. |
| `pydantic_ai` | Supported — returns `pydantic_ai.messages.BinaryContent` directly from the tool, pydantic-ai's own documented multimodal tool-result channel (`ToolReturnPart.content`). |
| `crewai`, `crewai_flow` | Supported — emits CrewAI's own `VISION_IMAGE:<media_type>:<base64_data>` sentinel string, parsed by `StepExecutor` (the default native-tool-calling execution path) into a real `image_url` content block before the LLM sees it. Both adapters share `integrations/crewai/`, so one fix covers both. |
| `codex` | Supported at the wire-shape level (`inputImage` content item with a `data:` URI, verified against the installed CLI's own generated JSON schema). Whether the Rust-side `codex-rs` binary actually accepts a `data:` URI, rather than only fetching `http(s)`, isn't verifiable from this repo's installed Python packages. |
| `letta`, `copilot_acp` | Supported transitively — both route through the same fixed MCP engine as `opencode`, so they inherit its fix and have no adapter-local path to probe on their own. |
| `google_adk` | **Not supportable today.** Installed `google-adk` 1.10.0's own `__build_response_event()` calls `Part.from_function_response()` without the `parts=` kwarg the underlying SDK supports, so no tool return value can reach a multimodal `FunctionResponse` through ADK's own flow. A framework limitation, not something fixable in this SDK. |
| `parlant` | **Not supportable today.** `parlant.core.tools.ToolResult` has no multimodal field, and Parlant's own MCP integration (`mcp_result_to_tool_result_data()`) discards image content blocks before they ever reach `ToolResult.data` — the same conclusion Parlant reaches on its own canonical external-tool-result path. |

Unit-level matrix proof for every supported row: `tests/framework_conformance/test_files_image_passthrough_matrix.py`. `crewai`/`crewai_flow` cases there need the isolated `dev-crewai` venv (listed explicitly in `ci.yml`'s crewai job — a bare `-k crewai` filter isn't statically verifiable by the job-coverage guard) and skip cleanly everywhere else.

## Live E2E coverage

Two live tests in `tests/e2e/baseline/smoke/matrix/test_capability_matrix.py`:
- `test_file_round_trip_across_files_adapters` — send → list → read round-trip with a text file, across every FILES-capable adapter in the baseline toolkit's matrix.
- `test_image_vision_passthrough_across_adapters` — a bystander peer uploads a randomly-colored generated PNG, the agent is asked to read and describe it, and an LLM judge checks the reply against the real uploaded color.

Both are gated behind `requires_file_transfer` (`pytest.mark.skipif` on `BaselineSettings().deployment.file_transfer`, i.e. the platform's `ff_file_transfer` flag), so they skip cleanly rather than fail on every deployment where that flag is off — which today is every SaaS and CI environment this repo runs against. Both were validated against a live deployment with the flag enabled during development (full-matrix dispatch run, 267 passed after fixing two real bugs this work surfaced: `letta`/`opencode`/the ACP client adapter caching their MCP tool registration from pre-negotiation features — see below — and a translation gap in `PeerActor.send_file`'s error path). Neither test currently executes in this repo's CI; they will the moment a lane points at a deployment with the flag on.

Two adapters are outside the baseline toolkit's matrix by design, not oversight:
- `parlant` registers no matrix adapter at all (self-hosted server per room, a fundamentally different lifecycle) — it gets a bespoke `@lane`-pinned smoke instead, per the baseline README.
- `crewai_flow`'s E2E builder uses a hardcoded echo flow with no Band tool loop, so there's no tool call for a file round-trip to drive.

Also fixed a capability-negotiation timing bug surfaced while wiring this: `letta`, `opencode`, and the ACP client adapter each cached their MCP tool registration once at construction time from pre-negotiation `self.features.capabilities`, so a deployment where negotiation *disabled* FILES after construction kept serving the file tools anyway. Each now overrides `apply_effective_features` to rebuild its cached registration from the negotiated features (`tests/adapters/test_negotiated_file_tools.py`).

## Single source of truth

- `READ_ROOM_FILE_TOOL_NAME`/`SEND_MESSAGE_TOOL_NAME` and the rest of the agent-surface tool vocabulary in `runtime/tools.py` are now `BandTool(StrEnum)` members, not loose string constants — every adapter's own `"band_read_room_file"` literal comparison was replaced with the enum member.
- `image_block_placeholder()`/`decode_image_block()` (`runtime/tools.py`) dedupe the placeholder string and base64-decode pattern repeated across `gemini`/`agno`/`strands`/`pydantic_ai`.
- `src/band/integrations/crewai/` was split into `reporting.py` (room context + tool-event reporters), `catalog.py` (the `@band_tool` bodies), and `tools.py` (build + run) — each of the 20 platform tools is now a single `@band_tool` async function instead of a hand-rolled `BaseTool` subclass, with the decorator owning the report_call/report_result/serialize lifecycle.
- `src/band/integrations/parlant/tools.py` was similarly rewritten to compose `require_session_tools`/`guard_failures`/`describe_from_master` instead of repeating the same guard-log-translate boilerplate in all 15 tools.
- `IMAGE_PASSTHROUGH_SUPPORTED_FRAMEWORK_IDS` derives from the lane-stable `Adapter` enum minus three `ExcludedAdapter(adapter, reason)` entries, rather than a hand-maintained allowlist.

## Test plan
- [x] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/ -q --no-cov` — 5357 passed, 0 failed (`dev` extra); `parlant` suite separately green under `dev-parlant`; `crewai`/`crewai_flow` suites separately green under `dev-crewai`
- [x] `uv run ruff check .` / `uv run ruff format .`
- [x] `uv run pyrefly check` — 0 errors
- [x] `uv run pytest --markdown-docs $(git ls-files '*.md' ':!:examples/*') --no-cov`
- [x] CI green on all 20 checks (lint, test × 2 OS × 2 Python, test-crewai × 4, test-parlant × 4, packaging, CodeQL, release-baseline-gate)
- [x] Live E2E validated manually against a deployment with `ff_file_transfer` on (full-matrix `workflow_dispatch`) before landing the skip-gate for CI environments where it's off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142oBtXk6Q7RJYK5f79UurZ
