### PR TITLE
refactor: integrate band-sdk-core Session into BandLink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,9 @@ jobs:
         /tmp/test-install/bin/python <<'PYEOF'
         from band import Agent, BandLink, AgentRuntime
         from band.config import load_agent_config
-        from band_sdk_core import ClaimRegistry, ParticipantRoster, RetryTracker
+        from band_sdk_core import (
+            ClaimRegistry, ParticipantRoster, RetryTracker, Session, SessionPolicy,
+        )
 
         # Prove the pinned band_sdk_core wheel is callable, not just importable,
         # from this isolated install -- not only from the dev checkout via uv sync.
@@ -265,6 +267,8 @@ jobs:
         assert tracker.max_retries == 1
         roster = ParticipantRoster()
         assert roster.list() == []
+        session = Session(SessionPolicy.default())
+        assert session.begin_attempt(0.0) == 0
         print('Core imports successful')
         PYEOF
 

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -24,7 +24,7 @@ from phoenix_channels_python_client.exceptions import PHXConnectionError
 from phoenix_channels_python_client.phx_messages import PHXMessage
 from band.client.streaming.errors import (
     WebSocketUpgradeError,
-    classify_initial_upgrade_error,
+    probe_upgrade_error,
 )
 from band.client.streaming.watchdog import HeartbeatWatchdog
 from band.client.streaming.wire import WirePayload
@@ -387,6 +387,8 @@ class WebSocketClient:
         self._last_disconnect_reason: WebSocketDisconnectReason | None = None
         self._watchdog = HeartbeatWatchdog(session_policy or SessionPolicy.default())
         self._session = Session(self._watchdog.policy)
+        self._connect_failure_probed: bool = False
+        self._cached_connect_failure: WebSocketUpgradeError | None = None
 
     @property
     def validation_error_count(self) -> int:
@@ -455,20 +457,39 @@ class WebSocketClient:
             client.channel_socket_url += f"&agent_id={self.agent_id}"
         return client
 
+    async def _classify_connect_failure(
+        self, exc: Exception
+    ) -> WebSocketUpgradeError | None:
+        """Classify one failed connect exception, reusing the previous
+        live-socket probe result for a repeat unclassifiable
+        PHXConnectionError.
+
+        probe_upgrade_error blocks for up to open_timeout=5s; without this
+        cache it reran on every backoff retry of the very same rejection,
+        stacking its own network latency on top of every computed delay.
+        """
+        upgrade_error = WebSocketUpgradeError.from_exception(exc)
+        if upgrade_error is not None or not isinstance(exc, PHXConnectionError):
+            return upgrade_error
+        if not self._connect_failure_probed:
+            self._cached_connect_failure = await probe_upgrade_error(
+                self._require_client().channel_socket_url
+            )
+            self._connect_failure_probed = True
+        return self._cached_connect_failure
+
     async def _resolve_failed_connect_attempt(
         self, exc: Exception, epoch: int
     ) -> float:
         """Classify one failed initial-connect attempt through Session and
         resolve it to a retry delay, or raise if Session now considers the
         session Dead."""
-        # Captured before the live-socket probe below (up to open_timeout=5s
-        # inside classify_initial_upgrade_error) -- charging the probe's own
-        # latency to Session's rapid-disconnect timing would understate how
-        # fast repeated failures are actually happening.
+        # Captured before the live-socket probe inside
+        # _classify_connect_failure (up to open_timeout=5s) -- charging the
+        # probe's own latency to Session's rapid-disconnect timing would
+        # understate how fast repeated failures are actually happening.
         now = asyncio.get_running_loop().time()
-        upgrade_error = await classify_initial_upgrade_error(
-            exc, self._require_client().channel_socket_url
-        )
+        upgrade_error = await self._classify_connect_failure(exc)
         match upgrade_error:
             case WebSocketUpgradeError():
                 outcome = self._session.on_upgrade_rejected(
@@ -555,6 +576,8 @@ class WebSocketClient:
         start a new connection lifecycle, not resume a now-Dead one.
         """
         self._session = Session(self._watchdog.policy)
+        self._connect_failure_probed = False
+        self._cached_connect_failure = None
         while True:
             now = asyncio.get_running_loop().time()
             epoch = self._session.begin_attempt(now)

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -387,7 +387,7 @@ class WebSocketClient:
         self._last_disconnect_reason: WebSocketDisconnectReason | None = None
         self._watchdog = HeartbeatWatchdog(session_policy or SessionPolicy.default())
         self._session = Session(self._watchdog.policy)
-        self._connect_failure_probed: bool = False
+        self._probed_failure_message: str | None = None
         self._cached_connect_failure: WebSocketUpgradeError | None = None
 
     @property
@@ -460,22 +460,19 @@ class WebSocketClient:
     async def _classify_connect_failure(
         self, exc: Exception
     ) -> WebSocketUpgradeError | None:
-        """Classify one failed connect exception, reusing the previous
-        live-socket probe result for a repeat unclassifiable
-        PHXConnectionError.
-
-        probe_upgrade_error blocks for up to open_timeout=5s; without this
-        cache it reran on every backoff retry of the very same rejection,
-        stacking its own network latency on top of every computed delay.
-        """
+        """Classify one failed connect exception. Reuses the previous
+        live-socket probe result only while the wrapped PHXConnectionError's
+        message is unchanged -- a different message means the underlying
+        failure may have changed, so it must be probed again."""
         upgrade_error = WebSocketUpgradeError.from_exception(exc)
         if upgrade_error is not None or not isinstance(exc, PHXConnectionError):
             return upgrade_error
-        if not self._connect_failure_probed:
+        message = str(exc)
+        if message != self._probed_failure_message:
             self._cached_connect_failure = await probe_upgrade_error(
                 self._require_client().channel_socket_url
             )
-            self._connect_failure_probed = True
+            self._probed_failure_message = message
         return self._cached_connect_failure
 
     async def _resolve_failed_connect_attempt(
@@ -576,7 +573,7 @@ class WebSocketClient:
         start a new connection lifecycle, not resume a now-Dead one.
         """
         self._session = Session(self._watchdog.policy)
-        self._connect_failure_probed = False
+        self._probed_failure_message = None
         self._cached_connect_failure = None
         while True:
             now = asyncio.get_running_loop().time()

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -461,10 +461,14 @@ class WebSocketClient:
         """Classify one failed initial-connect attempt through Session and
         resolve it to a retry delay, or raise if Session now considers the
         session Dead."""
+        # Captured before the live-socket probe below (up to open_timeout=5s
+        # inside classify_initial_upgrade_error) -- charging the probe's own
+        # latency to Session's rapid-disconnect timing would understate how
+        # fast repeated failures are actually happening.
+        now = asyncio.get_running_loop().time()
         upgrade_error = await classify_initial_upgrade_error(
             exc, self._require_client().channel_socket_url
         )
-        now = asyncio.get_running_loop().time()
         match upgrade_error:
             case WebSocketUpgradeError():
                 outcome = self._session.on_upgrade_rejected(
@@ -501,8 +505,12 @@ class WebSocketClient:
             raise raise_exc from exc
 
         # None only when Dead (handled above) or stale (unreachable here) --
-        # narrows the type for the caller's asyncio.sleep.
-        assert outcome.retry_after_s is not None
+        # fail loudly rather than trust a Session contract that assert would
+        # silently drop under python -O.
+        if outcome.retry_after_s is None:
+            raise RuntimeError(
+                "Session returned a non-Dead outcome with no retry_after_s"
+            )
         logger.warning(
             "Initial WebSocket connection failed; retrying in %.2fs: %s",
             outcome.retry_after_s,
@@ -553,7 +561,16 @@ class WebSocketClient:
             if epoch is None:
                 # Unreachable given this loop's own control flow, but
                 # Session's signature allows it -- fail loudly rather than
-                # silently proceed with a None epoch.
+                # silently proceed with a None epoch, and still populate
+                # last_disconnect_reason like every other Dead path in this
+                # class so BandLink.connect() sees a terminal reason too.
+                self.record_terminal_disconnect(
+                    WebSocketDisconnectReason(
+                        reason="session_ended",
+                        message="WebSocket session is no longer connectable",
+                        retryable=False,
+                    )
+                )
                 raise RuntimeError("WebSocket session is no longer connectable")
 
             self.client = self._build_phx_client()

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -8,15 +8,24 @@ import logging
 import random
 from typing import Any, Literal
 
-from band_sdk_core import Session, SessionPolicy
+from band_sdk_core import (
+    DeadReason,
+    Session,
+    SessionOutcome,
+    SessionPolicy,
+    SessionState,
+    StaleReason,
+)
 from phoenix_channels_python_client.client import (
     PHXChannelsClient,
     PhoenixChannelsProtocolVersion,
 )
-from phoenix_channels_python_client.client_types import ReconnectPolicy
 from phoenix_channels_python_client.exceptions import PHXConnectionError
 from phoenix_channels_python_client.phx_messages import PHXMessage
-from band.client.streaming.errors import classify_initial_upgrade_error
+from band.client.streaming.errors import (
+    WebSocketUpgradeError,
+    classify_initial_upgrade_error,
+)
 from band.client.streaming.watchdog import HeartbeatWatchdog
 from band.client.streaming.wire import WirePayload
 from band.logging_config import core_issues, trace_context_extra
@@ -35,6 +44,8 @@ class WebSocketDisconnectReason:
     retry_after: int | None = None
     target_socket_id: str | None = None
     correlation_id: str | None = None
+    dead_reason: DeadReason | None = None
+    stale_reason: StaleReason | None = None
 
 
 # WebSocket message payloads (based on actual backend messages)
@@ -324,13 +335,32 @@ _PAYLOAD_MODELS: dict[WireEvent, type[WirePayload]] = {
 KNOWN_UNHANDLED_EVENTS = frozenset({WireEvent.EVENT_CREATED})
 
 
-def _initial_reconnect_delay(policy: ReconnectPolicy, attempt: int) -> float:
-    delay = min(
-        policy.max_delay_s, policy.base_delay_s * (policy.factor ** max(attempt, 0))
+def _disconnect_reason_from_exception(
+    exc: Exception, outcome: SessionOutcome
+) -> WebSocketDisconnectReason:
+    """Synthesize a WebSocketDisconnectReason for an initial-connect failure
+    Session has classified as terminal. Unlike the supersede path, there is
+    no platform wire payload here -- reason/message are derived from the
+    raised exception itself, not a server-supplied constant."""
+    session_fields = {
+        "dead_reason": outcome.dead_reason,
+        "stale_reason": outcome.stale_reason,
+    }
+    if isinstance(exc, WebSocketUpgradeError):
+        return WebSocketDisconnectReason(
+            reason=exc.code or f"http_{exc.status_code}",
+            message=exc.message,
+            retryable=False,
+            retry_after=exc.retry_after,
+            correlation_id=exc.request_id,
+            **session_fields,
+        )
+    return WebSocketDisconnectReason(
+        reason="connection_failed",
+        message=str(exc),
+        retryable=False,
+        **session_fields,
     )
-    if delay <= 0:
-        return 0.0
-    return (delay / 2) + (random.random() * (delay / 2))
 
 
 class WebSocketClient:
@@ -396,54 +426,135 @@ class WebSocketClient:
         if self._on_reconnect is not None:
             await self._on_reconnect()
 
-    async def __aenter__(self):
-        """Create and enter the PHXChannelsClient context"""
-        policy = ReconnectPolicy()
-        for attempt in range(policy.rapid_suppress_disconnect_count + 1):
-            self.client = PHXChannelsClient(
-                self.ws_url,
-                self.api_key,
-                protocol_version=PhoenixChannelsProtocolVersion.V2,
-                auto_reconnect=False,
-                heartbeat_interval_s=self._watchdog.policy.heartbeat_interval_s,
-                on_reconnect=self._handle_reconnect,
-                on_disconnect=self._on_disconnect,
-                on_heartbeat_ack=self._watchdog.reset_deadline,
-                # Also send the key as an x-api-key handshake header. Under
-                # proxy-managed sandbox custody the host-side proxy replaces the
-                # sentinel in this header (it can't touch the URL query), and the
-                # platform authenticates off the header (precedence over the
-                # query) — so the WS upgrade works with the real key never in the
-                # VM. Harmless elsewhere: same value the query already carries.
-                additional_headers={"x-api-key": self.api_key},
+    def _build_phx_client(self) -> PHXChannelsClient:
+        """Construct a fresh PHXChannelsClient for one connection attempt --
+        a new instance is required per attempt; the vendored client has no
+        reconnect-from-here primitive."""
+        client = PHXChannelsClient(
+            self.ws_url,
+            self.api_key,
+            protocol_version=PhoenixChannelsProtocolVersion.V2,
+            auto_reconnect=False,
+            heartbeat_interval_s=self._watchdog.policy.heartbeat_interval_s,
+            on_reconnect=self._handle_reconnect,
+            on_disconnect=self._on_disconnect,
+            on_heartbeat_ack=self._watchdog.reset_deadline,
+            # Also send the key as an x-api-key handshake header. Under
+            # proxy-managed sandbox custody the host-side proxy replaces the
+            # sentinel in this header (it can't touch the URL query), and the
+            # platform authenticates off the header (precedence over the
+            # query) — so the WS upgrade works with the real key never in the
+            # VM. Harmless elsewhere: same value the query already carries.
+            additional_headers={"x-api-key": self.api_key},
+        )
+        if self.agent_id:
+            client.channel_socket_url += f"&agent_id={self.agent_id}"
+        return client
+
+    async def _resolve_failed_connect_attempt(
+        self, exc: Exception, epoch: int
+    ) -> float:
+        """Classify one failed initial-connect attempt through Session and
+        resolve it to a retry delay, or raise if Session now considers the
+        session Dead."""
+        upgrade_error = await classify_initial_upgrade_error(
+            exc, self._require_client().channel_socket_url
+        )
+        now = asyncio.get_running_loop().time()
+        match upgrade_error:
+            case WebSocketUpgradeError():
+                outcome = self._session.on_upgrade_rejected(
+                    epoch,
+                    now,
+                    upgrade_error.status_code,
+                    upgrade_error.retry_after,
+                    random.random(),
+                )
+                raise_exc: Exception = upgrade_error
+            case None if isinstance(exc, PHXConnectionError):
+                outcome = self._session.on_socket_close(
+                    epoch, now, None, random.random()
+                )
+                raise_exc = exc
+            case _:
+                raise
+
+        if outcome.state is SessionState.Dead:
+            self.record_terminal_disconnect(
+                _disconnect_reason_from_exception(raise_exc, outcome)
             )
-            if self.agent_id:
-                self.client.channel_socket_url += f"&agent_id={self.agent_id}"
+            logger.warning(
+                "Initial WebSocket connection permanently failed (dead_reason=%s): %s",
+                outcome.dead_reason,
+                raise_exc,
+            )
+            if raise_exc is exc:
+                # Re-raising the exception already being handled -- no new
+                # object, so no chaining to add (bare raise).
+                raise raise_exc
+            # A newly-built WebSocketUpgradeError -- chain it to the
+            # original exception, same as the pre-Session code did.
+            raise raise_exc from exc
+
+        # None only when Dead (handled above) or stale (unreachable here) --
+        # narrows the type for the caller's asyncio.sleep.
+        assert outcome.retry_after_s is not None
+        logger.warning(
+            "Initial WebSocket connection failed; retrying in %.2fs: %s",
+            outcome.retry_after_s,
+            raise_exc,
+        )
+        return outcome.retry_after_s
+
+    def _finalize_successful_connect(self, epoch: int) -> None:
+        """Confirm a successful connect with Session, then hand ongoing
+        reconnect timing to the vendored client's own auto_reconnect loop --
+        untouched by Session (see the out-of-scope note in the design doc)."""
+        now = asyncio.get_running_loop().time()
+        connected = self._session.on_connected(epoch, now)
+        if connected.stale_reason is not None:
+            # Session's contract allows a stale outcome here even though it
+            # can't occur on a synchronous success -- log, nothing to do
+            # (the connect already succeeded).
+            logger.warning(
+                "Session.on_connected reported a stale outcome "
+                "(stale_reason=%s) for a synchronously-successful connect; "
+                "proceeding anyway.",
+                connected.stale_reason,
+            )
+        client = self._require_client()
+        client.auto_reconnect = True
+        self._watchdog.start(client)
+
+    async def __aenter__(self):
+        """Create and enter the PHXChannelsClient context.
+
+        Backoff/retry timing for this *initial*-connect loop is driven by
+        ``self._session``: it decides, on every failure, whether to sleep and
+        retry (``Reconnecting``) or give up for good (``Dead``). Once this
+        loop returns successfully, ongoing reconnect timing passes to the
+        vendored PHXChannelsClient's own ``auto_reconnect`` loop -- untouched
+        by ``Session`` (see the out-of-scope note in the design doc).
+        """
+        while True:
+            now = asyncio.get_running_loop().time()
+            epoch = self._session.begin_attempt(now)
+            if epoch is None:
+                # Unreachable given this loop's own control flow, but
+                # Session's signature allows it -- fail loudly rather than
+                # silently proceed with a None epoch.
+                raise RuntimeError("WebSocket session is no longer connectable")
+
+            self.client = self._build_phx_client()
+
             try:
                 await self.client.__aenter__()
             except Exception as exc:
-                upgrade_error = await classify_initial_upgrade_error(
-                    exc, self.client.channel_socket_url
-                )
-                if upgrade_error is not None:
-                    raise upgrade_error from exc
-                if not isinstance(exc, PHXConnectionError):
-                    raise
-                if attempt >= policy.rapid_suppress_disconnect_count:
-                    raise
-                delay = _initial_reconnect_delay(policy, attempt)
-                logger.warning(
-                    "Initial WebSocket connection failed; retrying in %.2fs: %s",
-                    delay,
-                    exc,
-                )
+                delay = await self._resolve_failed_connect_attempt(exc, epoch)
                 await asyncio.sleep(delay)
             else:
-                self.client.auto_reconnect = True
-                self._watchdog.start(self.client)
+                self._finalize_successful_connect(epoch)
                 return self
-
-        raise RuntimeError("WebSocket client failed to connect")
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Exit the PHXChannelsClient context"""

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -264,7 +264,9 @@ class SupersedePayload(WirePayload):
     target_socket_id: str | None = None
     correlation_id: str | None = None
 
-    def to_disconnect_reason(self) -> WebSocketDisconnectReason:
+    def to_disconnect_reason(
+        self, outcome: SessionOutcome | None = None
+    ) -> WebSocketDisconnectReason:
         return WebSocketDisconnectReason(
             reason=self.reason,
             message=self.message,
@@ -272,6 +274,8 @@ class SupersedePayload(WirePayload):
             retry_after=self.retry_after,
             target_socket_id=self.target_socket_id,
             correlation_id=self.correlation_id,
+            dead_reason=outcome.dead_reason if outcome is not None else None,
+            stale_reason=outcome.stale_reason if outcome is not None else None,
         )
 
 
@@ -661,6 +665,18 @@ class WebSocketClient:
         """Disable PHX auto-reconnect for a terminal platform disconnect."""
         if self.client:
             self.client.auto_reconnect = False
+
+    def handle_supersede(
+        self, retryable: bool, retry_after_s: float | None
+    ) -> SessionOutcome:
+        """Arbitrate an agent_control supersede event through Session --
+        whether it's actually current (not a stale notification about an
+        epoch this connection has already moved past) and, in principle,
+        whether a retryable supersede should keep reconnecting."""
+        now = asyncio.get_running_loop().time()
+        return self._session.on_supersede(
+            now, retryable, retry_after_s, random.random()
+        )
 
     async def join_agent_control_channel(
         self,

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -8,7 +8,7 @@ import logging
 import random
 from typing import Any, Literal
 
-from band_sdk_core import SessionPolicy
+from band_sdk_core import Session, SessionPolicy
 from phoenix_channels_python_client.client import (
     PHXChannelsClient,
     PhoenixChannelsProtocolVersion,
@@ -352,6 +352,7 @@ class WebSocketClient:
         self._validation_error_count: int = 0
         self._last_disconnect_reason: WebSocketDisconnectReason | None = None
         self._watchdog = HeartbeatWatchdog(session_policy or SessionPolicy.default())
+        self._session = Session(self._watchdog.policy)
 
     @property
     def validation_error_count(self) -> int:
@@ -447,6 +448,7 @@ class WebSocketClient:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Exit the PHXChannelsClient context"""
         await self._watchdog.stop()
+        self._session.end()
         if self.client:
             await self.client.__aexit__(exc_type, exc_val, exc_tb)
 

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -522,9 +522,10 @@ class WebSocketClient:
                 raise_exc,
             )
             if raise_exc is exc:
-                # Re-raising the exception already being handled -- no new
-                # object, so no chaining to add (bare raise).
-                raise raise_exc
+                # Bare raise: re-raising the exception already being handled
+                # via `raise raise_exc` would add a spurious extra frame to
+                # its traceback.
+                raise
             # A newly-built WebSocketUpgradeError -- chain it to the
             # original exception, same as the pre-Session code did.
             raise raise_exc from exc

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -539,7 +539,14 @@ class WebSocketClient:
         loop returns successfully, ongoing reconnect timing passes to the
         vendored PHXChannelsClient's own ``auto_reconnect`` loop -- untouched
         by ``Session`` (see the out-of-scope note in the design doc).
+
+        A fresh ``Session`` is built for every entry, mirroring the fresh
+        ``PHXChannelsClient`` built below -- ``__aexit__`` ends the previous
+        one, so reusing this instance across sequential ``async with``
+        blocks (as callers were free to do before ``Session`` existed) must
+        start a new connection lifecycle, not resume a now-Dead one.
         """
+        self._session = Session(self._watchdog.policy)
         while True:
             now = asyncio.get_running_loop().time()
             epoch = self._session.begin_attempt(now)

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -460,20 +460,27 @@ class WebSocketClient:
     async def _classify_connect_failure(
         self, exc: Exception
     ) -> WebSocketUpgradeError | None:
-        """Classify one failed connect exception. Reuses the previous
-        live-socket probe result only while the wrapped PHXConnectionError's
-        message is unchanged -- a different message means the underlying
-        failure may have changed, so it must be probed again."""
+        """Classify one failed connect exception via a live-socket probe,
+        reusing the previous result only while the wrapped message is
+        unchanged and that result carries no retry_after -- a retry_after
+        (e.g. a 429's Retry-After) can differ between two occurrences of the
+        same status, and Session's backoff needs the current value, so any
+        cached classification carrying one always gets a fresh probe."""
         upgrade_error = WebSocketUpgradeError.from_exception(exc)
         if upgrade_error is not None or not isinstance(exc, PHXConnectionError):
             return upgrade_error
         message = str(exc)
-        if message != self._probed_failure_message:
-            self._cached_connect_failure = await probe_upgrade_error(
+        cached = self._cached_connect_failure
+        cache_is_valid = message == self._probed_failure_message and (
+            cached is None or cached.retry_after is None
+        )
+        if not cache_is_valid:
+            cached = await probe_upgrade_error(
                 self._require_client().channel_socket_url
             )
+            self._cached_connect_failure = cached
             self._probed_failure_message = message
-        return self._cached_connect_failure
+        return cached
 
     async def _resolve_failed_connect_attempt(
         self, exc: Exception, epoch: int

--- a/src/band/client/streaming/errors.py
+++ b/src/band/client/streaming/errors.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from phoenix_channels_python_client.exceptions import PHXConnectionError
 from websockets.asyncio.client import connect
 
 
@@ -59,16 +58,11 @@ class WebSocketUpgradeError(Exception):
         )
 
 
-async def classify_initial_upgrade_error(
-    exc: Exception, websocket_url: str
-) -> WebSocketUpgradeError | None:
-    """Recover platform upgrade errors hidden by the Phoenix client supervisor."""
-    upgrade_error = WebSocketUpgradeError.from_exception(exc)
-    if upgrade_error is not None:
-        return upgrade_error
-    if not isinstance(exc, PHXConnectionError):
-        return None
-
+async def probe_upgrade_error(websocket_url: str) -> WebSocketUpgradeError | None:
+    """Recover a platform upgrade error hidden by the Phoenix client
+    supervisor's generic PHXConnectionError, via a fresh live-socket
+    handshake (blocks for up to open_timeout=5s) -- the supervisor's own
+    exception carries no HTTP status of its own to classify."""
     try:
         async with connect(websocket_url, open_timeout=5):
             return None

--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -22,6 +22,7 @@ from band_sdk_core import (
     AgentTopicKind,
     LeaveOutcome,
     RoomSubscribeResult,
+    SessionState,
     SubscriptionTracker,
     chat_room_topic,
     room_participants_topic,
@@ -725,12 +726,37 @@ class BandLink:
             self._agent_topics_needing_reconciliation.discard(topic)
 
     async def _on_supersede(self, payload: "SupersedePayload") -> None:
-        """Handle terminal supersede event before the platform closes the socket."""
-        reason = payload.to_disconnect_reason()
+        """Handle an agent_control supersede event before the platform closes
+        the socket. Session arbitrates whether this specific supersede is
+        actually current (not a stale notification about an epoch this
+        connection has already moved past) and, in principle, whether a
+        retryable supersede should keep the connection reconnecting --
+        though the platform hardcodes retryable=False today, so in practice
+        this still always resolves to Dead.
+        """
+        if self._ws is not None:
+            outcome = self._ws.handle_supersede(payload.retryable, payload.retry_after)
+            reason = payload.to_disconnect_reason(outcome)
+            if outcome.state is not SessionState.Dead:
+                # outcome.retry_after_s is computed but intentionally not
+                # applied here: enforcing it would mean this SDK taking over
+                # firing the actual reconnect attempt, which is the vendored
+                # PHXChannelsClient auto_reconnect loop's job today (see the
+                # design doc's out-of-scope boundary) -- untouched reconnect
+                # keeps working exactly as it does for any other disconnect.
+                logger.info(
+                    "Supersede reported retryable=True; Session kept the "
+                    "connection reconnecting (state=%s, retry_after_s=%s), "
+                    "not treating it as terminal.",
+                    outcome.state,
+                    outcome.retry_after_s,
+                )
+                return
+            self._ws.record_terminal_disconnect(reason)
+        else:
+            reason = payload.to_disconnect_reason()
         self._last_disconnect_reason = reason
         self._is_connected = False
-        if self._ws:
-            self._ws.record_terminal_disconnect(reason)
         logger.warning(
             "WebSocket connection superseded: reason=%s retryable=%s correlation_id=%s",
             reason.reason,

--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -195,6 +195,12 @@ class BandLink:
                 # cancelled) must still close the half-opened client, or it
                 # leaks -- _ws itself was never assigned, so there's nothing
                 # to roll back on that side.
+                if ws.last_disconnect_reason is not None:
+                    # A Session-classified terminal initial-connect failure
+                    # (__aenter__ already called record_terminal_disconnect)
+                    # -- surface it the same way a terminal supersede does,
+                    # even though self._ws was never assigned.
+                    self._last_disconnect_reason = ws.last_disconnect_reason
                 await ws.__aexit__(None, None, None)
                 raise
 

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -14,6 +14,7 @@ from band_rest import (
     UnprocessableEntityError,
 )
 from band_rest.core.api_error import ApiError
+from phoenix_channels_python_client.exceptions import PHXConnectionError
 
 from band.client.streaming import (
     MessageCreatedPayload,
@@ -25,6 +26,7 @@ from band.client.streaming import (
     RoomRemovedPayload,
     SupersedePayload,
     WebSocketClient,
+    WebSocketDisconnectReason,
 )
 from band.platform.event import (
     MessageEvent,
@@ -36,7 +38,7 @@ from band.platform.event import (
     WebSocketDisconnectedEvent,
 )
 from band.platform.link import BandLink
-from band_sdk_core import AgentTopicStatus, chat_room_topic
+from band_sdk_core import AgentTopicStatus, DeadReason, chat_room_topic
 
 from tests.conftest import make_message_event
 from tests.platform.conftest import cancelled_mid_await
@@ -214,6 +216,39 @@ class TestBandLinkConnection:
         await link.connect()
 
         assert link.is_connected is True
+
+    @patch("band.platform.link.WebSocketClient")
+    async def test_connect_propagates_terminal_reason_from_failed_initial_connect(
+        self, mock_ws_class, mock_ws_client
+    ):
+        """A Session-classified terminal initial-connect failure must set
+        last_disconnect_reason even though self._ws is never assigned for
+        this failure -- real WebSocketClient.__aenter__ already calls
+        record_terminal_disconnect on itself before raising, and connect()
+        must read that off the local `ws` it still holds."""
+        mock_ws_class.return_value = mock_ws_client
+        reason = WebSocketDisconnectReason(
+            reason="connection_failed",
+            message="temporary network failure",
+            retryable=False,
+            dead_reason=DeadReason.RapidDisconnect,
+        )
+
+        def fail_after_recording_terminal_disconnect():
+            mock_ws_client.last_disconnect_reason = reason
+            raise PHXConnectionError("temporary network failure")
+
+        mock_ws_client.__aenter__.side_effect = fail_after_recording_terminal_disconnect
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+
+        with pytest.raises(PHXConnectionError):
+            await link.connect()
+
+        assert link._ws is None
+        assert link.is_connected is False
+        assert link.last_disconnect_reason == reason
+        mock_ws_client.__aexit__.assert_called_once()
 
     @patch("band.platform.link.WebSocketClient")
     async def test_disconnect_exits_websocket_context(

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -38,7 +38,7 @@ from band.platform.event import (
     WebSocketDisconnectedEvent,
 )
 from band.platform.link import BandLink
-from band_sdk_core import AgentTopicStatus, DeadReason, chat_room_topic
+from band_sdk_core import AgentTopicStatus, DeadReason, SessionState, chat_room_topic
 
 from tests.conftest import make_message_event
 from tests.platform.conftest import cancelled_mid_await
@@ -91,6 +91,19 @@ def mock_ws_client():
         ws.last_disconnect_reason = reason
 
     ws.record_terminal_disconnect.side_effect = record_terminal_disconnect
+
+    # Documented "every real-world supersede is terminal" default (the
+    # platform hardcodes retryable=False today) -- an unconfigured autospec
+    # call would otherwise return a bare MagicMock whose `.state` is not
+    # SessionState.Dead, silently skipping record_terminal_disconnect in
+    # _on_supersede and breaking every existing supersede test using this
+    # fixture.
+    ws.handle_supersede.return_value = MagicMock(
+        state=SessionState.Dead,
+        dead_reason=DeadReason.Classified,
+        stale_reason=None,
+        retry_after_s=None,
+    )
 
     return ws
 
@@ -357,6 +370,38 @@ class TestBandLinkConnection:
         event = await link.__anext__()
         assert isinstance(event, WebSocketDisconnectedEvent)
         assert event.payload == link.last_disconnect_reason
+
+    async def test_retryable_supersede_leaves_connection_non_terminal(
+        self, mock_ws_client
+    ):
+        """A supersede Session classifies as still-Reconnecting (not Dead)
+        must not disable reconnect, set last_disconnect_reason, or queue a
+        terminal event -- unlike every real-world supersede today, which the
+        platform always sends retryable=False (so this has no real-world
+        trigger yet, only this synthetic regression guard for if that ever
+        changes)."""
+        mock_ws_client.handle_supersede.return_value = MagicMock(
+            state=SessionState.Reconnecting,
+            dead_reason=None,
+            stale_reason=None,
+            retry_after_s=1.0,
+        )
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link._ws = mock_ws_client
+        link._is_connected = True
+        payload = SupersedePayload(
+            reason="session.already_connected",
+            message="This connection has been superseded by a newer session for this agent.",
+            retryable=True,
+            correlation_id="evict-123",
+        )
+
+        await link._on_supersede(payload)
+
+        mock_ws_client.record_terminal_disconnect.assert_not_called()
+        assert link.is_connected is True
+        assert link.last_disconnect_reason is None
+        assert link._event_queue.empty()
 
     async def test_disconnect_after_supersede_still_cleans_up_websocket(
         self, mock_ws_client

--- a/tests/websocket/conftest.py
+++ b/tests/websocket/conftest.py
@@ -8,7 +8,7 @@ SUCCEEDS = object()
 """Sentinel meaning a scripted connect attempt or probe finds no error."""
 
 
-class _Script:
+class Script:
     """Advances through a fixed sequence of outcomes, one per `next()`
     call; the last entry repeats once the sequence is exhausted."""
 
@@ -27,7 +27,7 @@ class ScriptedPHXClient:
     SUCCEEDS."""
 
     def __init__(self, *script: Exception | object):
-        self._script = _Script(script)
+        self._script = Script(script)
         self.auto_reconnect: bool | None = None
         self.channel_socket_url = "wss://test/socket"
 
@@ -61,7 +61,7 @@ def scripted_connect(monkeypatch):
     return use
 
 
-class _ScriptedProbeConnection:
+class ScriptedProbeConnection:
     def __init__(self, outcome: Exception | object):
         self._outcome = outcome
 
@@ -80,12 +80,12 @@ class ScriptedProbe:
     the next scripted exception, or finds a clean handshake on SUCCEEDS."""
 
     def __init__(self, *script: Exception | object):
-        self._script = _Script(script)
-        self.probed_urls: list[tuple[str, int]] = []
+        self._script = Script(script)
+        self.probed_urls: list[tuple[str, float]] = []
 
-    def __call__(self, url: str, *, open_timeout: float) -> _ScriptedProbeConnection:
+    def __call__(self, url: str, *, open_timeout: float) -> ScriptedProbeConnection:
         self.probed_urls.append((url, open_timeout))
-        return _ScriptedProbeConnection(self._script.next())
+        return ScriptedProbeConnection(self._script.next())
 
 
 @pytest.fixture

--- a/tests/websocket/conftest.py
+++ b/tests/websocket/conftest.py
@@ -1,6 +1,115 @@
 from __future__ import annotations
 
+import pytest
+
 from band_sdk_core import SessionPolicy
+
+SUCCEEDS = object()
+"""Sentinel meaning a scripted connect attempt or probe finds no error."""
+
+
+class _Script:
+    """Advances through a fixed sequence of outcomes, one per `next()`
+    call; the last entry repeats once the sequence is exhausted."""
+
+    def __init__(self, outcomes: tuple[Exception | object, ...]):
+        self._outcomes = outcomes
+        self.calls = 0
+
+    def next(self) -> Exception | object:
+        self.calls += 1
+        return self._outcomes[min(self.calls, len(self._outcomes)) - 1]
+
+
+class ScriptedPHXClient:
+    """Fake PHXChannelsClient driven by a script of outcomes: each
+    __aenter__ call raises the next scripted exception, or succeeds on
+    SUCCEEDS."""
+
+    def __init__(self, *script: Exception | object):
+        self._script = _Script(script)
+        self.auto_reconnect: bool | None = None
+        self.channel_socket_url = "wss://test/socket"
+
+    @property
+    def attempts(self) -> int:
+        return self._script.calls
+
+    def __call__(self, *args, **kwargs):
+        self.auto_reconnect = kwargs["auto_reconnect"]
+        return self
+
+    async def __aenter__(self):
+        outcome = self._script.next()
+        if outcome is SUCCEEDS:
+            return self
+        raise outcome
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+
+@pytest.fixture
+def scripted_connect(monkeypatch):
+    """Patch PHXChannelsClient with a ScriptedPHXClient driven by `script`."""
+
+    def use(*script: Exception | object) -> ScriptedPHXClient:
+        client = ScriptedPHXClient(*script)
+        monkeypatch.setattr("band.client.streaming.client.PHXChannelsClient", client)
+        return client
+
+    return use
+
+
+class _ScriptedProbeConnection:
+    def __init__(self, outcome: Exception | object):
+        self._outcome = outcome
+
+    async def __aenter__(self):
+        if self._outcome is SUCCEEDS:
+            return self
+        raise self._outcome
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+
+class ScriptedProbe:
+    """Fake live-socket probe (the `connect()` call inside
+    probe_upgrade_error) driven by a script of outcomes: each call raises
+    the next scripted exception, or finds a clean handshake on SUCCEEDS."""
+
+    def __init__(self, *script: Exception | object):
+        self._script = _Script(script)
+        self.probed_urls: list[tuple[str, int]] = []
+
+    def __call__(self, url: str, *, open_timeout: float) -> _ScriptedProbeConnection:
+        self.probed_urls.append((url, open_timeout))
+        return _ScriptedProbeConnection(self._script.next())
+
+
+@pytest.fixture
+def scripted_probe(monkeypatch):
+    """Patch errors.connect with a ScriptedProbe driven by `script`."""
+
+    def use(*script: Exception | object) -> ScriptedProbe:
+        probe = ScriptedProbe(*script)
+        monkeypatch.setattr("band.client.streaming.errors.connect", probe)
+        return probe
+
+    return use
+
+
+@pytest.fixture
+def no_real_sleep(monkeypatch) -> list[float]:
+    """Patch asyncio.sleep to return immediately, recording each delay."""
+    delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr("band.client.streaming.client.asyncio.sleep", fake_sleep)
+    return delays
 
 
 def fast_session_policy(

--- a/tests/websocket/conftest.py
+++ b/tests/websocket/conftest.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from band_sdk_core import SessionPolicy
+
+
+def fast_session_policy(
+    *, heartbeat_interval_s: float, dead_threshold_s: float
+) -> SessionPolicy:
+    """A SessionPolicy with real reconnect-backoff defaults (mirroring
+    SessionPolicy.default()) but a fast heartbeat/dead-threshold pair, so
+    watchdog/reconnect tests run in real fractional seconds instead of
+    production's 30s/60s."""
+    return SessionPolicy(
+        {
+            "base_delay_s": 1.0,
+            "factor": 2.0,
+            "max_delay_s": 30.0,
+            "stable_reset_s": 60.0,
+            "rapid_disconnect_uptime_s": 10.0,
+            "rapid_window_s": 300.0,
+            "rapid_first_min_delay_s": 1.0,
+            "rapid_second_min_delay_s": 5.0,
+            "rapid_cooldown_base_s": 10.0,
+            "rapid_cooldown_step_s": 10.0,
+            "rapid_cooldown_max_s": 60.0,
+            "rapid_threshold": 10,
+            "heartbeat_interval_s": heartbeat_interval_s,
+            "dead_threshold_s": dead_threshold_s,
+        }
+    )

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -399,6 +399,71 @@ async def test_aenter_probes_initial_phx_connection_error_then_retries_and_succe
     await client.__aexit__(None, None, None)
 
 
+async def test_aenter_caches_probe_result_across_repeated_connect_failures(
+    monkeypatch,
+):
+    """The live-socket probe recovering a PHXConnectionError's hidden upgrade
+    rejection blocks for up to open_timeout=5s -- rerunning it on every
+    backoff retry of the very same rejection would stack a fresh network
+    round trip onto every computed delay. A repeat bare PHXConnectionError
+    must reuse the first probe's classification instead of probing again."""
+    upgrade_exc = _upgrade_exception(
+        429,
+        b'{"error":{"code":"too_many_requests","message":"slow down","request_id":"req-429"}}',
+        {"Retry-After": "5"},
+    )
+    probed_urls = []
+    attempts = 0
+
+    class RecoveringPHXClient:
+        def __init__(self, *args, **kwargs):
+            self.channel_socket_url = "wss://test/socket"
+            self.auto_reconnect = kwargs["auto_reconnect"]
+
+        async def __aenter__(self):
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise PHXConnectionError(
+                    "Connection supervisor stopped before connecting"
+                )
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
+    class FailingProbe:
+        async def __aenter__(self):
+            raise upgrade_exc
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
+    def fake_connect(url, *, open_timeout):
+        probed_urls.append((url, open_timeout))
+        return FailingProbe()
+
+    async def fake_sleep(delay):
+        return None
+
+    monkeypatch.setattr(
+        "band.client.streaming.client.PHXChannelsClient", RecoveringPHXClient
+    )
+    monkeypatch.setattr("band.client.streaming.errors.connect", fake_connect)
+    monkeypatch.setattr("band.client.streaming.client.asyncio.sleep", fake_sleep)
+
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+    await client.__aenter__()
+
+    assert attempts == 3
+    # Two attempts failed with the unclassifiable PHXConnectionError, but the
+    # probe only ran once -- the second failure's classification came from
+    # the cache.
+    assert probed_urls == [("wss://test/socket&agent_id=agent-123", 5)]
+
+    await client.__aexit__(None, None, None)
+
+
 async def test_aenter_restores_reconnect_after_successful_initial_connect(monkeypatch):
     init_kwargs = {}
 
@@ -480,7 +545,7 @@ async def test_aenter_retries_unclassified_initial_connection_errors(monkeypatch
         async def __aexit__(self, exc_type, exc_val, exc_tb):
             return None
 
-    async def no_upgrade_error(exc, websocket_url):
+    async def no_upgrade_error(websocket_url):
         return None
 
     async def fake_sleep(delay):
@@ -490,7 +555,7 @@ async def test_aenter_retries_unclassified_initial_connection_errors(monkeypatch
         "band.client.streaming.client.PHXChannelsClient", FlakyPHXClient
     )
     monkeypatch.setattr(
-        "band.client.streaming.client.classify_initial_upgrade_error",
+        "band.client.streaming.client.probe_upgrade_error",
         no_upgrade_error,
     )
     monkeypatch.setattr("band.client.streaming.client.asyncio.sleep", fake_sleep)
@@ -535,7 +600,7 @@ async def test_aenter_trips_dead_after_rapid_disconnect_threshold(monkeypatch):
             attempts += 1
             raise PHXConnectionError("temporary network failure")
 
-    async def no_upgrade_error(exc, websocket_url):
+    async def no_upgrade_error(websocket_url):
         return None
 
     async def fake_sleep(delay):
@@ -545,7 +610,7 @@ async def test_aenter_trips_dead_after_rapid_disconnect_threshold(monkeypatch):
         "band.client.streaming.client.PHXChannelsClient", AlwaysFailingPHXClient
     )
     monkeypatch.setattr(
-        "band.client.streaming.client.classify_initial_upgrade_error",
+        "band.client.streaming.client.probe_upgrade_error",
         no_upgrade_error,
     )
     monkeypatch.setattr("band.client.streaming.client.asyncio.sleep", fake_sleep)
@@ -572,10 +637,10 @@ async def test_resolve_failed_connect_attempt_captures_now_before_probe_latency(
     monkeypatch,
 ):
     """`now` must be the wall-clock time the connect attempt actually failed,
-    not the time classify_initial_upgrade_error's live-socket probe finished
-    -- otherwise a burst of true back-to-back failures each looks slower than
-    it really was, understating how rapid the disconnects are to Session's
-    rolling rapid-disconnect window."""
+    not the time probe_upgrade_error's live-socket probe finished -- otherwise
+    a burst of true back-to-back failures each looks slower than it really
+    was, understating how rapid the disconnects are to Session's rolling
+    rapid-disconnect window."""
     now_s_seen = []
 
     class RecordingSession:
@@ -604,13 +669,13 @@ async def test_resolve_failed_connect_attempt_captures_now_before_probe_latency(
 
     probe_delay_s = 0.1
 
-    async def slow_classify(exc, websocket_url):
+    async def slow_probe(websocket_url):
         await asyncio.sleep(probe_delay_s)
         return None
 
     monkeypatch.setattr(
-        "band.client.streaming.client.classify_initial_upgrade_error",
-        slow_classify,
+        "band.client.streaming.client.probe_upgrade_error",
+        slow_probe,
     )
 
     attempts = 0
@@ -699,11 +764,11 @@ async def test_resolve_failed_connect_attempt_raises_when_retry_after_s_missing(
 
     monkeypatch.setattr("band.client.streaming.client.Session", BadOutcomeSession)
 
-    async def no_upgrade_error(exc, websocket_url):
+    async def no_upgrade_error(websocket_url):
         return None
 
     monkeypatch.setattr(
-        "band.client.streaming.client.classify_initial_upgrade_error",
+        "band.client.streaming.client.probe_upgrade_error",
         no_upgrade_error,
     )
 

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -209,7 +209,8 @@ async def test_supersede_event_records_terminal_reason_and_disables_reconnect():
     async def on_supersede(payload: SupersedePayload):
         nonlocal received_payload
         received_payload = payload
-        client.record_terminal_disconnect(payload.to_disconnect_reason())
+        outcome = client.handle_supersede(payload.retryable, payload.retry_after)
+        client.record_terminal_disconnect(payload.to_disconnect_reason(outcome))
 
     class MockMessage:
         event = "supersede"
@@ -233,6 +234,7 @@ async def test_supersede_event_records_terminal_reason_and_disables_reconnect():
         retry_after=15,
         target_socket_id="agent_socket:agent-123",
         correlation_id="evict-123",
+        dead_reason=DeadReason.Classified,
     )
 
 

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -430,6 +430,37 @@ async def test_aenter_restores_reconnect_after_successful_initial_connect(monkey
     await client.__aexit__(None, None, None)
 
 
+async def test_aenter_reusable_after_aexit_ends_the_session(monkeypatch):
+    """__aexit__ ends self._session (Dead), so a second __aenter__ on the
+    same instance must build a fresh Session rather than resuming the
+    now-Dead one -- otherwise begin_attempt() returns None and __aenter__
+    raises, even though reusing an exited instance across sequential
+    `async with` blocks worked before Session existed (a fresh
+    PHXChannelsClient was always built per entry)."""
+
+    class SuccessfulPHXClient:
+        def __init__(self, *args, **kwargs):
+            self.channel_socket_url = "wss://test/socket"
+            self.auto_reconnect = kwargs["auto_reconnect"]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
+    monkeypatch.setattr(
+        "band.client.streaming.client.PHXChannelsClient", SuccessfulPHXClient
+    )
+
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+    async with client:
+        pass
+
+    async with client:
+        assert client.client.auto_reconnect is True
+
+
 async def test_aenter_retries_unclassified_initial_connection_errors(monkeypatch):
     attempts = 0
     sleep_delays = []

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -17,7 +17,6 @@ from unittest.mock import AsyncMock
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
-from band_sdk_core import SessionPolicy
 from opentelemetry.sdk.trace import TracerProvider
 from phoenix_channels_python_client.exceptions import PHXConnectionError
 from websockets.asyncio.server import ServerConnection, serve
@@ -43,6 +42,7 @@ from band.client.streaming import (
     RoomRemovedPayload,
     WebSocketClient,
 )
+from tests.websocket.conftest import fast_session_policy
 
 # Shared valid payload used by multiple tests
 VALID_MESSAGE_CREATED_PAYLOAD: dict = {
@@ -1021,33 +1021,6 @@ async def test_cancelled_error_propagates_through_callback():
 # --- Heartbeat dead-threshold watchdog tests (INT-1323) ---
 
 
-def _fast_session_policy(
-    *, heartbeat_interval_s: float, dead_threshold_s: float
-) -> SessionPolicy:
-    """A SessionPolicy with real reconnect-backoff defaults (mirroring
-    SessionPolicy.default()) but a fast heartbeat/dead-threshold pair, so
-    watchdog tests run in real fractional seconds instead of production's
-    30s/60s."""
-    return SessionPolicy(
-        {
-            "base_delay_s": 1.0,
-            "factor": 2.0,
-            "max_delay_s": 30.0,
-            "stable_reset_s": 60.0,
-            "rapid_disconnect_uptime_s": 10.0,
-            "rapid_window_s": 300.0,
-            "rapid_first_min_delay_s": 1.0,
-            "rapid_second_min_delay_s": 5.0,
-            "rapid_cooldown_base_s": 10.0,
-            "rapid_cooldown_step_s": 10.0,
-            "rapid_cooldown_max_s": 60.0,
-            "rapid_threshold": 10,
-            "heartbeat_interval_s": heartbeat_interval_s,
-            "dead_threshold_s": dead_threshold_s,
-        }
-    )
-
-
 @asynccontextmanager
 async def phoenix_peer(*, ack_heartbeats: bool = True):
     """In-process peer that completes the WS upgrade and, when
@@ -1090,7 +1063,7 @@ async def test_watchdog_ack_keeps_connection_alive_across_heartbeat_cycles():
     """A real heartbeat/ack round-trip resets the watchdog deadline each
     cycle, so the connection survives well past a single dead_threshold_s
     window without the watchdog ever tripping."""
-    policy = _fast_session_policy(heartbeat_interval_s=0.15, dead_threshold_s=0.4)
+    policy = fast_session_policy(heartbeat_interval_s=0.15, dead_threshold_s=0.4)
     async with phoenix_peer() as (ws_url, connected):
         async with WebSocketClient(
             ws_url, "test-key", "agent-123", session_policy=policy
@@ -1106,7 +1079,7 @@ async def test_watchdog_forces_close_and_reconnect_when_ack_withheld():
     """A withheld ack forces close_connection at (approximately)
     dead_threshold_s, and the forced close flows into the client's own
     reconnect path -- on_reconnect fires once the new connection lands."""
-    policy = _fast_session_policy(heartbeat_interval_s=0.15, dead_threshold_s=0.4)
+    policy = fast_session_policy(heartbeat_interval_s=0.15, dead_threshold_s=0.4)
     reconnected = asyncio.Event()
 
     async def on_reconnect() -> None:
@@ -1134,7 +1107,7 @@ async def test_watchdog_task_cancelled_cleanly_on_aexit():
     (HeartbeatWatchdog's own cancellation behavior is covered directly in
     test_watchdog.py; this test only checks WebSocketClient wires __aexit__
     to it.)"""
-    policy = _fast_session_policy(heartbeat_interval_s=0.05, dead_threshold_s=5.0)
+    policy = fast_session_policy(heartbeat_interval_s=0.05, dead_threshold_s=5.0)
     async with phoenix_peer() as (ws_url, connected):
         client = WebSocketClient(ws_url, "test-key", "agent-123", session_policy=policy)
         async with client:

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -25,7 +25,7 @@ from websockets.exceptions import InvalidStatus
 from websockets.http11 import Response
 
 import band_sdk_core
-from band_sdk_core import DeadReason
+from band_sdk_core import DeadReason, SessionState
 
 from band.credentials import PROXY_MANAGED_API_KEY
 import band.client.streaming.wire as wire_module
@@ -566,6 +566,162 @@ async def test_aenter_trips_dead_after_rapid_disconnect_threshold(monkeypatch):
     # so no `from` chaining applies -- self-referential __cause__ would be
     # incorrect (and misleading) here.
     assert exc_info.value.__cause__ is None
+
+
+async def test_resolve_failed_connect_attempt_captures_now_before_probe_latency(
+    monkeypatch,
+):
+    """`now` must be the wall-clock time the connect attempt actually failed,
+    not the time classify_initial_upgrade_error's live-socket probe finished
+    -- otherwise a burst of true back-to-back failures each looks slower than
+    it really was, understating how rapid the disconnects are to Session's
+    rolling rapid-disconnect window."""
+    now_s_seen = []
+
+    class RecordingSession:
+        def __init__(self, policy):
+            pass
+
+        def begin_attempt(self, now_s):
+            return 1
+
+        def on_socket_close(self, epoch, now_s, close_code, jitter_sample):
+            now_s_seen.append(now_s)
+            return SimpleNamespace(
+                state=SessionState.Reconnecting,
+                retry_after_s=0.0,
+                dead_reason=None,
+                stale_reason=None,
+            )
+
+        def on_connected(self, epoch, now_s):
+            return SimpleNamespace(stale_reason=None)
+
+        def end(self):
+            return SessionState.Dead
+
+    monkeypatch.setattr("band.client.streaming.client.Session", RecordingSession)
+
+    probe_delay_s = 0.1
+
+    async def slow_classify(exc, websocket_url):
+        await asyncio.sleep(probe_delay_s)
+        return None
+
+    monkeypatch.setattr(
+        "band.client.streaming.client.classify_initial_upgrade_error",
+        slow_classify,
+    )
+
+    attempts = 0
+
+    class FailOncePHXClient:
+        def __init__(self, *args, **kwargs):
+            self.channel_socket_url = "wss://test/socket"
+            self.auto_reconnect = kwargs["auto_reconnect"]
+
+        async def __aenter__(self):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise PHXConnectionError("temporary network failure")
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
+    monkeypatch.setattr(
+        "band.client.streaming.client.PHXChannelsClient", FailOncePHXClient
+    )
+
+    start = asyncio.get_running_loop().time()
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+    await client.__aenter__()
+
+    assert len(now_s_seen) == 1
+    # The probe alone burns probe_delay_s; if `now` were captured after it,
+    # the recorded gap would be at least that large.
+    assert now_s_seen[0] - start < probe_delay_s / 2
+
+    await client.__aexit__(None, None, None)
+
+
+async def test_aenter_records_terminal_disconnect_when_session_returns_no_epoch(
+    monkeypatch,
+):
+    """begin_attempt() returning None is unreachable given this loop's own
+    control flow, but Session's own signature allows it -- if it ever
+    happens, last_disconnect_reason must still be populated before raising,
+    like every other Dead path in this class, so BandLink.connect() sees a
+    terminal reason instead of silently keeping a stale one."""
+
+    class DeadOnArrivalSession:
+        def __init__(self, policy):
+            pass
+
+        def begin_attempt(self, now_s):
+            return None
+
+    monkeypatch.setattr("band.client.streaming.client.Session", DeadOnArrivalSession)
+
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+
+    with pytest.raises(RuntimeError, match="no longer connectable"):
+        await client.__aenter__()
+
+    assert client.last_disconnect_reason is not None
+    assert client.last_disconnect_reason.retryable is False
+
+
+async def test_resolve_failed_connect_attempt_raises_when_retry_after_s_missing(
+    monkeypatch,
+):
+    """A non-Dead SessionOutcome with retry_after_s=None can't happen with the
+    real Session today, but if that contract were ever violated, a bare
+    `assert` would be stripped under `python -O` and surface as an unhandled
+    `asyncio.sleep(None)` TypeError -- this must fail loudly instead, like
+    the sibling `epoch is None` check in `__aenter__`."""
+
+    class BadOutcomeSession:
+        def __init__(self, policy):
+            pass
+
+        def begin_attempt(self, now_s):
+            return 1
+
+        def on_socket_close(self, epoch, now_s, close_code, jitter_sample):
+            return SimpleNamespace(
+                state=SessionState.Reconnecting,
+                retry_after_s=None,
+                dead_reason=None,
+                stale_reason=None,
+            )
+
+    monkeypatch.setattr("band.client.streaming.client.Session", BadOutcomeSession)
+
+    async def no_upgrade_error(exc, websocket_url):
+        return None
+
+    monkeypatch.setattr(
+        "band.client.streaming.client.classify_initial_upgrade_error",
+        no_upgrade_error,
+    )
+
+    class FailingPHXClient:
+        def __init__(self, *args, **kwargs):
+            self.channel_socket_url = "wss://test/socket"
+
+        async def __aenter__(self):
+            raise PHXConnectionError("temporary network failure")
+
+    monkeypatch.setattr(
+        "band.client.streaming.client.PHXChannelsClient", FailingPHXClient
+    )
+
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+
+    with pytest.raises(RuntimeError, match="no retry_after_s"):
+        await client.__aenter__()
 
 
 async def test_aenter_reraises_unrecognized_upgrade_error(monkeypatch):

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -25,6 +25,7 @@ from websockets.exceptions import InvalidStatus
 from websockets.http11 import Response
 
 import band_sdk_core
+from band_sdk_core import DeadReason
 
 from band.credentials import PROXY_MANAGED_API_KEY
 import band.client.streaming.wire as wire_module
@@ -319,23 +320,45 @@ async def test_aenter_wraps_upgrade_error(monkeypatch):
     assert exc_info.value.status_code == 409
     assert exc_info.value.code == "connection_conflict"
     assert exc_info.value.request_id == "req-409"
+    # WebSocketUpgradeError is a new object distinct from the raw exception
+    # PHXChannelsClient raised -- explicit chaining keeps that link visible
+    # in tracebacks and error trackers.
+    assert exc_info.value.__cause__ is upgrade_exc
 
 
-async def test_aenter_probes_initial_phx_connection_error(monkeypatch):
+async def test_aenter_probes_initial_phx_connection_error_then_retries_and_succeeds(
+    monkeypatch,
+):
+    """A 429 upgrade rejection -- recovered via classify_initial_upgrade_error's
+    probe fallback, since the raw PHXConnectionError carries no HTTP status
+    itself -- classifies as Retry (classify_upgrade marks only 400/403/409
+    Terminal), so it retries using Retry-After as a delay floor instead of
+    raising on the first attempt, then succeeds once the rate limit clears."""
     upgrade_exc = _upgrade_exception(
         429,
         b'{"error":{"code":"too_many_requests","message":"slow down","request_id":"req-429"}}',
-        {"Retry-After": "30"},
+        {"Retry-After": "5"},
     )
     probed_urls = []
+    attempts = 0
 
-    class FailingPHXClient:
+    class RecoveringPHXClient:
         def __init__(self, *args, **kwargs):
             assert kwargs["auto_reconnect"] is False
             self.channel_socket_url = "wss://test/socket"
+            self.auto_reconnect = kwargs["auto_reconnect"]
 
         async def __aenter__(self):
-            raise PHXConnectionError("Connection supervisor stopped before connecting")
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise PHXConnectionError(
+                    "Connection supervisor stopped before connecting"
+                )
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
 
     class FailingProbe:
         async def __aenter__(self):
@@ -348,20 +371,30 @@ async def test_aenter_probes_initial_phx_connection_error(monkeypatch):
         probed_urls.append((url, open_timeout))
         return FailingProbe()
 
+    sleep_delays = []
+
+    async def fake_sleep(delay):
+        sleep_delays.append(delay)
+
     monkeypatch.setattr(
-        "band.client.streaming.client.PHXChannelsClient", FailingPHXClient
+        "band.client.streaming.client.PHXChannelsClient", RecoveringPHXClient
     )
     monkeypatch.setattr("band.client.streaming.errors.connect", fake_connect)
+    monkeypatch.setattr("band.client.streaming.client.asyncio.sleep", fake_sleep)
 
     client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+    await client.__aenter__()
 
-    with pytest.raises(WebSocketUpgradeError) as exc_info:
-        await client.__aenter__()
-
+    assert attempts == 2
     assert probed_urls == [("wss://test/socket&agent_id=agent-123", 5)]
-    assert exc_info.value.status_code == 429
-    assert exc_info.value.code == "too_many_requests"
-    assert exc_info.value.retry_after == 30
+    # retry_after_s is a lower bound (Retry-After) with an upper bound of
+    # max(max_delay_s, retry_after_s) -- see the design doc's "on_upgrade_rejected"
+    # semantics -- rather than asserting one exact jittered value.
+    assert len(sleep_delays) == 1
+    assert 5.0 <= sleep_delays[0] <= 30.0
+    assert client.client.auto_reconnect is True
+
+    await client.__aexit__(None, None, None)
 
 
 async def test_aenter_restores_reconnect_after_successful_initial_connect(monkeypatch):
@@ -429,16 +462,77 @@ async def test_aenter_retries_unclassified_initial_connection_errors(monkeypatch
     )
     monkeypatch.setattr("band.client.streaming.client.asyncio.sleep", fake_sleep)
 
-    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+    client = WebSocketClient(
+        "ws://localhost",
+        "test-key",
+        "agent-123",
+        session_policy=fast_session_policy(
+            heartbeat_interval_s=0.15, dead_threshold_s=0.4
+        ),
+    )
     await client.__aenter__()
 
     assert attempts == 3
-    assert len(sleep_delays) == 2
+    # Both retries are the first two rapid disconnects (never having reached
+    # Up) -- their delay floors (rapid_first_min_delay_s/rapid_second_min_delay_s)
+    # are policy-driven and not jitter-scaled, so this is deterministic.
+    assert sleep_delays == [1.0, 5.0]
     assert client.client.auto_reconnect is True
 
     # fake_sleep never advances the clock; an un-stopped watchdog's
     # deadline-check loop would spin on it with no real yield point.
     await client.__aexit__(None, None, None)
+
+
+async def test_aenter_trips_dead_after_rapid_disconnect_threshold(monkeypatch):
+    """A burst of fast-repeating initial-connect failures trips Session
+    straight to Dead(RapidDisconnect) once the rolling rapid-disconnect
+    window's threshold is reached. Uses SessionPolicy.default() (not
+    fast_session_policy, which only fast-forwards heartbeat/dead-threshold,
+    not reconnect-backoff fields) since asyncio.sleep is mocked below, so
+    the real default rapid_threshold=10 costs no wall-clock time."""
+    attempts = 0
+
+    class AlwaysFailingPHXClient:
+        def __init__(self, *args, **kwargs):
+            self.channel_socket_url = "wss://test/socket"
+
+        async def __aenter__(self):
+            nonlocal attempts
+            attempts += 1
+            raise PHXConnectionError("temporary network failure")
+
+    async def no_upgrade_error(exc, websocket_url):
+        return None
+
+    async def fake_sleep(delay):
+        return None
+
+    monkeypatch.setattr(
+        "band.client.streaming.client.PHXChannelsClient", AlwaysFailingPHXClient
+    )
+    monkeypatch.setattr(
+        "band.client.streaming.client.classify_initial_upgrade_error",
+        no_upgrade_error,
+    )
+    monkeypatch.setattr("band.client.streaming.client.asyncio.sleep", fake_sleep)
+
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+
+    with pytest.raises(
+        PHXConnectionError, match="temporary network failure"
+    ) as exc_info:
+        await client.__aenter__()
+
+    # SessionPolicy.default()'s rapid_threshold is 10 -- the 10th rapid
+    # disconnect trips Dead(RapidDisconnect) instead of computing another delay.
+    assert attempts == 10
+    assert client.last_disconnect_reason is not None
+    assert client.last_disconnect_reason.dead_reason == DeadReason.RapidDisconnect
+    # PHXConnectionError is re-raised as itself (no new exception object),
+    # so no `from` chaining applies -- self-referential __cause__ would be
+    # incorrect (and misleading) here.
+    assert exc_info.value.__cause__ is None
 
 
 async def test_aenter_reraises_unrecognized_upgrade_error(monkeypatch):

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -369,11 +369,11 @@ async def test_aenter_caches_probe_result_across_repeated_connect_failures(
     rejection blocks for up to open_timeout=5s -- rerunning it on every
     backoff retry of the very same rejection would stack a fresh network
     round trip onto every computed delay. A repeat bare PHXConnectionError
-    must reuse the first probe's classification instead of probing again."""
+    must reuse the first probe's classification instead of probing again,
+    as long as that classification carries no retry_after to go stale."""
     upgrade_exc = _upgrade_exception(
-        429,
-        b'{"error":{"code":"too_many_requests","message":"slow down","request_id":"req-429"}}',
-        {"Retry-After": "5"},
+        503,
+        b'{"error":{"code":"tracking_failed","message":"tracking unavailable","request_id":"req-503"}}',
     )
     connect = scripted_connect(
         PHXConnectionError("Connection supervisor stopped before connecting"),
@@ -390,6 +390,33 @@ async def test_aenter_caches_probe_result_across_repeated_connect_failures(
     # but the probe only ran once -- the second failure's classification
     # came from the cache.
     assert probe.probed_urls == [("wss://test/socket&agent_id=agent-123", 5)]
+
+    await client.__aexit__(None, None, None)
+
+
+async def test_aenter_reprobes_repeated_429_for_current_retry_after(
+    scripted_connect, scripted_probe, no_real_sleep
+):
+    """A repeated 429 always gets a fresh probe, even with an unchanged
+    wrapped message: the wrapper's message is just "HTTP 429" -- it can't
+    carry Retry-After -- so a cached 429 could silently reuse a stale delay
+    while the server's current Retry-After has since grown."""
+    stale = _upgrade_exception(429, b"", {"Retry-After": "5"})
+    current = _upgrade_exception(429, b"", {"Retry-After": "60"})
+    connect = scripted_connect(
+        PHXConnectionError("Connection supervisor stopped before connecting"),
+        PHXConnectionError("Connection supervisor stopped before connecting"),
+        SUCCEEDS,
+    )
+    probe = scripted_probe(stale, current)
+
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+    await client.__aenter__()
+
+    assert connect.attempts == 3
+    assert len(probe.probed_urls) == 2
+    assert len(no_real_sleep) == 2
+    assert no_real_sleep[1] >= 60.0
 
     await client.__aexit__(None, None, None)
 

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -43,7 +43,7 @@ from band.client.streaming import (
     RoomRemovedPayload,
     WebSocketClient,
 )
-from tests.websocket.conftest import fast_session_policy
+from tests.websocket.conftest import SUCCEEDS, fast_session_policy
 
 # Shared valid payload used by multiple tests
 VALID_MESSAGE_CREATED_PAYLOAD: dict = {
@@ -329,11 +329,11 @@ async def test_aenter_wraps_upgrade_error(monkeypatch):
 
 
 async def test_aenter_probes_initial_phx_connection_error_then_retries_and_succeeds(
-    monkeypatch,
+    scripted_connect, scripted_probe, no_real_sleep
 ):
-    """A 429 upgrade rejection -- recovered via classify_initial_upgrade_error's
+    """A 429 upgrade rejection -- recovered via _classify_connect_failure's
     probe fallback, since the raw PHXConnectionError carries no HTTP status
-    itself -- classifies as Retry (classify_upgrade marks only 400/403/409
+    itself -- classifies as Retry (classify_upgrade marks only 400/409
     Terminal), so it retries using Retry-After as a delay floor instead of
     raising on the first attempt, then succeeds once the rate limit clears."""
     upgrade_exc = _upgrade_exception(
@@ -341,66 +341,29 @@ async def test_aenter_probes_initial_phx_connection_error_then_retries_and_succe
         b'{"error":{"code":"too_many_requests","message":"slow down","request_id":"req-429"}}',
         {"Retry-After": "5"},
     )
-    probed_urls = []
-    attempts = 0
-
-    class RecoveringPHXClient:
-        def __init__(self, *args, **kwargs):
-            assert kwargs["auto_reconnect"] is False
-            self.channel_socket_url = "wss://test/socket"
-            self.auto_reconnect = kwargs["auto_reconnect"]
-
-        async def __aenter__(self):
-            nonlocal attempts
-            attempts += 1
-            if attempts == 1:
-                raise PHXConnectionError(
-                    "Connection supervisor stopped before connecting"
-                )
-            return self
-
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
-            return None
-
-    class FailingProbe:
-        async def __aenter__(self):
-            raise upgrade_exc
-
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
-            return None
-
-    def fake_connect(url, *, open_timeout):
-        probed_urls.append((url, open_timeout))
-        return FailingProbe()
-
-    sleep_delays = []
-
-    async def fake_sleep(delay):
-        sleep_delays.append(delay)
-
-    monkeypatch.setattr(
-        "band.client.streaming.client.PHXChannelsClient", RecoveringPHXClient
+    connect = scripted_connect(
+        PHXConnectionError("Connection supervisor stopped before connecting"),
+        SUCCEEDS,
     )
-    monkeypatch.setattr("band.client.streaming.errors.connect", fake_connect)
-    monkeypatch.setattr("band.client.streaming.client.asyncio.sleep", fake_sleep)
+    probe = scripted_probe(upgrade_exc)
 
     client = WebSocketClient("ws://localhost", "test-key", "agent-123")
     await client.__aenter__()
 
-    assert attempts == 2
-    assert probed_urls == [("wss://test/socket&agent_id=agent-123", 5)]
+    assert connect.attempts == 2
+    assert probe.probed_urls == [("wss://test/socket&agent_id=agent-123", 5)]
     # retry_after_s is a lower bound (Retry-After) with an upper bound of
     # max(max_delay_s, retry_after_s) -- see the design doc's "on_upgrade_rejected"
     # semantics -- rather than asserting one exact jittered value.
-    assert len(sleep_delays) == 1
-    assert 5.0 <= sleep_delays[0] <= 30.0
+    assert len(no_real_sleep) == 1
+    assert 5.0 <= no_real_sleep[0] <= 30.0
     assert client.client.auto_reconnect is True
 
     await client.__aexit__(None, None, None)
 
 
 async def test_aenter_caches_probe_result_across_repeated_connect_failures(
-    monkeypatch,
+    scripted_connect, scripted_probe, no_real_sleep
 ):
     """The live-socket probe recovering a PHXConnectionError's hidden upgrade
     rejection blocks for up to open_timeout=5s -- rerunning it on every
@@ -412,54 +375,57 @@ async def test_aenter_caches_probe_result_across_repeated_connect_failures(
         b'{"error":{"code":"too_many_requests","message":"slow down","request_id":"req-429"}}',
         {"Retry-After": "5"},
     )
-    probed_urls = []
-    attempts = 0
-
-    class RecoveringPHXClient:
-        def __init__(self, *args, **kwargs):
-            self.channel_socket_url = "wss://test/socket"
-            self.auto_reconnect = kwargs["auto_reconnect"]
-
-        async def __aenter__(self):
-            nonlocal attempts
-            attempts += 1
-            if attempts < 3:
-                raise PHXConnectionError(
-                    "Connection supervisor stopped before connecting"
-                )
-            return self
-
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
-            return None
-
-    class FailingProbe:
-        async def __aenter__(self):
-            raise upgrade_exc
-
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
-            return None
-
-    def fake_connect(url, *, open_timeout):
-        probed_urls.append((url, open_timeout))
-        return FailingProbe()
-
-    async def fake_sleep(delay):
-        return None
-
-    monkeypatch.setattr(
-        "band.client.streaming.client.PHXChannelsClient", RecoveringPHXClient
+    connect = scripted_connect(
+        PHXConnectionError("Connection supervisor stopped before connecting"),
+        PHXConnectionError("Connection supervisor stopped before connecting"),
+        SUCCEEDS,
     )
-    monkeypatch.setattr("band.client.streaming.errors.connect", fake_connect)
-    monkeypatch.setattr("band.client.streaming.client.asyncio.sleep", fake_sleep)
+    probe = scripted_probe(upgrade_exc)
 
     client = WebSocketClient("ws://localhost", "test-key", "agent-123")
     await client.__aenter__()
 
-    assert attempts == 3
-    # Two attempts failed with the unclassifiable PHXConnectionError, but the
-    # probe only ran once -- the second failure's classification came from
-    # the cache.
-    assert probed_urls == [("wss://test/socket&agent_id=agent-123", 5)]
+    assert connect.attempts == 3
+    # Two attempts failed with the same unclassifiable PHXConnectionError,
+    # but the probe only ran once -- the second failure's classification
+    # came from the cache.
+    assert probe.probed_urls == [("wss://test/socket&agent_id=agent-123", 5)]
+
+    await client.__aexit__(None, None, None)
+
+
+async def test_aenter_reprobes_when_wrapped_failure_message_changes(
+    scripted_connect, scripted_probe, no_real_sleep
+):
+    """A repeat PHXConnectionError with a *different* message may be a
+    genuinely different failure, not a repeat of the last one -- reusing
+    the earlier probe's classification for it would hide a real, terminal
+    rejection behind a stale retryable one."""
+    conflict_exc = _upgrade_exception(
+        409,
+        b'{"error":{"code":"conflict","message":"stale session","request_id":"req-409"}}',
+    )
+    connect = scripted_connect(
+        PHXConnectionError("temporary network failure"),
+        PHXConnectionError("temporary network failure"),
+        PHXConnectionError("connection reset by peer"),
+    )
+    probe = scripted_probe(SUCCEEDS, conflict_exc)
+
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+
+    with pytest.raises(WebSocketUpgradeError, match="stale session") as exc_info:
+        await client.__aenter__()
+
+    # Attempts 1-2 shared one message and one probe call (a clean result,
+    # cached); attempt 3's different message forced a second probe, which
+    # recovered the real terminal rejection instead of reusing attempt 1's
+    # cached clean result.
+    assert connect.attempts == 3
+    assert len(probe.probed_urls) == 2
+    assert exc_info.value.status_code == 409
+    assert client.last_disconnect_reason is not None
+    assert client.last_disconnect_reason.dead_reason == DeadReason.Classified
 
     await client.__aexit__(None, None, None)
 
@@ -526,39 +492,15 @@ async def test_aenter_reusable_after_aexit_ends_the_session(monkeypatch):
         assert client.client.auto_reconnect is True
 
 
-async def test_aenter_retries_unclassified_initial_connection_errors(monkeypatch):
-    attempts = 0
-    sleep_delays = []
-
-    class FlakyPHXClient:
-        def __init__(self, *args, **kwargs):
-            self.channel_socket_url = "wss://test/socket"
-            self.auto_reconnect = kwargs["auto_reconnect"]
-
-        async def __aenter__(self):
-            nonlocal attempts
-            attempts += 1
-            if attempts < 3:
-                raise PHXConnectionError("temporary network failure")
-            return self
-
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
-            return None
-
-    async def no_upgrade_error(websocket_url):
-        return None
-
-    async def fake_sleep(delay):
-        sleep_delays.append(delay)
-
-    monkeypatch.setattr(
-        "band.client.streaming.client.PHXChannelsClient", FlakyPHXClient
+async def test_aenter_retries_unclassified_initial_connection_errors(
+    scripted_connect, scripted_probe, no_real_sleep
+):
+    connect = scripted_connect(
+        PHXConnectionError("temporary network failure"),
+        PHXConnectionError("temporary network failure"),
+        SUCCEEDS,
     )
-    monkeypatch.setattr(
-        "band.client.streaming.client.probe_upgrade_error",
-        no_upgrade_error,
-    )
-    monkeypatch.setattr("band.client.streaming.client.asyncio.sleep", fake_sleep)
+    scripted_probe(SUCCEEDS)
 
     client = WebSocketClient(
         "ws://localhost",
@@ -570,50 +512,28 @@ async def test_aenter_retries_unclassified_initial_connection_errors(monkeypatch
     )
     await client.__aenter__()
 
-    assert attempts == 3
+    assert connect.attempts == 3
     # Both retries are the first two rapid disconnects (never having reached
     # Up) -- their delay floors (rapid_first_min_delay_s/rapid_second_min_delay_s)
     # are policy-driven and not jitter-scaled, so this is deterministic.
-    assert sleep_delays == [1.0, 5.0]
+    assert no_real_sleep == [1.0, 5.0]
     assert client.client.auto_reconnect is True
 
-    # fake_sleep never advances the clock; an un-stopped watchdog's
+    # no_real_sleep never advances the clock; an un-stopped watchdog's
     # deadline-check loop would spin on it with no real yield point.
     await client.__aexit__(None, None, None)
 
 
-async def test_aenter_trips_dead_after_rapid_disconnect_threshold(monkeypatch):
+async def test_aenter_trips_dead_after_rapid_disconnect_threshold(
+    scripted_connect, scripted_probe, no_real_sleep
+):
     """A burst of fast-repeating initial-connect failures trips Session
     straight to Dead(RapidDisconnect) once the rolling rapid-disconnect
-    window's threshold is reached. Uses SessionPolicy.default() (not
-    fast_session_policy, which only fast-forwards heartbeat/dead-threshold,
-    not reconnect-backoff fields) since asyncio.sleep is mocked below, so
-    the real default rapid_threshold=10 costs no wall-clock time."""
-    attempts = 0
-
-    class AlwaysFailingPHXClient:
-        def __init__(self, *args, **kwargs):
-            self.channel_socket_url = "wss://test/socket"
-
-        async def __aenter__(self):
-            nonlocal attempts
-            attempts += 1
-            raise PHXConnectionError("temporary network failure")
-
-    async def no_upgrade_error(websocket_url):
-        return None
-
-    async def fake_sleep(delay):
-        return None
-
-    monkeypatch.setattr(
-        "band.client.streaming.client.PHXChannelsClient", AlwaysFailingPHXClient
-    )
-    monkeypatch.setattr(
-        "band.client.streaming.client.probe_upgrade_error",
-        no_upgrade_error,
-    )
-    monkeypatch.setattr("band.client.streaming.client.asyncio.sleep", fake_sleep)
+    window's threshold is reached. Uses SessionPolicy.default()'s real
+    rapid_threshold=10 -- asyncio.sleep is mocked, so it costs no
+    wall-clock time."""
+    connect = scripted_connect(PHXConnectionError("temporary network failure"))
+    scripted_probe(SUCCEEDS)
 
     client = WebSocketClient("ws://localhost", "test-key", "agent-123")
 
@@ -624,7 +544,7 @@ async def test_aenter_trips_dead_after_rapid_disconnect_threshold(monkeypatch):
 
     # SessionPolicy.default()'s rapid_threshold is 10 -- the 10th rapid
     # disconnect trips Dead(RapidDisconnect) instead of computing another delay.
-    assert attempts == 10
+    assert connect.attempts == 10
     assert client.last_disconnect_reason is not None
     assert client.last_disconnect_reason.dead_reason == DeadReason.RapidDisconnect
     # PHXConnectionError is re-raised as itself (no new exception object),
@@ -634,7 +554,7 @@ async def test_aenter_trips_dead_after_rapid_disconnect_threshold(monkeypatch):
 
 
 async def test_resolve_failed_connect_attempt_captures_now_before_probe_latency(
-    monkeypatch,
+    monkeypatch, scripted_connect
 ):
     """`now` must be the wall-clock time the connect attempt actually failed,
     not the time probe_upgrade_error's live-socket probe finished -- otherwise
@@ -678,26 +598,7 @@ async def test_resolve_failed_connect_attempt_captures_now_before_probe_latency(
         slow_probe,
     )
 
-    attempts = 0
-
-    class FailOncePHXClient:
-        def __init__(self, *args, **kwargs):
-            self.channel_socket_url = "wss://test/socket"
-            self.auto_reconnect = kwargs["auto_reconnect"]
-
-        async def __aenter__(self):
-            nonlocal attempts
-            attempts += 1
-            if attempts == 1:
-                raise PHXConnectionError("temporary network failure")
-            return self
-
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
-            return None
-
-    monkeypatch.setattr(
-        "band.client.streaming.client.PHXChannelsClient", FailOncePHXClient
-    )
+    scripted_connect(PHXConnectionError("temporary network failure"), SUCCEEDS)
 
     start = asyncio.get_running_loop().time()
     client = WebSocketClient("ws://localhost", "test-key", "agent-123")
@@ -739,7 +640,7 @@ async def test_aenter_records_terminal_disconnect_when_session_returns_no_epoch(
 
 
 async def test_resolve_failed_connect_attempt_raises_when_retry_after_s_missing(
-    monkeypatch,
+    monkeypatch, scripted_connect, scripted_probe
 ):
     """A non-Dead SessionOutcome with retry_after_s=None can't happen with the
     real Session today, but if that contract were ever violated, a bare
@@ -764,24 +665,8 @@ async def test_resolve_failed_connect_attempt_raises_when_retry_after_s_missing(
 
     monkeypatch.setattr("band.client.streaming.client.Session", BadOutcomeSession)
 
-    async def no_upgrade_error(websocket_url):
-        return None
-
-    monkeypatch.setattr(
-        "band.client.streaming.client.probe_upgrade_error",
-        no_upgrade_error,
-    )
-
-    class FailingPHXClient:
-        def __init__(self, *args, **kwargs):
-            self.channel_socket_url = "wss://test/socket"
-
-        async def __aenter__(self):
-            raise PHXConnectionError("temporary network failure")
-
-    monkeypatch.setattr(
-        "band.client.streaming.client.PHXChannelsClient", FailingPHXClient
-    )
+    scripted_connect(PHXConnectionError("temporary network failure"))
+    scripted_probe(SUCCEEDS)
 
     client = WebSocketClient("ws://localhost", "test-key", "agent-123")
 

--- a/tests/websocket/test_watchdog.py
+++ b/tests/websocket/test_watchdog.py
@@ -6,36 +6,8 @@ from __future__ import annotations
 
 import asyncio
 
-from band_sdk_core import SessionPolicy
-
 from band.client.streaming.watchdog import HeartbeatWatchdog
-
-
-def _fast_session_policy(
-    *, heartbeat_interval_s: float, dead_threshold_s: float
-) -> SessionPolicy:
-    """A SessionPolicy with real reconnect-backoff defaults (mirroring
-    SessionPolicy.default()) but a fast heartbeat/dead-threshold pair, so
-    watchdog tests run in real fractional seconds instead of production's
-    30s/60s."""
-    return SessionPolicy(
-        {
-            "base_delay_s": 1.0,
-            "factor": 2.0,
-            "max_delay_s": 30.0,
-            "stable_reset_s": 60.0,
-            "rapid_disconnect_uptime_s": 10.0,
-            "rapid_window_s": 300.0,
-            "rapid_first_min_delay_s": 1.0,
-            "rapid_second_min_delay_s": 5.0,
-            "rapid_cooldown_base_s": 10.0,
-            "rapid_cooldown_step_s": 10.0,
-            "rapid_cooldown_max_s": 60.0,
-            "rapid_threshold": 10,
-            "heartbeat_interval_s": heartbeat_interval_s,
-            "dead_threshold_s": dead_threshold_s,
-        }
-    )
+from tests.websocket.conftest import fast_session_policy
 
 
 class FakePHXClient:
@@ -50,7 +22,7 @@ class FakePHXClient:
 async def test_start_cancelled_cleanly_on_stop():
     """stop() cancels the watchdog task cleanly -- no dangling task
     survives shutdown."""
-    policy = _fast_session_policy(heartbeat_interval_s=0.05, dead_threshold_s=5.0)
+    policy = fast_session_policy(heartbeat_interval_s=0.05, dead_threshold_s=5.0)
     watchdog = HeartbeatWatchdog(policy)
     watchdog.start(FakePHXClient())
 
@@ -72,7 +44,7 @@ async def test_stale_watchdog_cannot_close_a_superseded_connection():
     superseded by the next one in `WebSocketClient.__aenter__`'s retry loop
     -- it must only ever act on its own (stale) instance, never the
     replacement."""
-    policy = _fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
+    policy = fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
     watchdog = HeartbeatWatchdog(policy)
     first, second = FakePHXClient(), FakePHXClient()
 
@@ -104,7 +76,7 @@ async def test_survives_a_close_connection_failure():
             if len(self.close_calls) == 1:
                 raise RuntimeError("close boom")
 
-    policy = _fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
+    policy = fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
     watchdog = HeartbeatWatchdog(policy)
     fake = FlakyThenFakePHXClient()
     watchdog.start(fake)
@@ -119,7 +91,7 @@ async def test_does_not_warn_or_close_while_already_disconnected():
     """No live connection to force-close means nothing to warn about either
     -- an extended reconnect backoff must not spam misleading 'forcing
     reconnect' warnings for a connection that's already down."""
-    policy = _fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
+    policy = fast_session_policy(heartbeat_interval_s=0.01, dead_threshold_s=0.05)
     watchdog = HeartbeatWatchdog(policy)
     fake = FakePHXClient(connection=None)
     watchdog.start(fake)
@@ -135,7 +107,7 @@ async def test_reset_deadline_lets_a_fresh_socket_survive_a_reconnect():
     it can inherit a stale deadline (from the disconnected-state polling
     above) that expires before the fresh socket's first heartbeat cycle,
     force-closing a healthy connection."""
-    policy = _fast_session_policy(heartbeat_interval_s=0.1, dead_threshold_s=0.12)
+    policy = fast_session_policy(heartbeat_interval_s=0.1, dead_threshold_s=0.12)
     watchdog = HeartbeatWatchdog(policy)
     fake = FakePHXClient()
 


### PR DESCRIPTION
## Summary

Implements INT-1303: replaces band-sdk-python's hand-rolled reconnect/backoff/disconnect-classification logic in `WebSocketClient`/`BandLink` with band_sdk_core's `Session` state machine, per the ticket's attached implementation plan. All 5 migration steps shipped, squashed into 5 commits matching the plan's own step boundaries:

1. Extract the duplicated `_fast_session_policy` test helper into `tests/websocket/conftest.py` (prep, test-only)
2. Wire `Session` into `WebSocketClient.__init__`/`__aexit__` (no behavior change)
3. Replace `__aenter__`'s retry loop with `Session`-driven backoff
4. Route `agent_control:supersede` through `Session.on_supersede`
5. Extend the CI wheel-smoke step with a `Session`/`SessionPolicy` call

## Design decisions (from the plan) — all 4 shipped as specified

1. 429/503 upgrade rejections on the initial-connect path are now retried automatically via `Session.on_upgrade_rejected` (using `Retry-After` as a delay floor), instead of raised immediately as before.
2. `Session.on_supersede`'s `Reconnecting` branch is implemented in `BandLink._on_supersede`, even though the platform hardcodes `retryable=False` on every real supersede today (only a synthetic regression test exercises it) — keeps the SDK correct about *not treating it as terminal* if that ever changes. It does not yet drive actual reconnect timing off that decision — see below.
3. `WebSocketDisconnectReason` gained `dead_reason`/`stale_reason` fields.
4. Those fields are populated from both the supersede path and `__aenter__`'s terminal-failure path (a new `_disconnect_reason_from_exception`, since there's no platform wire payload for that case) — widening `BandLink.last_disconnect_reason`'s trigger scenarios to include a permanently-failed initial connect, not just a supersede.

**Out of scope** (per the ticket, untouched): taking ownership of the vendored `PHXChannelsClient`'s internal `auto_reconnect` loop — separate, larger follow-up work, tracked as [INT-1355](https://linear.app/thenvoi/issue/INT-1355/take-over-phxchannelsclients-auto-reconnect-loop-so-session-drives) (filed during review: a retryable supersede's `retry_after_s` is classified but not enforced without that ownership change; not reachable today since the platform always sends `retryable=False`).

Other real, intentional behavior change from Step 3: the initial-connect give-up bound is now a rolling 5-minute rapid-disconnect window (10 by default) instead of a fixed 11-attempt cap.

INT-1303: https://linear.app/thenvoi/issue/INT-1303/integrate-band-sdk-core-session-connection-reliability-into-band-sdk

## Review history

Two rounds of external review, both verified and closed out:
- `/code-review high`: confirmed a real exception-chaining regression (`raise raise_exc` had dropped `from exc` for the classified-upgrade-error case) — fixed, with a regression assertion. A comment-style finding (narrating removed mechanisms) — fixed.
- `/my-here-is-a-review` (2 rounds) on the retryable-supersede `retry_after_s` gap: confirmed real but architecturally out of scope (needs the deferred `auto_reconnect`-ownership work) — filed as INT-1355, PR thread resolved.

## Test plan

- [x] `uv run ruff check .` / `uv run ruff format .` / `uv run pyrefly check` / full unit suite (`uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/`) — clean
- [x] Every ticket-listed acceptance regression test passes explicitly (`test_aenter_restores_reconnect_after_successful_initial_connect`, `test_uses_retry_after_header_for_429_upgrade_error`, `test_supersede_event_records_terminal_reason_and_disables_reconnect`, `test_watchdog_forces_close_and_reconnect_when_ack_withheld`, `test_cancelled_connect_closes_the_half_opened_client_and_allows_retry`, `test_disconnect_after_supersede_still_cleans_up_websocket`, `test_close_without_supersede_leaves_disconnect_reason_empty`, all of `tests/websocket/test_watchdog.py`)
- [x] New tests added per the plan's test plan: rapid-disconnect-ladder trip to `Dead`, 429 upgrade rejection retried via the probe fallback then succeeding, retryable supersede leaves the connection non-terminal, `connect()` propagates a terminal initial-connect failure onto `last_disconnect_reason`, exception-chaining regression guards
- [x] All CI checks green (lint, packaging, full test matrix, CodeQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuwaxzwGje1eq94W7V8zrW