### PR TITLE
chore: switch Discord changelog announcements to live mode

### DIFF
--- a/.band/changelog.yml
+++ b/.band/changelog.yml
@@ -12,7 +12,6 @@ announce:
     channel: integrations
     mode: live
   discord:
-    # channel is a label only — the webhook fixes the real target, which in
-    # draft mode is the private review channel a human forwards from.
     enabled: true
-    mode: draft
+    channel: announcements
+    mode: live


### PR DESCRIPTION
## Summary
- `announce.discord.mode: draft` (added in #554) documented posts landing in a private review channel for a human to forward. The installed `changelog-generator` skill (1.3.0) has no draft/review path — every enabled service posts straight to its webhook, public, immediately.
- The `DISCORD_WEBHOOK_URL` repo secret now points at `#announcements` directly. This aligns the config with actual behavior and with Slack (`mode: live`).
- `SLACK_WEBHOOK_URL` and `DISCORD_WEBHOOK_URL` are both set as repo secrets on `band-ai/band-sdk-python` (not on the `fern` docs repo, which only ever held an unrelated, differently-named `SLACK_CHANGELOG_WEBHOOK_URL`).

## Context
Investigating why the band-sdk-v3.0.0 Slack announcement never went out: no `SLACK_WEBHOOK_URL` secret existed anywhere, no CI workflow invokes the generator, and no scheduled routine exists — `generate` has only ever been run manually. This PR doesn't add automation (explicitly out of scope for now); it just makes the manual `generate` run produce the announcements the config claims it will.

## Test plan
- [x] `.band/changelog.yml` diff reviewed — no other keys touched
- [ ] Confirm the `SLACK_WEBHOOK_URL` and `DISCORD_WEBHOOK_URL` secrets were test-posted before being stored (not verified by me — I never had the raw URLs)