### PR TITLE
test: fill A2A adapter unit test gaps

### DIFF
--- a/src/band/integrations/a2a/adapter.py
+++ b/src/band/integrations/a2a/adapter.py
@@ -107,7 +107,13 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
 
         headers = self.auth.to_headers() if self.auth else {}
 
-        self._http_client = httpx.AsyncClient(headers=headers)
+        # httpx's default 5s read timeout fires on the normal, multi-second
+        # gap between SSE events during a real remote turn (a live LLM call,
+        # a tool loop) -- not a hang. Leave read unbounded; connect/write/pool
+        # stay bounded so a genuinely dead peer still fails promptly.
+        self._http_client = httpx.AsyncClient(
+            headers=headers, timeout=httpx.Timeout(10.0, read=None)
+        )
         factory = ClientFactory(
             ClientConfig(streaming=self.streaming, httpx_client=self._http_client)
         )

--- a/src/band/integrations/a2a/adapter.py
+++ b/src/band/integrations/a2a/adapter.py
@@ -319,12 +319,14 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
 
     async def cleanup_all(self) -> None:
         """Close the owned A2A client and its HTTP transport."""
-        if self._client is not None:
-            await self._client.close()
-            self._client = None
-        if self._http_client is not None:
-            await self._http_client.aclose()
-            self._http_client = None
+        client, self._client = self._client, None
+        http_client, self._http_client = self._http_client, None
+        try:
+            if client is not None:
+                await client.close()
+        finally:
+            if http_client is not None:
+                await http_client.aclose()
 
     async def _emit_task_event(
         self, tools: AgentToolsProtocol, task: Task, state: TaskState

--- a/src/band/integrations/a2a/adapter.py
+++ b/src/band/integrations/a2a/adapter.py
@@ -37,6 +37,13 @@ from band.integrations.a2a.types import A2AAuth, A2ASessionState
 
 logger = logging.getLogger(__name__)
 
+# httpx's read timeout resets on every chunk received, so this bounds the gap
+# between SSE events, not the turn as a whole. Generous enough for the
+# multi-second silences of a live LLM call or tool loop; still finite, so a
+# peer that accepts the connection and then hangs eventually fails the turn
+# instead of blocking the room forever.
+_SSE_READ_TIMEOUT_S = 300.0
+
 
 class A2AAdapter(SimpleAdapter[A2ASessionState]):
     """Adapter that forwards messages to a remote A2A agent.
@@ -109,10 +116,11 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
 
         # httpx's default 5s read timeout fires on the normal, multi-second
         # gap between SSE events during a real remote turn (a live LLM call,
-        # a tool loop) -- not a hang. Leave read unbounded; connect/write/pool
-        # stay bounded so a genuinely dead peer still fails promptly.
+        # a tool loop) -- not a hang. Use a generous bound instead of the
+        # default so a genuinely dead peer still fails promptly.
         self._http_client = httpx.AsyncClient(
-            headers=headers, timeout=httpx.Timeout(10.0, read=None)
+            headers=headers,
+            timeout=httpx.Timeout(10.0, read=_SSE_READ_TIMEOUT_S),
         )
         factory = ClientFactory(
             ClientConfig(streaming=self.streaming, httpx_client=self._http_client)

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -337,14 +337,14 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
                 request.pending.task.id,
             )
             raise
-        except Exception as exc:
+        except Exception:
             logger.exception(
                 "A2A request failed: room=%s context=%s task=%s",
                 request.room_id,
                 request.context_id,
                 request.pending.task.id,
             )
-            await request.pending.fail(f"A2A request failed: {exc}")
+            await request.pending.fail("A2A request failed")
             raise
         else:
             if completed:

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -189,7 +189,7 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
         )
         await self._server.start()
 
-        logger.info("Gateway HTTP server started on port %d", self.port)
+        logger.info("Gateway HTTP server started on port %d", self._server.bound_port)
 
     @property
     def rest(self) -> AsyncRestClient:

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -337,13 +337,14 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
                 request.pending.task.id,
             )
             raise
-        except Exception:
+        except Exception as exc:
             logger.exception(
                 "A2A request failed: room=%s context=%s task=%s",
                 request.room_id,
                 request.context_id,
                 request.pending.task.id,
             )
+            await request.pending.fail(f"A2A request failed: {exc}")
             raise
         else:
             if completed:

--- a/src/band/integrations/a2a/gateway/server.py
+++ b/src/band/integrations/a2a/gateway/server.py
@@ -22,6 +22,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import BaseRoute, Route
 
+from band.integrations.uvicorn_server import wait_until_started
 from band_rest import Peer
 
 logger = logging.getLogger(__name__)
@@ -253,7 +254,7 @@ class GatewayServer:
         import uvicorn
 
         self._app = self._build_app()
-        self._uvicorn = uvicorn.Server(
+        server = uvicorn.Server(
             uvicorn.Config(
                 self._app,
                 host="0.0.0.0",
@@ -262,24 +263,15 @@ class GatewayServer:
                 timeout_graceful_shutdown=SERVER_STOP_TIMEOUT_S,
             )
         )
-        self._server_task = asyncio.create_task(self._uvicorn.serve())
-        await self._wait_until_started()
+        server_task = asyncio.create_task(server.serve())
+        self._uvicorn = server
+        self._server_task = server_task
+        await wait_until_started(server, server_task, timeout_s=SERVER_START_TIMEOUT_S)
         logger.info(
             "Starting A2A Gateway server on port %d with %d peers",
             self.port,
             len(self.peers),
         )
-
-    async def _wait_until_started(self) -> None:
-        assert self._uvicorn is not None
-        deadline = asyncio.get_running_loop().time() + SERVER_START_TIMEOUT_S
-        while not self._uvicorn.started:
-            if asyncio.get_running_loop().time() > deadline:
-                raise RuntimeError(
-                    f"A2A Gateway server did not start within "
-                    f"{SERVER_START_TIMEOUT_S}s on port {self.port}"
-                )
-            await asyncio.sleep(0.05)
 
     async def stop(self) -> None:
         if self._uvicorn is None or self._server_task is None:

--- a/src/band/integrations/a2a/gateway/server.py
+++ b/src/band/integrations/a2a/gateway/server.py
@@ -266,7 +266,15 @@ class GatewayServer:
         server_task = asyncio.create_task(server.serve())
         self._uvicorn = server
         self._server_task = server_task
-        await wait_until_started(server, server_task, timeout_s=SERVER_START_TIMEOUT_S)
+        try:
+            await wait_until_started(
+                server, server_task, timeout_s=SERVER_START_TIMEOUT_S
+            )
+        except BaseException:
+            # A failed/timed-out startup still leaves server_task running and
+            # the socket bound; stop() already unwinds both.
+            await self.stop()
+            raise
         logger.info(
             "Starting A2A Gateway server on port %d with %d peers",
             self.port,

--- a/src/band/integrations/a2a/gateway/server.py
+++ b/src/band/integrations/a2a/gateway/server.py
@@ -20,7 +20,11 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import BaseRoute, Route
 
-from band.integrations.uvicorn_server import ManagedUvicornServer
+from band.integrations.uvicorn_server import (
+    SERVER_START_TIMEOUT_S,
+    SERVER_STOP_TIMEOUT_S,
+    ManagedUvicornServer,
+)
 from band_rest import Peer
 
 logger = logging.getLogger(__name__)
@@ -29,15 +33,6 @@ ExecutorFactory = Callable[[str], AgentExecutor]
 
 # sse_starlette's shutdown-drain footgun (see uvicorn_server's docstring)
 # is disabled by importing that module, not here.
-
-# A live message:stream response has no other way to end on stop() --
-# uvicorn's own default (None) would wait forever for it to close on its own.
-SERVER_STOP_TIMEOUT_S = 5
-
-# How long start() waits for uvicorn to report ready -- without it, a caller
-# dialing in right after start() returns could race a socket that isn't
-# listening yet.
-SERVER_START_TIMEOUT_S = 5
 
 # The REST endpoints the gateway serves per peer: the messaging binding and
 # the compat card. The upstream factory also returns task read/cancel/list

--- a/src/band/integrations/a2a/gateway/server.py
+++ b/src/band/integrations/a2a/gateway/server.py
@@ -36,6 +36,12 @@ ExecutorFactory = Callable[[str], AgentExecutor]
 # only thing that keeps stop() from hanging once that happens.
 SERVER_STOP_TIMEOUT_S = 5
 
+# How long start() waits for uvicorn to report ready before giving up. Without
+# this wait, start() returns as soon as serve() is merely scheduled -- a caller
+# (e.g. an A2A client dialing in immediately after on_started()) can then race
+# a socket that isn't listening yet.
+SERVER_START_TIMEOUT_S = 5
+
 # The REST endpoints the gateway serves per peer: the messaging binding and
 # the compat card. The upstream factory also returns task read/cancel/list
 # and push-config routes — an unauthenticated window into past conversations.
@@ -251,11 +257,23 @@ class GatewayServer:
             )
         )
         self._server_task = asyncio.create_task(self._uvicorn.serve())
+        await self._wait_until_started()
         logger.info(
             "Starting A2A Gateway server on port %d with %d peers",
             self.port,
             len(self.peers),
         )
+
+    async def _wait_until_started(self) -> None:
+        assert self._uvicorn is not None
+        deadline = asyncio.get_running_loop().time() + SERVER_START_TIMEOUT_S
+        while not self._uvicorn.started:
+            if asyncio.get_running_loop().time() > deadline:
+                raise RuntimeError(
+                    f"A2A Gateway server did not start within "
+                    f"{SERVER_START_TIMEOUT_S}s on port {self.port}"
+                )
+            await asyncio.sleep(0.05)
 
     async def stop(self) -> None:
         if self._uvicorn is None or self._server_task is None:

--- a/src/band/integrations/a2a/gateway/server.py
+++ b/src/band/integrations/a2a/gateway/server.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -16,31 +15,25 @@ from a2a.server.tasks import InMemoryTaskStore
 from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill
 from a2a.compat.v0_3.conversions import to_compat_agent_card
 from a2a.utils.constants import PROTOCOL_VERSION_0_3, PROTOCOL_VERSION_CURRENT
-from sse_starlette.sse import AppStatus
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import BaseRoute, Route
 
-from band.integrations.uvicorn_server import wait_until_started
+from band.integrations.uvicorn_server import ManagedUvicornServer
 from band_rest import Peer
 
 logger = logging.getLogger(__name__)
 
 ExecutorFactory = Callable[[str], AgentExecutor]
 
-# sse_starlette's shutdown watcher polls whichever uvicorn.Server owns the
-# process's SIGTERM slot and promotes its should_exit to the process-global
-# AppStatus.should_exit -- so a GatewayServer.stop() (which sets should_exit
-# directly, not via a signal) can poison every later GatewayServer's SSE
-# streams in the same process. band.integrations.mcp.local_server disables
-# this for the same reason; calling it here too avoids depending on that
-# import (idempotent, process-wide).
-AppStatus.disable_automatic_graceful_drain()
+# The process-global sse_starlette shutdown-drain footgun (see
+# band.integrations.uvicorn_server's docstring) is disabled by importing
+# that module above, not here -- ManagedUvicornServer's every caller shares
+# the fix.
 
-# The automatic drain above is disabled, so a live message:stream response
-# has no other way to end on stop() -- uvicorn's own default (None) would
-# wait forever for it to close on its own.
+# A live message:stream response has no other way to end on stop() --
+# uvicorn's own default (None) would wait forever for it to close on its own.
 SERVER_STOP_TIMEOUT_S = 5
 
 # How long start() waits for uvicorn to report ready before giving up. Without
@@ -91,8 +84,7 @@ class GatewayServer:
         self.port = port
         self.executor_factory = executor_factory
         self._app: Starlette | None = None
-        self._uvicorn: Any | None = None
-        self._server_task: asyncio.Task[Any] | None = None
+        self._runtime: ManagedUvicornServer | None = None
 
     def _agent_card(self, slug: str, peer: Peer) -> AgentCard:
         rpc_url = f"{self.gateway_url}/agents/{slug}"
@@ -250,31 +242,24 @@ class GatewayServer:
         ]
         return JSONResponse({"peers": peers, "count": len(peers)})
 
-    async def start(self) -> None:
-        import uvicorn
+    @property
+    def bound_port(self) -> int:
+        """The actual listening port -- resolves ``port=0`` to whatever the
+        OS assigned."""
+        if self._runtime is None:
+            raise RuntimeError("A2A Gateway server has not started")
+        return self._runtime.bound_port
 
+    async def start(self) -> None:
         self._app = self._build_app()
-        server = uvicorn.Server(
-            uvicorn.Config(
-                self._app,
-                host="0.0.0.0",
-                port=self.port,
-                log_level="warning",
-                timeout_graceful_shutdown=SERVER_STOP_TIMEOUT_S,
-            )
+        self._runtime = ManagedUvicornServer(
+            self._app,
+            host="0.0.0.0",
+            port=self.port,
+            start_timeout_s=SERVER_START_TIMEOUT_S,
+            stop_timeout_s=SERVER_STOP_TIMEOUT_S,
         )
-        server_task = asyncio.create_task(server.serve())
-        self._uvicorn = server
-        self._server_task = server_task
-        try:
-            await wait_until_started(
-                server, server_task, timeout_s=SERVER_START_TIMEOUT_S
-            )
-        except BaseException:
-            # A failed/timed-out startup still leaves server_task running and
-            # the socket bound; stop() already unwinds both.
-            await self.stop()
-            raise
+        await self._runtime.start()
         logger.info(
             "Starting A2A Gateway server on port %d with %d peers",
             self.port,
@@ -282,17 +267,8 @@ class GatewayServer:
         )
 
     async def stop(self) -> None:
-        if self._uvicorn is None or self._server_task is None:
+        if self._runtime is None:
             return
-        # Ask uvicorn to exit rather than cancelling serve(): cancellation
-        # skips its shutdown phase and leaks the listening socket.
-        self._uvicorn.should_exit = True
-        try:
-            await self._server_task
-        except asyncio.CancelledError:
-            raise
-        except BaseException:  # uvicorn raises SystemExit on startup failure
-            logger.exception("A2A Gateway server exited with error")
-        self._uvicorn = None
-        self._server_task = None
+        await self._runtime.stop()
+        self._runtime = None
         logger.info("A2A Gateway server stopped")

--- a/src/band/integrations/a2a/gateway/server.py
+++ b/src/band/integrations/a2a/gateway/server.py
@@ -251,7 +251,7 @@ class GatewayServer:
         await self._runtime.start()
         logger.info(
             "Starting A2A Gateway server on port %d with %d peers",
-            self.port,
+            self.bound_port,
             len(self.peers),
         )
 

--- a/src/band/integrations/a2a/gateway/server.py
+++ b/src/band/integrations/a2a/gateway/server.py
@@ -27,19 +27,16 @@ logger = logging.getLogger(__name__)
 
 ExecutorFactory = Callable[[str], AgentExecutor]
 
-# The process-global sse_starlette shutdown-drain footgun (see
-# band.integrations.uvicorn_server's docstring) is disabled by importing
-# that module above, not here -- ManagedUvicornServer's every caller shares
-# the fix.
+# sse_starlette's shutdown-drain footgun (see uvicorn_server's docstring)
+# is disabled by importing that module, not here.
 
 # A live message:stream response has no other way to end on stop() --
 # uvicorn's own default (None) would wait forever for it to close on its own.
 SERVER_STOP_TIMEOUT_S = 5
 
-# How long start() waits for uvicorn to report ready before giving up. Without
-# this wait, start() returns as soon as serve() is merely scheduled -- a caller
-# (e.g. an A2A client dialing in immediately after on_started()) can then race
-# a socket that isn't listening yet.
+# How long start() waits for uvicorn to report ready -- without it, a caller
+# dialing in right after start() returns could race a socket that isn't
+# listening yet.
 SERVER_START_TIMEOUT_S = 5
 
 # The REST endpoints the gateway serves per peer: the messaging binding and
@@ -47,12 +44,10 @@ SERVER_START_TIMEOUT_S = 5
 # and push-config routes — an unauthenticated window into past conversations.
 MESSAGING_REST_SUFFIXES = ("/message:send", "/message:stream", "/card")
 
-# The JSON-RPC methods the gateway serves (1.0 names and their v0.3-compat
-# spellings). Sends create work; the per-task operations are gated by the
-# unguessable task UUID the server minted for the caller. Everything else
-# stays closed: with no auth layer every caller shares one identity, so
-# enumeration (ListTasks) and the push-config/extended-card methods would
-# disclose or disrupt other callers' conversations.
+# JSON-RPC methods the gateway serves (1.0 + v0.3-compat spellings). Sends
+# create work; per-task ops are gated by the unguessable task UUID. Everything
+# else stays closed -- with no auth layer, enumeration/push-config methods
+# would disclose or disrupt other callers' conversations.
 ALLOWED_JSONRPC_METHODS = frozenset(
     {
         "SendMessage",
@@ -198,10 +193,9 @@ class GatewayServer:
     ) -> list[BaseRoute]:
         """The REST binding, reduced to the endpoints this gateway serves.
 
-        Beyond the unauthenticated task routes, the upstream factory ends with
-        a multi-tenant catch-all ``Mount("/{tenant}")``; peers here are
-        namespaced by path, and the first alias's mount would shadow every
-        later alias's flat routes.
+        The upstream factory also returns a catch-all ``Mount("/{tenant}")``;
+        since peers are namespaced by path here, the first alias's mount
+        would shadow every later alias's routes.
         """
         return [
             route

--- a/src/band/integrations/a2a/gateway/server.py
+++ b/src/band/integrations/a2a/gateway/server.py
@@ -16,6 +16,7 @@ from a2a.server.tasks import InMemoryTaskStore
 from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill
 from a2a.compat.v0_3.conversions import to_compat_agent_card
 from a2a.utils.constants import PROTOCOL_VERSION_0_3, PROTOCOL_VERSION_CURRENT
+from sse_starlette.sse import AppStatus
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -27,13 +28,18 @@ logger = logging.getLogger(__name__)
 
 ExecutorFactory = Callable[[str], AgentExecutor]
 
-# uvicorn's own default (None) waits forever for existing connections to close
-# on stop() -- and a live message:stream SSE response has no other way to end
-# on its own. sse_starlette normally closes it cooperatively on shutdown, but
-# that mechanism is a process-global switch any co-located
-# band.integrations.mcp.local_server permanently disables (see that module's
-# AppStatus.disable_automatic_graceful_drain() call) -- so this bound is the
-# only thing that keeps stop() from hanging once that happens.
+# sse_starlette's shutdown watcher polls whichever uvicorn.Server owns the
+# process's SIGTERM slot and promotes its should_exit to the process-global
+# AppStatus.should_exit -- so a GatewayServer.stop() (which sets should_exit
+# directly, not via a signal) can poison every later GatewayServer's SSE
+# streams in the same process. band.integrations.mcp.local_server disables
+# this for the same reason; calling it here too avoids depending on that
+# import (idempotent, process-wide).
+AppStatus.disable_automatic_graceful_drain()
+
+# The automatic drain above is disabled, so a live message:stream response
+# has no other way to end on stop() -- uvicorn's own default (None) would
+# wait forever for it to close on its own.
 SERVER_STOP_TIMEOUT_S = 5
 
 # How long start() waits for uvicorn to report ready before giving up. Without

--- a/src/band/integrations/mcp/local_server.py
+++ b/src/band/integrations/mcp/local_server.py
@@ -1,15 +1,12 @@
 """The embedded MCP front door: run one ``LocalMCPServer`` per adapter.
 
 Ephemeral-port scanning starts from a random offset (dodges a just-freed-
-port wedge). Mounts ``engine.py``'s FastMCP app rather than hand-rolling a
-lowlevel ``Server``; building the tool-registration list itself is
-``engine.py``'s job too (``build_band_mcp_tool_registrations`` /
-``build_resolved_band_mcp_tool_registrations``) -- this module only runs
-the server once it has that list.
+port wedge). Mounts ``engine.py``'s FastMCP app; ``engine.py`` also builds
+the tool-registration list, this module only runs the server once it has one.
 
-Every lifecycle transition (``start()``/``stop()``) routes through one lock,
-with cleanup in ``finally`` -- so a serve-task crash always closes the
-socket and resets state, and concurrent start/stop calls can't race.
+Every ``start()``/``stop()`` routes through one lock with cleanup in
+``finally``, so a serve-task crash always closes the socket and resets
+state, and concurrent start/stop calls can't race.
 """
 
 from __future__ import annotations
@@ -62,14 +59,12 @@ SERVER_STOP_TIMEOUT_S = 5
 class EmbeddedUvicornServer(uvicorn.Server):
     """A uvicorn server that leaves process signal handling to its host.
 
-    uvicorn's ``serve()`` captures SIGINT/SIGTERM for itself -- fine for a
-    standalone process, but this server is embedded in a host that may run
-    several servers over its lifetime and already owns its own signal
-    handling. It's also the other half of the sse_starlette bug documented in
-    ``band.integrations.uvicorn_server``: capturing signals here would let
-    sse_starlette latch its process-global shutdown flag through *this*
-    server's handler too. Shutdown is driven programmatically instead, via
-    ``should_exit`` (see ``LocalMCPServer.stop``).
+    uvicorn's ``serve()`` captures SIGINT/SIGTERM by default -- wrong for a
+    server embedded in a host that already owns signal handling, and it's
+    the other half of the sse_starlette footgun (see uvicorn_server's
+    docstring): capturing signals here would let sse_starlette latch its
+    shutdown flag through this server's handler too. Shutdown goes through
+    ``should_exit`` instead (see ``LocalMCPServer.stop``).
     """
 
     @contextmanager
@@ -181,9 +176,8 @@ class LocalMCPServer:
                 return
 
             reserved_socket, port = self._reserve_socket()
-            # Tracked immediately, before anything below can raise: `stop()`'s
-            # cleanup closes `self._socket` unconditionally, so a failure in
-            # engine/app/uvicorn construction still gets the socket closed
+            # Tracked immediately: stop()'s cleanup closes self._socket
+            # unconditionally, so a failure below still gets it closed
             # instead of leaking a bound-and-listening fd.
             self._socket = reserved_socket
             self._port = port
@@ -242,9 +236,9 @@ class LocalMCPServer:
     async def _stop_locked(self) -> None:
         """The actual teardown, run only while ``_lifecycle_lock`` is held.
 
-        Cleanup lives in ``finally``: the previous version's bare ``await
-        self._serve_task`` re-raised past the socket-close/state-reset code
-        below it whenever the serve task crashed with anything but
+        Cleanup lives in ``finally`` -- a bare ``await self._serve_task``
+        outside one would re-raise past the socket-close/state-reset code
+        below it if the serve task crashed with anything but
         ``CancelledError``, leaking the socket and leaving stale state for
         the next ``start()``.
         """
@@ -271,11 +265,10 @@ class LocalMCPServer:
     def _build_app(self, mcp: FastMCP) -> Starlette:
         """Mount the engine's SSE + streamable-HTTP routes onto one host app.
 
-        ``streamable_http_app()`` lazily creates ``mcp.session_manager`` and
-        returns its own Starlette app whose lifespan runs it -- but a mounted
-        sub-app's lifespan is never invoked by the ASGI server, only the
-        top-level app's is. So the host lifespan below enters
-        ``session_manager.run()`` itself (verified by the step-1 spike).
+        ``streamable_http_app()`` lazily creates ``mcp.session_manager``, but
+        a mounted sub-app's lifespan is never invoked by the ASGI server --
+        only the top-level app's is. So the host lifespan below enters
+        ``session_manager.run()`` itself.
         """
         sse_routes = list(mcp.sse_app().routes)
         http_routes = list(mcp.streamable_http_app().routes)
@@ -305,11 +298,10 @@ class LocalMCPServer:
             port = reserved_socket.getsockname()[1]
             return _listen(reserved_socket), port
 
-        # Scan the range from a random starting offset (wrapping around), not
-        # first-fit from port_min: first-fit hands a new server the port a
-        # just-stopped sibling freed moments ago, and that port's previous
-        # consumers (e.g. an MCP client subprocess still winding down) keep
-        # sending stale session traffic that wedges the new server's transport.
+        # Random starting offset, not first-fit from port_min: first-fit
+        # reuses the port a just-stopped sibling freed, and that port's old
+        # consumers (an MCP client subprocess still winding down) keep
+        # sending stale traffic that wedges the new server's transport.
         last_error: OSError | None = None
         span = self._port_max - self._port_min + 1
         start = random.randrange(span)

--- a/src/band/integrations/mcp/local_server.py
+++ b/src/band/integrations/mcp/local_server.py
@@ -35,6 +35,7 @@ from band.integrations.mcp.engine import (
     build_engine,
     validate_unique_tool_names,
 )
+from band.integrations.uvicorn_server import wait_until_started
 
 logger = logging.getLogger(__name__)
 
@@ -236,7 +237,9 @@ class LocalMCPServer:
                 self._uvicorn_server = uvicorn_server
                 self._serve_task = serve_task
 
-                await self._wait_until_started()
+                await wait_until_started(
+                    uvicorn_server, serve_task, timeout_s=SERVER_START_TIMEOUT_S
+                )
             except Exception:
                 await self._stop_locked()
                 raise
@@ -343,15 +346,3 @@ class LocalMCPServer:
             "Could not find a free localhost MCP port in range "
             f"{self._port_min}-{self._port_max}"
         ) from last_error
-
-    async def _wait_until_started(self) -> None:
-        if self._serve_task is None or self._uvicorn_server is None:
-            raise RuntimeError("Local MCP server task not initialized")
-
-        deadline = asyncio.get_running_loop().time() + SERVER_START_TIMEOUT_S
-        while not self._uvicorn_server.started:
-            if self._serve_task.done():
-                await self._serve_task
-            if asyncio.get_running_loop().time() >= deadline:
-                raise TimeoutError("Timed out waiting for local MCP server startup")
-            await asyncio.sleep(0.05)

--- a/src/band/integrations/mcp/local_server.py
+++ b/src/band/integrations/mcp/local_server.py
@@ -31,7 +31,11 @@ from band.integrations.mcp.engine import (
     build_engine,
     validate_unique_tool_names,
 )
-from band.integrations.uvicorn_server import wait_until_started
+from band.integrations.uvicorn_server import (
+    SERVER_START_TIMEOUT_S,
+    SERVER_STOP_TIMEOUT_S,
+    wait_until_started,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -42,13 +46,6 @@ LOCAL_MCP_SSE_PATH = "/sse"
 LOCAL_MCP_HTTP_PATH = "/mcp"
 LOCAL_MCP_MESSAGE_PATH = "/messages/"
 LOCAL_MCP_HEALTH_PATH = "/healthz"
-SERVER_START_TIMEOUT_S = 5.0
-# uvicorn's own default (None) waits forever for existing connections to close
-# on `stop()` -- fatal here, since an MCP client (e.g. OpenCode) holds its `/sse`
-# GET open for the life of its session and may never close it on its own after
-# we deregister. Bound it so `stop()` force-cancels that connection instead of
-# hanging the adapter's cleanup indefinitely.
-SERVER_STOP_TIMEOUT_S = 5
 
 # The process-global sse_starlette shutdown-drain footgun (see
 # band.integrations.uvicorn_server's docstring) is disabled by importing

--- a/src/band/integrations/mcp/local_server.py
+++ b/src/band/integrations/mcp/local_server.py
@@ -69,12 +69,10 @@ SERVER_STOP_TIMEOUT_S = 5
 # something threaded through LocalMCPServer's API.
 #
 # Cost of that global scope: any *other* sse_starlette consumer in the same
-# process -- e.g. the A2A gateway's own message:stream responses
-# (src/band/integrations/a2a/gateway/server.py) -- loses this same
-# cooperative-drain signal too, permanently, the moment this module is
-# imported anywhere in the process. That server's own uvicorn.Config sets
-# timeout_graceful_shutdown precisely so its stop() still bounds how long it
-# waits on a live stream, rather than relying on the now-disabled signal.
+# process loses this same signal too, the moment this module is imported.
+# The A2A gateway (src/band/integrations/a2a/gateway/server.py) hits the
+# identical bug independently and disables this itself; the call here is
+# redundant with that one but harmless (idempotent, process-wide).
 AppStatus.disable_automatic_graceful_drain()
 
 

--- a/src/band/integrations/mcp/local_server.py
+++ b/src/band/integrations/mcp/local_server.py
@@ -23,7 +23,6 @@ from contextlib import asynccontextmanager, contextmanager
 
 import uvicorn
 from mcp.server.fastmcp import FastMCP
-from sse_starlette.sse import AppStatus
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
@@ -54,27 +53,10 @@ SERVER_START_TIMEOUT_S = 5.0
 # hanging the adapter's cleanup indefinitely.
 SERVER_STOP_TIMEOUT_S = 5
 
-# sse_starlette's EventSourceResponse watches a process-global AppStatus for a
-# shutdown signal, closing every open SSE stream right after its headers once
-# latched -- from either of two sources: our own signal handler (neutralized
-# by EmbeddedUvicornServer.capture_signals below), or *any other*
-# uvicorn.Server anywhere in this process whose handle_exit() ever fires,
-# since AppStatus.should_exit is a bare class attribute with no notion of
-# "which server." The second case is real: a Windows CI hang traced to
-# exactly this, a live SSE connection closing right after its headers with no
-# code of ours involved. LocalMCPServer.stop() already forces its own socket
-# closed and cancels its serve task directly, so it never needed
-# sse_starlette's automatic drain-on-shutdown; disabling it here removes the
-# dependency on that global entirely. Process-wide and one-time by nature
-# (AppStatus has no per-instance scope), hence a module-level call rather than
-# something threaded through LocalMCPServer's API.
-#
-# Cost of that global scope: any *other* sse_starlette consumer in the same
-# process loses this same signal too, the moment this module is imported.
-# The A2A gateway (src/band/integrations/a2a/gateway/server.py) hits the
-# identical bug independently and disables this itself; the call here is
-# redundant with that one but harmless (idempotent, process-wide).
-AppStatus.disable_automatic_graceful_drain()
+# The process-global sse_starlette shutdown-drain footgun (see
+# band.integrations.uvicorn_server's docstring) is disabled by importing
+# that module above, not here -- a Windows CI hang was traced to exactly
+# this before that fix existed.
 
 
 class EmbeddedUvicornServer(uvicorn.Server):
@@ -83,11 +65,11 @@ class EmbeddedUvicornServer(uvicorn.Server):
     uvicorn's ``serve()`` captures SIGINT/SIGTERM for itself -- fine for a
     standalone process, but this server is embedded in a host that may run
     several servers over its lifetime and already owns its own signal
-    handling. It's also the other half of the sse_starlette bug documented at
-    the ``AppStatus.disable_automatic_graceful_drain()`` call above: capturing
-    signals here would let sse_starlette latch its process-global shutdown
-    flag through *this* server's handler too. Shutdown is driven
-    programmatically instead, via ``should_exit`` (see ``LocalMCPServer.stop``).
+    handling. It's also the other half of the sse_starlette bug documented in
+    ``band.integrations.uvicorn_server``: capturing signals here would let
+    sse_starlette latch its process-global shutdown flag through *this*
+    server's handler too. Shutdown is driven programmatically instead, via
+    ``should_exit`` (see ``LocalMCPServer.stop``).
     """
 
     @contextmanager

--- a/src/band/integrations/uvicorn_server.py
+++ b/src/band/integrations/uvicorn_server.py
@@ -1,15 +1,10 @@
 """Shared lifecycle for integrations that embed their own uvicorn server.
 
-``wait_until_started`` and ``ManagedUvicornServer`` are used by
-``band.integrations.mcp.local_server``, ``band.integrations.a2a.gateway.server``,
-and the A2A baseline test fixture, so the correctness-sensitive pieces --
-surfacing a serve task that never came up, and cleaning up after a failed
-start -- are each fixed in one place, not re-derived per caller.
-
-Importing this module also disables sse_starlette's automatic
-graceful-drain watcher (see the ``AppStatus`` call below): every consumer
-here embeds its own ``uvicorn.Server`` the same way, and that watcher's
-shutdown signal is a bare process-global with no notion of "which server."
+Used by ``mcp.local_server``, ``a2a.gateway.server``, and the A2A baseline
+test fixture. Importing this module also disables sse_starlette's
+automatic graceful-drain watcher (see the ``AppStatus`` call below): its
+shutdown signal is a bare process-global with no notion of "which server,"
+so every embedder needs it disabled once, not per caller.
 """
 
 from __future__ import annotations
@@ -25,13 +20,7 @@ logger = logging.getLogger(__name__)
 
 POLL_INTERVAL_S = 0.05
 
-# sse_starlette's shutdown watcher polls whichever uvicorn.Server owns the
-# process's SIGTERM slot and promotes its should_exit to the process-global
-# AppStatus.should_exit -- so one embedded server's stop() (which sets
-# should_exit directly, not via a signal) can poison every other embedded
-# server's SSE streams in the same process. Every caller here embeds its own
-# uvicorn.Server this same way, so this is disabled once, on import, rather
-# than duplicated per caller.
+# Process-global footgun -- see module docstring. Disabled once, on import.
 AppStatus.disable_automatic_graceful_drain()
 
 
@@ -43,12 +32,10 @@ async def wait_until_started(
 ) -> None:
     """Block until ``server`` reports ready.
 
-    ``serve_task`` only returns once the server stops, so readiness is
-    polled via ``server.started`` instead of awaiting the task directly.
-    But a task that ends before ever setting ``started`` -- raising (a port
-    already in use, a bad TLS config) or not (an early shutdown signal) --
-    means the server will never start; either way that's fatal immediately,
-    not something worth busy-waiting the full timeout to discover.
+    Polls ``server.started`` since ``serve_task`` only returns once the
+    server stops. A task that ends first -- raising or not -- means the
+    server will never start, so that's fatal immediately rather than
+    busy-waited to the timeout.
     """
     deadline = asyncio.get_running_loop().time() + timeout_s
     while not server.started:

--- a/src/band/integrations/uvicorn_server.py
+++ b/src/band/integrations/uvicorn_server.py
@@ -1,0 +1,42 @@
+"""Shared startup wait for integrations that embed their own uvicorn server.
+
+Used by both ``band.integrations.mcp.local_server`` and
+``band.integrations.a2a.gateway.server`` (and the A2A baseline test fixture)
+so the one correctness-sensitive piece -- surfacing a serve task that died
+before the server ever came up -- is fixed in one place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import uvicorn
+
+POLL_INTERVAL_S = 0.05
+
+
+async def wait_until_started(
+    server: uvicorn.Server,
+    serve_task: asyncio.Task[object],
+    *,
+    timeout_s: float,
+) -> None:
+    """Block until ``server`` reports ready.
+
+    ``serve_task`` only returns once the server stops, so readiness is
+    polled via ``server.started`` instead of awaiting the task directly.
+    But a task that dies before ever setting ``started`` -- a port already
+    in use, a bad TLS config -- would otherwise busy-wait the full
+    ``timeout_s`` and then raise a generic timeout instead of the real
+    failure; checking ``serve_task.done()`` on every pass re-raises that
+    failure immediately.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while not server.started:
+        if serve_task.done():
+            await serve_task
+        if asyncio.get_running_loop().time() >= deadline:
+            raise TimeoutError(
+                f"uvicorn server did not report ready within {timeout_s}s"
+            )
+        await asyncio.sleep(POLL_INTERVAL_S)

--- a/src/band/integrations/uvicorn_server.py
+++ b/src/band/integrations/uvicorn_server.py
@@ -20,6 +20,17 @@ logger = logging.getLogger(__name__)
 
 POLL_INTERVAL_S = 0.05
 
+# How long start() waits for uvicorn to report ready -- without it, a caller
+# dialing in right after start() returns could race a socket that isn't
+# listening yet.
+SERVER_START_TIMEOUT_S = 5.0
+
+# uvicorn's own default (None) waits forever for an open connection to close
+# on stop() -- fatal for a caller holding one open on purpose (a live
+# message:stream response, an MCP client's long-lived /sse GET). Bound it so
+# stop() force-closes the connection instead of hanging indefinitely.
+SERVER_STOP_TIMEOUT_S = 5
+
 # Process-global footgun -- see module docstring. Disabled once, on import.
 AppStatus.disable_automatic_graceful_drain()
 
@@ -62,8 +73,8 @@ class ManagedUvicornServer:
         *,
         host: str,
         port: int,
-        start_timeout_s: float,
-        stop_timeout_s: int,
+        start_timeout_s: float = SERVER_START_TIMEOUT_S,
+        stop_timeout_s: int = SERVER_STOP_TIMEOUT_S,
     ) -> None:
         self._app = app
         self._host = host

--- a/src/band/integrations/uvicorn_server.py
+++ b/src/band/integrations/uvicorn_server.py
@@ -1,18 +1,38 @@
-"""Shared startup wait for integrations that embed their own uvicorn server.
+"""Shared lifecycle for integrations that embed their own uvicorn server.
 
-Used by both ``band.integrations.mcp.local_server`` and
-``band.integrations.a2a.gateway.server`` (and the A2A baseline test fixture)
-so the one correctness-sensitive piece -- surfacing a serve task that died
-before the server ever came up -- is fixed in one place.
+``wait_until_started`` and ``ManagedUvicornServer`` are used by
+``band.integrations.mcp.local_server``, ``band.integrations.a2a.gateway.server``,
+and the A2A baseline test fixture, so the correctness-sensitive pieces --
+surfacing a serve task that never came up, and cleaning up after a failed
+start -- are each fixed in one place, not re-derived per caller.
+
+Importing this module also disables sse_starlette's automatic
+graceful-drain watcher (see the ``AppStatus`` call below): every consumer
+here embeds its own ``uvicorn.Server`` the same way, and that watcher's
+shutdown signal is a bare process-global with no notion of "which server."
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import uvicorn
+from sse_starlette.sse import AppStatus
+from starlette.types import ASGIApp
+
+logger = logging.getLogger(__name__)
 
 POLL_INTERVAL_S = 0.05
+
+# sse_starlette's shutdown watcher polls whichever uvicorn.Server owns the
+# process's SIGTERM slot and promotes its should_exit to the process-global
+# AppStatus.should_exit -- so one embedded server's stop() (which sets
+# should_exit directly, not via a signal) can poison every other embedded
+# server's SSE streams in the same process. Every caller here embeds its own
+# uvicorn.Server this same way, so this is disabled once, on import, rather
+# than duplicated per caller.
+AppStatus.disable_automatic_graceful_drain()
 
 
 async def wait_until_started(
@@ -25,18 +45,87 @@ async def wait_until_started(
 
     ``serve_task`` only returns once the server stops, so readiness is
     polled via ``server.started`` instead of awaiting the task directly.
-    But a task that dies before ever setting ``started`` -- a port already
-    in use, a bad TLS config -- would otherwise busy-wait the full
-    ``timeout_s`` and then raise a generic timeout instead of the real
-    failure; checking ``serve_task.done()`` on every pass re-raises that
-    failure immediately.
+    But a task that ends before ever setting ``started`` -- raising (a port
+    already in use, a bad TLS config) or not (an early shutdown signal) --
+    means the server will never start; either way that's fatal immediately,
+    not something worth busy-waiting the full timeout to discover.
     """
     deadline = asyncio.get_running_loop().time() + timeout_s
     while not server.started:
         if serve_task.done():
-            await serve_task
+            await serve_task  # re-raises if the task itself failed
+            raise RuntimeError("uvicorn server task ended before ever starting")
         if asyncio.get_running_loop().time() >= deadline:
             raise TimeoutError(
                 f"uvicorn server did not report ready within {timeout_s}s"
             )
         await asyncio.sleep(POLL_INTERVAL_S)
+
+
+class ManagedUvicornServer:
+    """Runs one ASGI app on a background uvicorn server.
+
+    Starts it, waits for readiness, tears it down -- no knowledge of what
+    the app is or does.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        host: str,
+        port: int,
+        start_timeout_s: float,
+        stop_timeout_s: int,
+    ) -> None:
+        self._app = app
+        self._host = host
+        self._port = port
+        self._start_timeout_s = start_timeout_s
+        self._stop_timeout_s = stop_timeout_s
+        self._server: uvicorn.Server | None = None
+        self._task: asyncio.Task[None] | None = None
+
+    @property
+    def bound_port(self) -> int:
+        """The actual listening port -- resolves ``port=0`` to whatever the
+        OS assigned."""
+        if self._server is None:
+            raise RuntimeError("server has not started")
+        return self._server.servers[0].sockets[0].getsockname()[1]
+
+    async def start(self) -> None:
+        server = uvicorn.Server(
+            uvicorn.Config(
+                self._app,
+                host=self._host,
+                port=self._port,
+                log_level="warning",
+                timeout_graceful_shutdown=self._stop_timeout_s,
+            )
+        )
+        task = asyncio.create_task(server.serve())
+        self._server = server
+        self._task = task
+        try:
+            await wait_until_started(server, task, timeout_s=self._start_timeout_s)
+        except BaseException:
+            # A failed/timed-out startup still leaves the task running and
+            # the socket bound; stop() unwinds both.
+            await self.stop()
+            raise
+
+    async def stop(self) -> None:
+        if self._server is None or self._task is None:
+            return
+        # Ask uvicorn to exit rather than cancelling serve(): cancellation
+        # skips its shutdown phase and leaks the listening socket.
+        self._server.should_exit = True
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            raise
+        except BaseException:  # uvicorn raises SystemExit on startup failure
+            logger.exception("Embedded uvicorn server exited with error")
+        self._server = None
+        self._task = None

--- a/tests/e2e/baseline/README.md
+++ b/tests/e2e/baseline/README.md
@@ -239,7 +239,7 @@ These three are why the toolkit is shaped the way it is — keep them when exten
 | `smoke/matrix/` | runs across the adapter matrix: `test_adapter_matrix.py`, `test_capability_matrix.py` (memory store + recall), `test_context_recall.py` (in-session + rejoin), `test_rehydration_offline.py` / `test_rehydration_partial.py` (cold-boot / partial-reboot `/context` recall), `test_rehydration_cross_framework.py` (a different-framework `peer=` authors, A rehydrates), `test_room_isolation.py`, `test_noisy_room.py`, `test_tool_round_trip.py` (custom-tool subgroup) |
 | `smoke/behavior/` | platform/transport + scenario behavior: `test_delivery_status.py`, `test_processing_barrier.py`, `test_isolation.py`, `test_agent_scenarios.py` |
 | `smoke/inspection/` | `capture.*` observation worked-examples: `test_tool_calls.py`, `test_events.py`, `test_memory.py`, `test_usage.py` (the `Emit.USAGE` fan), plus `test_next_actionable_semantics.py` (a platform `/next` invariant, `@lane`-pinned since it runs no adapter) |
-| `smoke/adapters/` | adapter-specific showcases: `test_agno.py`, `test_copilot_acp.py`, `test_copilot_sdk.py`, `test_crewai.py`, `test_letta.py`, `test_opencode.py`, `test_parlant.py` |
+| `smoke/adapters/` | adapter-specific showcases: `test_a2a.py`, `test_a2a_gateway.py`, `test_a2a_roundtrip.py` (+ their shared `a2aServer.py` fixture -- a scripted, non-Band A2A counterparty), `test_agno.py`, `test_copilot_acp.py`, `test_copilot_sdk.py`, `test_crewai.py`, `test_letta.py`, `test_opencode.py`, `test_parlant.py` |
 
 The `toolkit/` modules are pytest-free and reusable anywhere. The package root
 (`settings`, `requires`, `agents`, `conftest`) is the pytest wiring.

--- a/tests/e2e/baseline/smoke/adapters/a2aServer.py
+++ b/tests/e2e/baseline/smoke/adapters/a2aServer.py
@@ -28,20 +28,16 @@ from a2a.types import (
 from a2a.utils.constants import PROTOCOL_VERSION_CURRENT
 from starlette.applications import Starlette
 
-from band.integrations.uvicorn_server import ManagedUvicornServer
+from band.integrations.uvicorn_server import (
+    SERVER_START_TIMEOUT_S,
+    SERVER_STOP_TIMEOUT_S,
+    ManagedUvicornServer,
+)
 
 from tests.ports import reserve_port
 
 CANNED_REPLY = "a2a-fixture-canned-reply"
 ERROR_MARKER = "a2a-fixture-trigger-error"
-
-# Mirrors band.integrations.a2a.gateway.server.SERVER_STOP_TIMEOUT_S: uvicorn's
-# own default (None) waits forever for an open connection to close on stop(),
-# and a live message:stream response has no other way to end on its own.
-STOP_TIMEOUT_S = 5
-
-# How long start() waits for uvicorn to report ready before giving up.
-START_TIMEOUT_S = 5
 
 
 class ScriptedExecutor(AgentExecutor):
@@ -130,8 +126,8 @@ class A2ACounterparty:
             self._build_app(),
             host="127.0.0.1",
             port=self.port,
-            start_timeout_s=START_TIMEOUT_S,
-            stop_timeout_s=STOP_TIMEOUT_S,
+            start_timeout_s=SERVER_START_TIMEOUT_S,
+            stop_timeout_s=SERVER_STOP_TIMEOUT_S,
         )
         await self._runtime.start()
 

--- a/tests/e2e/baseline/smoke/adapters/a2aServer.py
+++ b/tests/e2e/baseline/smoke/adapters/a2aServer.py
@@ -1,0 +1,164 @@
+"""Standalone A2A counterparty server for baseline E2E smokes.
+
+Built directly on a2a-sdk's own server primitives (not Band's gateway), so
+``test_a2a.py`` can point a live ``A2AAdapter`` at a real, independent A2A
+implementation -- proving the SDK's outbound client against something other
+than our own gateway. Scripted, not LLM-backed, so it needs no LLM key: a
+request whose text carries ``ERROR_MARKER`` fails the task; every other
+request completes with ``CANNED_REPLY``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import uvicorn
+from a2a.helpers import get_message_text, new_task_from_user_message
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.routes.agent_card_routes import create_agent_card_routes
+from a2a.server.routes.jsonrpc_routes import create_jsonrpc_routes
+from a2a.server.tasks import InMemoryTaskStore, TaskUpdater
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentInterface,
+    AgentSkill,
+    Part,
+    UnsupportedOperationError,
+)
+from a2a.utils.constants import PROTOCOL_VERSION_CURRENT
+from starlette.applications import Starlette
+
+from tests.ports import reserve_port
+
+CANNED_REPLY = "a2a-fixture-canned-reply"
+ERROR_MARKER = "a2a-fixture-trigger-error"
+
+# Mirrors band.integrations.a2a.gateway.server.SERVER_STOP_TIMEOUT_S: uvicorn's
+# own default (None) waits forever for an open connection to close on stop(),
+# and a live message:stream response has no other way to end on its own.
+STOP_TIMEOUT_S = 5
+
+# How long start() waits for uvicorn to report ready before giving up.
+START_TIMEOUT_S = 5
+
+
+class ScriptedExecutor(AgentExecutor):
+    """A deterministic counterparty: a canned reply, or a scripted failure.
+
+    No LLM involved -- ``ERROR_MARKER`` in the request text is the only
+    branch, so a smoke can trigger either path deterministically.
+    """
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        if context.message is None:
+            raise ValueError("A2A request is missing its message")
+        task = context.current_task or new_task_from_user_message(context.message)
+        if context.current_task is None:
+            await event_queue.enqueue_event(task)
+
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
+        if ERROR_MARKER in get_message_text(context.message):
+            await updater.failed(
+                updater.new_agent_message([Part(text="fixture: scripted failure")])
+            )
+            return
+        await updater.complete(updater.new_agent_message([Part(text=CANNED_REPLY)]))
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        raise UnsupportedOperationError()
+
+
+class A2ACounterparty:
+    """A live, standalone A2A JSON-RPC server for a smoke to point an
+    ``A2AAdapter`` at.
+
+    Binds an OS-assigned free port (via ``reserve_port``) so parallel runs
+    never collide. The port must be known before the agent card is built (the
+    card advertises it), so it is reserved up front in ``__init__`` rather
+    than left to uvicorn to pick at ``start()`` time.
+    """
+
+    def __init__(self) -> None:
+        self.port = reserve_port()
+        self._uvicorn: uvicorn.Server | None = None
+        self._server_task: asyncio.Task[Any] | None = None
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def _agent_card(self) -> AgentCard:
+        return AgentCard(
+            name="A2A Smoke Fixture",
+            description="Deterministic A2A counterparty for baseline E2E smokes.",
+            supported_interfaces=[
+                AgentInterface(
+                    protocol_binding="JSONRPC",
+                    protocol_version=PROTOCOL_VERSION_CURRENT,
+                    url=self.url,
+                ),
+            ],
+            version="1.0.0",
+            capabilities=AgentCapabilities(streaming=True),
+            skills=[
+                AgentSkill(
+                    id="default",
+                    name="Scripted reply",
+                    description="Replies with a deterministic canned marker.",
+                    tags=["smoke"],
+                )
+            ],
+            default_input_modes=["text/plain"],
+            default_output_modes=["text/plain"],
+        )
+
+    def _build_app(self) -> Starlette:
+        card = self._agent_card()
+        handler = DefaultRequestHandler(
+            agent_executor=ScriptedExecutor(),
+            task_store=InMemoryTaskStore(),
+            agent_card=card,
+        )
+        routes = create_agent_card_routes(card) + create_jsonrpc_routes(
+            handler, rpc_url="/", enable_v0_3_compat=True
+        )
+        return Starlette(routes=routes)
+
+    async def start(self) -> None:
+        self._uvicorn = uvicorn.Server(
+            uvicorn.Config(
+                self._build_app(),
+                host="127.0.0.1",
+                port=self.port,
+                log_level="warning",
+                timeout_graceful_shutdown=STOP_TIMEOUT_S,
+            )
+        )
+        self._server_task = asyncio.create_task(self._uvicorn.serve())
+        deadline = asyncio.get_running_loop().time() + START_TIMEOUT_S
+        while not self._uvicorn.started:
+            if asyncio.get_running_loop().time() > deadline:
+                raise RuntimeError(
+                    f"A2A fixture server did not start within {START_TIMEOUT_S}s "
+                    f"on port {self.port}"
+                )
+            await asyncio.sleep(0.05)
+
+    async def stop(self) -> None:
+        if self._uvicorn is None or self._server_task is None:
+            return
+        # Ask uvicorn to exit rather than cancelling serve(): cancellation
+        # skips its shutdown phase and leaks the listening socket.
+        self._uvicorn.should_exit = True
+        try:
+            await self._server_task
+        except asyncio.CancelledError:
+            raise
+        except BaseException:  # uvicorn raises SystemExit on startup failure
+            pass
+        self._uvicorn = None
+        self._server_task = None

--- a/tests/e2e/baseline/smoke/adapters/a2aServer.py
+++ b/tests/e2e/baseline/smoke/adapters/a2aServer.py
@@ -10,10 +10,6 @@ request completes with ``CANNED_REPLY``.
 
 from __future__ import annotations
 
-import asyncio
-from typing import Any
-
-import uvicorn
 from a2a.helpers import get_message_text, new_task_from_user_message
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
@@ -32,7 +28,7 @@ from a2a.types import (
 from a2a.utils.constants import PROTOCOL_VERSION_CURRENT
 from starlette.applications import Starlette
 
-from band.integrations.uvicorn_server import wait_until_started
+from band.integrations.uvicorn_server import ManagedUvicornServer
 
 from tests.ports import reserve_port
 
@@ -86,8 +82,7 @@ class A2ACounterparty:
 
     def __init__(self) -> None:
         self.port = reserve_port()
-        self._uvicorn: uvicorn.Server | None = None
-        self._server_task: asyncio.Task[Any] | None = None
+        self._runtime: ManagedUvicornServer | None = None
 
     @property
     def url(self) -> str:
@@ -131,31 +126,17 @@ class A2ACounterparty:
         return Starlette(routes=routes)
 
     async def start(self) -> None:
-        server = uvicorn.Server(
-            uvicorn.Config(
-                self._build_app(),
-                host="127.0.0.1",
-                port=self.port,
-                log_level="warning",
-                timeout_graceful_shutdown=STOP_TIMEOUT_S,
-            )
+        self._runtime = ManagedUvicornServer(
+            self._build_app(),
+            host="127.0.0.1",
+            port=self.port,
+            start_timeout_s=START_TIMEOUT_S,
+            stop_timeout_s=STOP_TIMEOUT_S,
         )
-        server_task = asyncio.create_task(server.serve())
-        self._uvicorn = server
-        self._server_task = server_task
-        await wait_until_started(server, server_task, timeout_s=START_TIMEOUT_S)
+        await self._runtime.start()
 
     async def stop(self) -> None:
-        if self._uvicorn is None or self._server_task is None:
+        if self._runtime is None:
             return
-        # Ask uvicorn to exit rather than cancelling serve(): cancellation
-        # skips its shutdown phase and leaks the listening socket.
-        self._uvicorn.should_exit = True
-        try:
-            await self._server_task
-        except asyncio.CancelledError:
-            raise
-        except BaseException:  # uvicorn raises SystemExit on startup failure
-            pass
-        self._uvicorn = None
-        self._server_task = None
+        await self._runtime.stop()
+        self._runtime = None

--- a/tests/e2e/baseline/smoke/adapters/a2aServer.py
+++ b/tests/e2e/baseline/smoke/adapters/a2aServer.py
@@ -32,6 +32,8 @@ from a2a.types import (
 from a2a.utils.constants import PROTOCOL_VERSION_CURRENT
 from starlette.applications import Starlette
 
+from band.integrations.uvicorn_server import wait_until_started
+
 from tests.ports import reserve_port
 
 CANNED_REPLY = "a2a-fixture-canned-reply"
@@ -129,7 +131,7 @@ class A2ACounterparty:
         return Starlette(routes=routes)
 
     async def start(self) -> None:
-        self._uvicorn = uvicorn.Server(
+        server = uvicorn.Server(
             uvicorn.Config(
                 self._build_app(),
                 host="127.0.0.1",
@@ -138,15 +140,10 @@ class A2ACounterparty:
                 timeout_graceful_shutdown=STOP_TIMEOUT_S,
             )
         )
-        self._server_task = asyncio.create_task(self._uvicorn.serve())
-        deadline = asyncio.get_running_loop().time() + START_TIMEOUT_S
-        while not self._uvicorn.started:
-            if asyncio.get_running_loop().time() > deadline:
-                raise RuntimeError(
-                    f"A2A fixture server did not start within {START_TIMEOUT_S}s "
-                    f"on port {self.port}"
-                )
-            await asyncio.sleep(0.05)
+        server_task = asyncio.create_task(server.serve())
+        self._uvicorn = server
+        self._server_task = server_task
+        await wait_until_started(server, server_task, timeout_s=START_TIMEOUT_S)
 
     async def stop(self) -> None:
         if self._uvicorn is None or self._server_task is None:

--- a/tests/e2e/baseline/smoke/adapters/test_a2a.py
+++ b/tests/e2e/baseline/smoke/adapters/test_a2a.py
@@ -1,0 +1,121 @@
+"""A2AAdapter showcase smoke -- a live A2AAdapter driven against a real,
+independent A2A counterparty (not Band's own gateway).
+
+A2A is a protocol bridge, not an LLM-agent adapter (listed in
+``NON_AGENT_ADAPTERS``), so this is a bespoke, non-matrix smoke like
+``test_parlant.py``: the adapter is built directly and handed to the
+toolkit's ``running_provisioned_agent`` so provisioning, capture, and reaping
+share the same plumbing as every other baseline test.
+
+The counterparty is ``a2aServer.A2ACounterparty``: a minimal, scripted A2A
+server built on a2a-sdk's own primitives (not Band), so this proves the
+outbound ``A2AAdapter`` against a real, independent A2A implementation --
+not just our own gateway. It is deterministic, not LLM-backed, so neither
+side of this smoke needs an LLM key.
+
+Run with:
+    E2E_TESTS_ENABLED=true uv run pytest \\
+        tests/e2e/baseline/smoke/adapters/test_a2a.py -v -s --no-cov
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from band.integrations.a2a import A2AAdapter
+
+from tests.e2e.baseline.agents import Lane, lane
+from tests.e2e.baseline.flaky import flaky_infra
+from tests.e2e.baseline.settings import BaselineSettings
+from tests.e2e.baseline.smoke.adapters.a2aServer import (
+    CANNED_REPLY,
+    ERROR_MARKER,
+    A2ACounterparty,
+)
+from tests.e2e.baseline.toolkit.capture import CaptureFactory
+from tests.e2e.baseline.toolkit.provisioning import (
+    ResourceManager,
+    running_provisioned_agent,
+)
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+
+# A2A isn't in the adapter registry (NON_AGENT_ADAPTERS), so the lane selector
+# can't derive its home lane and would run it in every lane. Pin it to core --
+# this smoke needs no provider key (the counterparty is scripted, not
+# LLM-backed), only the always-on Band-platform gate.
+@lane(Lane.CORE)
+@flaky_infra("retry a transient live-turn timeout; assertion failures fail loud")
+@pytest.mark.timeout(extra=60)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_a2a_adapter_relays_a_real_counterparty_reply(
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+    baseline_settings: BaselineSettings,
+) -> None:
+    """A live ``A2AAdapter`` forwards a Band room message to a real,
+    independent A2A server and relays its reply back into the room."""
+    counterparty = A2ACounterparty()
+    await counterparty.start()
+    try:
+        adapter = A2AAdapter(remote_url=counterparty.url, streaming=True)
+        async with running_provisioned_agent(
+            adapter, resource_manager, label="a2a"
+        ) as agent:
+            room_id = await resource_manager.provision_room(
+                title="e2e-a2a-reply", participants=[agent.id]
+            )
+            async with reply_capture(room_id) as capture:
+                mid = await user_ops.send_message(
+                    room_id,
+                    "Please say hello.",
+                    mention_id=agent.id,
+                    mention_name=agent.name,
+                )
+                replies = await capture.wait_for_reply(
+                    mid, agent.id, deadline_s=baseline_settings.e2e_timeout
+                )
+    finally:
+        await counterparty.stop()
+
+    replies.assert_contains_any([CANNED_REPLY])
+
+
+@lane(Lane.CORE)
+@flaky_infra("retry a transient live-turn timeout; assertion failures fail loud")
+@pytest.mark.timeout(extra=60)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_a2a_adapter_surfaces_a_remote_task_failure(
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+    baseline_settings: BaselineSettings,
+) -> None:
+    """A terminal FAILED task from the remote A2A server surfaces as a room
+    error event, not a silently dropped turn."""
+    counterparty = A2ACounterparty()
+    await counterparty.start()
+    try:
+        adapter = A2AAdapter(remote_url=counterparty.url, streaming=True)
+        async with running_provisioned_agent(
+            adapter, resource_manager, label="a2a"
+        ) as agent:
+            room_id = await resource_manager.provision_room(
+                title="e2e-a2a-failure", participants=[agent.id]
+            )
+            async with reply_capture(room_id) as capture:
+                mid = await user_ops.send_message(
+                    room_id,
+                    f"trigger a scripted failure: {ERROR_MARKER}",
+                    mention_id=agent.id,
+                    mention_name=agent.name,
+                )
+                await capture.wait_for_processed(
+                    mid, agent.id, deadline_s=baseline_settings.e2e_timeout
+                )
+                errors = await capture.errors(sender_id=agent.id)
+    finally:
+        await counterparty.stop()
+
+    errors.assert_present()

--- a/tests/e2e/baseline/smoke/adapters/test_a2a.py
+++ b/tests/e2e/baseline/smoke/adapters/test_a2a.py
@@ -1,17 +1,14 @@
-"""A2AAdapter showcase smoke -- a live A2AAdapter driven against a real,
-independent A2A counterparty (not Band's own gateway).
+"""A2AAdapter showcase smoke -- a live A2AAdapter driven against
+``a2aServer.A2ACounterparty``, a minimal scripted A2A server (not Band's
+own gateway), proving the outbound adapter against an independent
+implementation. Deterministic, not LLM-backed, so neither side needs an
+LLM key.
 
-A2A is a protocol bridge, not an LLM-agent adapter (listed in
-``NON_AGENT_ADAPTERS``), so this is a bespoke, non-matrix smoke like
-``test_parlant.py``: the adapter is built directly and handed to the
-toolkit's ``running_provisioned_agent`` so provisioning, capture, and reaping
-share the same plumbing as every other baseline test.
-
-The counterparty is ``a2aServer.A2ACounterparty``: a minimal, scripted A2A
-server built on a2a-sdk's own primitives (not Band), so this proves the
-outbound ``A2AAdapter`` against a real, independent A2A implementation --
-not just our own gateway. It is deterministic, not LLM-backed, so neither
-side of this smoke needs an LLM key.
+A2A is a protocol bridge, not an LLM-agent adapter (``NON_AGENT_ADAPTERS``),
+so this is a bespoke, non-matrix smoke like ``test_parlant.py``: the
+adapter is built directly and handed to ``running_provisioned_agent`` so
+provisioning, capture, and reaping share the same plumbing as every other
+baseline test.
 
 Run with:
     E2E_TESTS_ENABLED=true uv run pytest \\
@@ -40,10 +37,9 @@ from tests.e2e.baseline.toolkit.user_ops import UserOps
 from tests.lifecycle import running
 
 
-# A2A isn't in the adapter registry (NON_AGENT_ADAPTERS), so the lane selector
-# can't derive its home lane and would run it in every lane. Pin it to core --
-# this smoke needs no provider key (the counterparty is scripted, not
-# LLM-backed), only the always-on Band-platform gate.
+# Not in the adapter registry, so the lane selector can't derive a home
+# lane and would run it in every lane. Pin to core -- needs no provider key
+# (the counterparty is scripted), only the always-on Band-platform gate.
 @lane(Lane.CORE)
 @pytest.mark.timeout(extra=60)
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/e2e/baseline/smoke/adapters/test_a2a.py
+++ b/tests/e2e/baseline/smoke/adapters/test_a2a.py
@@ -25,7 +25,6 @@ import pytest
 from band.integrations.a2a import A2AAdapter
 
 from tests.e2e.baseline.agents import Lane, lane
-from tests.e2e.baseline.flaky import flaky_infra
 from tests.e2e.baseline.settings import BaselineSettings
 from tests.e2e.baseline.smoke.adapters.a2aServer import (
     CANNED_REPLY,
@@ -45,7 +44,6 @@ from tests.e2e.baseline.toolkit.user_ops import UserOps
 # this smoke needs no provider key (the counterparty is scripted, not
 # LLM-backed), only the always-on Band-platform gate.
 @lane(Lane.CORE)
-@flaky_infra("retry a transient live-turn timeout; assertion failures fail loud")
 @pytest.mark.timeout(extra=60)
 @pytest.mark.asyncio(loop_scope="session")
 async def test_a2a_adapter_relays_a_real_counterparty_reply(
@@ -83,7 +81,6 @@ async def test_a2a_adapter_relays_a_real_counterparty_reply(
 
 
 @lane(Lane.CORE)
-@flaky_infra("retry a transient live-turn timeout; assertion failures fail loud")
 @pytest.mark.timeout(extra=60)
 @pytest.mark.asyncio(loop_scope="session")
 async def test_a2a_adapter_surfaces_a_remote_task_failure(

--- a/tests/e2e/baseline/smoke/adapters/test_a2a.py
+++ b/tests/e2e/baseline/smoke/adapters/test_a2a.py
@@ -37,6 +37,7 @@ from tests.e2e.baseline.toolkit.provisioning import (
     running_provisioned_agent,
 )
 from tests.e2e.baseline.toolkit.user_ops import UserOps
+from tests.lifecycle import running
 
 
 # A2A isn't in the adapter registry (NON_AGENT_ADAPTERS), so the lane selector
@@ -54,9 +55,7 @@ async def test_a2a_adapter_relays_a_real_counterparty_reply(
 ) -> None:
     """A live ``A2AAdapter`` forwards a Band room message to a real,
     independent A2A server and relays its reply back into the room."""
-    counterparty = A2ACounterparty()
-    try:
-        await counterparty.start()
+    async with running(A2ACounterparty()) as counterparty:
         adapter = A2AAdapter(remote_url=counterparty.url, streaming=True)
         async with running_provisioned_agent(
             adapter, resource_manager, label="a2a"
@@ -74,8 +73,6 @@ async def test_a2a_adapter_relays_a_real_counterparty_reply(
                 replies = await capture.wait_for_reply(
                     mid, agent.id, deadline_s=baseline_settings.e2e_timeout
                 )
-    finally:
-        await counterparty.stop()
 
     replies.assert_contains_any([CANNED_REPLY])
 
@@ -91,9 +88,7 @@ async def test_a2a_adapter_surfaces_a_remote_task_failure(
 ) -> None:
     """A terminal FAILED task from the remote A2A server surfaces as a room
     error event, not a silently dropped turn."""
-    counterparty = A2ACounterparty()
-    try:
-        await counterparty.start()
+    async with running(A2ACounterparty()) as counterparty:
         adapter = A2AAdapter(remote_url=counterparty.url, streaming=True)
         async with running_provisioned_agent(
             adapter, resource_manager, label="a2a"
@@ -112,7 +107,5 @@ async def test_a2a_adapter_surfaces_a_remote_task_failure(
                     mid, agent.id, deadline_s=baseline_settings.e2e_timeout
                 )
                 errors = await capture.errors(sender_id=agent.id)
-    finally:
-        await counterparty.stop()
 
     errors.assert_present()

--- a/tests/e2e/baseline/smoke/adapters/test_a2a.py
+++ b/tests/e2e/baseline/smoke/adapters/test_a2a.py
@@ -57,8 +57,8 @@ async def test_a2a_adapter_relays_a_real_counterparty_reply(
     """A live ``A2AAdapter`` forwards a Band room message to a real,
     independent A2A server and relays its reply back into the room."""
     counterparty = A2ACounterparty()
-    await counterparty.start()
     try:
+        await counterparty.start()
         adapter = A2AAdapter(remote_url=counterparty.url, streaming=True)
         async with running_provisioned_agent(
             adapter, resource_manager, label="a2a"
@@ -95,8 +95,8 @@ async def test_a2a_adapter_surfaces_a_remote_task_failure(
     """A terminal FAILED task from the remote A2A server surfaces as a room
     error event, not a silently dropped turn."""
     counterparty = A2ACounterparty()
-    await counterparty.start()
     try:
+        await counterparty.start()
         adapter = A2AAdapter(remote_url=counterparty.url, streaming=True)
         async with running_provisioned_agent(
             adapter, resource_manager, label="a2a"

--- a/tests/e2e/baseline/smoke/adapters/test_a2a_gateway.py
+++ b/tests/e2e/baseline/smoke/adapters/test_a2a_gateway.py
@@ -26,6 +26,7 @@ from a2a.client import ClientConfig, ClientFactory
 from a2a.helpers import get_message_text, new_text_message
 from a2a.types import Role, SendMessageRequest
 
+from band.integrations.a2a.adapter import _SSE_READ_TIMEOUT_S
 from band.integrations.a2a.gateway import A2AGatewayAdapter
 
 from tests.e2e.baseline.agents import Adapter, with_adapters
@@ -56,9 +57,12 @@ async def test_gateway_serves_a_real_a2a_client(
     async with running_provisioned_agent(gateway, resource_manager, label="a2a-gw"):
         # The Anthropic peer's own id is a stable alias the gateway always
         # serves (alongside its slug), so the client needs no slug lookup.
-        # httpx's default 5s read timeout fires on the normal, multi-second
-        # gap between SSE events during a real LLM turn -- not a hang.
-        http_client = httpx.AsyncClient(timeout=httpx.Timeout(10.0, read=None))
+        # Same generous-but-bounded read timeout as A2AAdapter itself (see
+        # its module docstring): httpx's default 5s fires on the normal,
+        # multi-second gap between SSE events during a real LLM turn.
+        http_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(10.0, read=_SSE_READ_TIMEOUT_S)
+        )
         factory = ClientFactory(ClientConfig(streaming=True, httpx_client=http_client))
         client = await factory.create_from_url(
             f"http://127.0.0.1:{port}/agents/{agent.id}"

--- a/tests/e2e/baseline/smoke/adapters/test_a2a_gateway.py
+++ b/tests/e2e/baseline/smoke/adapters/test_a2a_gateway.py
@@ -20,6 +20,7 @@ Run with:
 
 from __future__ import annotations
 
+import httpx
 import pytest
 from a2a.client import ClientConfig, ClientFactory
 from a2a.helpers import get_message_text, new_text_message
@@ -55,7 +56,10 @@ async def test_gateway_serves_a_real_a2a_client(
     async with running_provisioned_agent(gateway, resource_manager, label="a2a-gw"):
         # The Anthropic peer's own id is a stable alias the gateway always
         # serves (alongside its slug), so the client needs no slug lookup.
-        factory = ClientFactory(ClientConfig(streaming=True))
+        # httpx's default 5s read timeout fires on the normal, multi-second
+        # gap between SSE events during a real LLM turn -- not a hang.
+        http_client = httpx.AsyncClient(timeout=httpx.Timeout(10.0, read=None))
+        factory = ClientFactory(ClientConfig(streaming=True, httpx_client=http_client))
         client = await factory.create_from_url(
             f"http://127.0.0.1:{port}/agents/{agent.id}"
         )
@@ -71,5 +75,6 @@ async def test_gateway_serves_a_real_a2a_client(
                         reply_text = text
         finally:
             await client.close()
+            await http_client.aclose()
 
     assert reply_text, "expected a reply relayed from the live Band peer over A2A"

--- a/tests/e2e/baseline/smoke/adapters/test_a2a_gateway.py
+++ b/tests/e2e/baseline/smoke/adapters/test_a2a_gateway.py
@@ -1,0 +1,75 @@
+"""A2AGatewayAdapter showcase smoke -- driving a live gateway with the
+official a2a-sdk reference client, independent of ``A2AAdapter``.
+
+A2A is a protocol bridge, not an LLM-agent adapter (listed in
+``NON_AGENT_ADAPTERS``), so the gateway itself is built bespoke and handed to
+``running_provisioned_agent``, like ``test_parlant.py``. The *target* peer it
+exposes, though, is an ordinary Anthropic-backed Band agent provisioned
+through ``@with_adapters`` -- which also derives this smoke's home lane
+(``core``), so no ``@lane`` pin is needed here.
+
+Drives the gateway with a real ``a2a.client.Client`` (the a2a-sdk reference
+client), not our own ``A2AAdapter`` -- this validates the gateway's JSON-RPC
+server against the actual upstream implementation, independent of any bug
+the two could otherwise share.
+
+Run with:
+    E2E_TESTS_ENABLED=true uv run pytest \\
+        tests/e2e/baseline/smoke/adapters/test_a2a_gateway.py -v -s --no-cov
+"""
+
+from __future__ import annotations
+
+import pytest
+from a2a.client import ClientConfig, ClientFactory
+from a2a.helpers import get_message_text, new_text_message
+from a2a.types import Role, SendMessageRequest
+
+from band.integrations.a2a.gateway import A2AGatewayAdapter
+
+from tests.e2e.baseline.agents import Adapter, with_adapters
+from tests.e2e.baseline.flaky import flaky_infra
+from tests.e2e.baseline.toolkit.provisioning import (
+    ProvisionedAgent,
+    ResourceManager,
+    running_provisioned_agent,
+)
+from tests.ports import reserve_port
+
+_SHORT = "You are a friendly assistant in a chat room. Reply in one short sentence."
+
+
+@with_adapters(Adapter.ANTHROPIC, prompt=_SHORT)
+@flaky_infra("retry a transient live-turn timeout; assertion failures fail loud")
+@pytest.mark.timeout(extra=120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_gateway_serves_a_real_a2a_client(
+    agent: ProvisionedAgent,
+    resource_manager: ResourceManager,
+) -> None:
+    """A raw a2a-sdk client drives the gateway's JSON-RPC endpoint for a live
+    Band peer and receives its real reply back over A2A."""
+    port = reserve_port()
+    gateway = A2AGatewayAdapter(gateway_url=f"http://127.0.0.1:{port}", port=port)
+
+    async with running_provisioned_agent(gateway, resource_manager, label="a2a-gw"):
+        # The Anthropic peer's own id is a stable alias the gateway always
+        # serves (alongside its slug), so the client needs no slug lookup.
+        factory = ClientFactory(ClientConfig(streaming=True))
+        client = await factory.create_from_url(
+            f"http://127.0.0.1:{port}/agents/{agent.id}"
+        )
+        reply_text = ""
+        try:
+            message = new_text_message("Please say hello.", role=Role.ROLE_USER)
+            async for event in client.send_message(SendMessageRequest(message=message)):
+                if event.HasField(
+                    "status_update"
+                ) and event.status_update.status.HasField("message"):
+                    text = get_message_text(event.status_update.status.message)
+                    if text:
+                        reply_text = text
+        finally:
+            await client.close()
+
+    assert reply_text, "expected a reply relayed from the live Band peer over A2A"

--- a/tests/e2e/baseline/smoke/adapters/test_a2a_roundtrip.py
+++ b/tests/e2e/baseline/smoke/adapters/test_a2a_roundtrip.py
@@ -1,0 +1,86 @@
+"""Full A2A round-trip smoke: Band Agent A -> ``A2AAdapter`` -> a live
+gateway -> Band Agent B (Anthropic), and the reply flowing all the way back.
+
+Reuses ``test_a2a_gateway.py``'s target-peer + gateway setup, but swaps the
+raw a2a-sdk reference client for a live ``A2AAdapter`` as the caller --
+proving the realistic Band-to-Band usage pattern end to end: a Band room
+message forwarded over real A2A JSON-RPC to a gateway-exposed Band peer, with
+that peer's real LLM reply relayed all the way back into Agent A's own room.
+
+``@with_adapters(Adapter.ANTHROPIC)`` (for the target peer B) also derives
+this smoke's home lane (``core``), so no ``@lane`` pin is needed -- the
+gateway and the caller ``A2AAdapter`` are themselves protocol bridges
+(``NON_AGENT_ADAPTERS``) built bespoke, same as ``test_a2a_gateway.py``.
+
+Run with:
+    E2E_TESTS_ENABLED=true uv run pytest \\
+        tests/e2e/baseline/smoke/adapters/test_a2a_roundtrip.py -v -s --no-cov
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from band.integrations.a2a import A2AAdapter
+from band.integrations.a2a.gateway import A2AGatewayAdapter
+
+from tests.e2e.baseline.agents import Adapter, with_adapters
+from tests.e2e.baseline.flaky import flaky_infra
+from tests.e2e.baseline.settings import BaselineSettings
+from tests.e2e.baseline.toolkit.capture import CaptureFactory
+from tests.e2e.baseline.toolkit.provisioning import (
+    ProvisionedAgent,
+    ResourceManager,
+    running_provisioned_agent,
+)
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+from tests.ports import reserve_port
+
+_SHORT = "You are a friendly assistant in a chat room. Reply in one short sentence."
+
+
+@with_adapters(Adapter.ANTHROPIC, prompt=_SHORT)
+@flaky_infra("retry a transient live-turn timeout; assertion failures fail loud")
+# Two relayed hops (Agent A -> gateway -> Agent B) plus one real LLM turn on
+# top of a gateway + two adapter cold starts: 240s outer, leaving 120s
+# overhead beyond the 2x e2e_timeout barrier deadline below.
+@pytest.mark.timeout(extra=240)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_band_to_band_round_trip_over_real_a2a(
+    agent: ProvisionedAgent,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+    baseline_settings: BaselineSettings,
+) -> None:
+    """Band Agent A relays a room message through a live A2A gateway to Band
+    Agent B (a real Anthropic turn) and posts B's reply back into A's room."""
+    port = reserve_port()
+    gateway = A2AGatewayAdapter(gateway_url=f"http://127.0.0.1:{port}", port=port)
+
+    async with running_provisioned_agent(gateway, resource_manager, label="a2a-gw"):
+        caller = A2AAdapter(
+            remote_url=f"http://127.0.0.1:{port}/agents/{agent.id}", streaming=True
+        )
+        async with running_provisioned_agent(
+            caller, resource_manager, label="a2a-caller"
+        ) as caller_agent:
+            room_id = await resource_manager.provision_room(
+                title="e2e-a2a-roundtrip", participants=[caller_agent.id]
+            )
+            async with reply_capture(room_id) as capture:
+                mid = await user_ops.send_message(
+                    room_id,
+                    "Please say hello.",
+                    mention_id=caller_agent.id,
+                    mention_name=caller_agent.name,
+                )
+                replies = await capture.wait_for_reply(
+                    mid,
+                    caller_agent.id,
+                    deadline_s=baseline_settings.e2e_timeout * 2,
+                )
+
+    replies.assert_present(
+        what="a reply relayed over a live Band-to-Band A2A round trip"
+    )

--- a/tests/integrations/a2a/gateway/helpers.py
+++ b/tests/integrations/a2a/gateway/helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from band_rest import Peer
 
 
@@ -16,3 +18,9 @@ def make_peer(peer_id: str, name: str, description: str = "") -> Peer:
         is_contact=False,
         source="registry",
     )
+
+
+def peers_page(peers: list[Peer]) -> SimpleNamespace:
+    """A fake ``list_agent_peers`` response page -- only ``.data`` matters
+    to ``_fetch_all_peers``, which pages until a page comes back short."""
+    return SimpleNamespace(data=peers)

--- a/tests/integrations/a2a/gateway/test_adapter.py
+++ b/tests/integrations/a2a/gateway/test_adapter.py
@@ -269,6 +269,57 @@ class TestGatewayExecution:
         ), "a timed-out request must not be logged as completed"
 
     @pytest.mark.asyncio
+    async def test_send_failure_publishes_terminal_failure(self) -> None:
+        """A REST failure while posting to Band must not leave the remote
+        A2A caller waiting on a stuck WORKING task."""
+        adapter = A2AGatewayAdapter(rest_client=MagicMock())
+        adapter._peers = {"weather": make_peer("weather", "Weather Agent")}
+        configure_room_creation(adapter)
+        adapter._rest.agent_api_messages.create_agent_chat_message = AsyncMock(
+            side_effect=RuntimeError("Band unavailable")
+        )
+        queue = EventQueueLegacy()
+
+        with pytest.raises(RuntimeError, match="Band unavailable"):
+            await BandAgentExecutor(adapter, "weather").execute(make_request(), queue)
+
+        initial = await queue.dequeue_event()
+        terminal = await queue.dequeue_event()
+        assert initial.status.state == TaskState.TASK_STATE_WORKING
+        assert terminal.status.state == TaskState.TASK_STATE_FAILED
+        assert adapter._pending_tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_establish_request_raises_when_peer_missing(self) -> None:
+        adapter = A2AGatewayAdapter(rest_client=MagicMock())
+
+        with pytest.raises(ValueError, match="Peer not found"):
+            await adapter._establish_request(
+                "missing", make_request(), EventQueueLegacy()
+            )
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_peers_accumulates_across_pages(self) -> None:
+        adapter = A2AGatewayAdapter(rest_client=MagicMock())
+        page1 = MagicMock()
+        page1.data = [make_peer(f"peer-{i}", f"Peer {i}") for i in range(100)]
+        page2 = MagicMock()
+        page2.data = [make_peer("peer-100", "Peer 100")]
+        adapter._rest.agent_api_peers.list_agent_peers = AsyncMock(
+            side_effect=[page1, page2]
+        )
+
+        peers = await adapter._fetch_all_peers()
+
+        assert len(peers) == 101
+        assert adapter._rest.agent_api_peers.list_agent_peers.await_count == 2
+        first_call, second_call = (
+            adapter._rest.agent_api_peers.list_agent_peers.call_args_list
+        )
+        assert first_call.kwargs["page"] == 1
+        assert second_call.kwargs["page"] == 2
+
+    @pytest.mark.asyncio
     async def test_cleanup_all_stops_the_hosted_server(self) -> None:
         """Agent.stop() reaches the adapter only via cleanup_all, so the
         self-hosted HTTP server must be stopped there."""
@@ -381,6 +432,23 @@ class TestGatewayRoomState:
         assert (room_a, room_b) == ("room-a", "room-b"), (
             "distinct A2A contexts must not share a Band room"
         )
+
+    @pytest.mark.asyncio
+    async def test_participant_add_failure_leaves_no_partial_room_state(
+        self, adapter: A2AGatewayAdapter
+    ) -> None:
+        """Regression coverage: a REST failure after room creation currently
+        leaves no context/room mapping behind, so a retry creates a brand
+        new room rather than reusing the one that was just orphaned."""
+        adapter._rest.agent_api_participants.add_agent_chat_participant = AsyncMock(
+            side_effect=RuntimeError("participant add failed")
+        )
+
+        with pytest.raises(RuntimeError, match="participant add failed"):
+            await adapter._get_or_create_room("ctx", "weather")
+
+        assert adapter._context_to_room == {}
+        assert adapter._room_participants == {}
 
     def test_rehydrate_merges_without_overwriting_live_context(self) -> None:
         adapter = A2AGatewayAdapter(rest_client=MagicMock())

--- a/tests/integrations/a2a/gateway/test_adapter.py
+++ b/tests/integrations/a2a/gateway/test_adapter.py
@@ -56,10 +56,18 @@ def make_request(content: str = "What is the weather?") -> RequestContext:
     return RequestContext(None, request=SendMessageRequest(message=message))
 
 
-def configure_room_creation(adapter: A2AGatewayAdapter) -> None:
+def room_creation_response(room_id: str) -> MagicMock:
     response = MagicMock()
-    response.data.id = "room-123"
-    adapter._rest.agent_api_chats.create_agent_chat = AsyncMock(return_value=response)
+    response.data.id = room_id
+    return response
+
+
+def configure_room_creation(
+    adapter: A2AGatewayAdapter, *, room_id: str = "room-123"
+) -> None:
+    adapter._rest.agent_api_chats.create_agent_chat = AsyncMock(
+        return_value=room_creation_response(room_id)
+    )
     adapter._rest.agent_api_participants.add_agent_chat_participant = AsyncMock()
     adapter._rest.agent_api_messages.create_agent_chat_message = AsyncMock()
     adapter._rest.agent_api_events.create_agent_chat_event = AsyncMock()
@@ -97,10 +105,8 @@ class TestGatewayStartup:
     @pytest.mark.asyncio
     async def test_discovers_peers_and_starts_server(self) -> None:
         adapter = A2AGatewayAdapter(rest_client=MagicMock())
-        response = MagicMock()
-        response.data = [make_peer("weather", "Weather Agent")]
         adapter._rest.agent_api_peers.list_agent_peers = AsyncMock(
-            return_value=response
+            return_value=peers_page([make_peer("weather", "Weather Agent")])
         )
 
         with patch(
@@ -389,12 +395,7 @@ class TestGatewayRoomState:
             "weather": make_peer("weather", "Weather Agent"),
             "data": make_peer("data", "Data Agent"),
         }
-        response = MagicMock()
-        response.data.id = "new-room"
-        adapter._rest.agent_api_chats.create_agent_chat = AsyncMock(
-            return_value=response
-        )
-        adapter._rest.agent_api_participants.add_agent_chat_participant = AsyncMock()
+        configure_room_creation(adapter, room_id="new-room")
         return adapter
 
     @pytest.mark.asyncio
@@ -417,13 +418,11 @@ class TestGatewayRoomState:
     async def test_different_contexts_get_different_rooms(
         self, adapter: A2AGatewayAdapter
     ) -> None:
-        responses = []
-        for room_id in ("room-a", "room-b"):
-            response = MagicMock()
-            response.data.id = room_id
-            responses.append(response)
         adapter._rest.agent_api_chats.create_agent_chat = AsyncMock(
-            side_effect=responses
+            side_effect=[
+                room_creation_response("room-a"),
+                room_creation_response("room-b"),
+            ]
         )
 
         room_a, _ = await adapter._get_or_create_room("ctx-a", "weather")

--- a/tests/integrations/a2a/gateway/test_adapter.py
+++ b/tests/integrations/a2a/gateway/test_adapter.py
@@ -26,7 +26,7 @@ from band.integrations.a2a.gateway import A2AGatewayAdapter, A2AGatewayAdapterCo
 from band.integrations.a2a.gateway.adapter import BandAgentExecutor
 from band.integrations.a2a.gateway.types import GatewaySessionState, PendingA2ATask
 from band.testing import FakeAgentTools
-from tests.integrations.a2a.gateway.helpers import make_peer
+from tests.integrations.a2a.gateway.helpers import make_peer, peers_page
 
 
 def make_platform_message(
@@ -303,12 +303,10 @@ class TestGatewayExecution:
     @pytest.mark.asyncio
     async def test_fetch_all_peers_accumulates_across_pages(self) -> None:
         adapter = A2AGatewayAdapter(rest_client=MagicMock())
-        page1 = MagicMock()
-        page1.data = [make_peer(f"peer-{i}", f"Peer {i}") for i in range(100)]
-        page2 = MagicMock()
-        page2.data = [make_peer("peer-100", "Peer 100")]
+        full_page = [make_peer(f"peer-{i}", f"Peer {i}") for i in range(100)]
+        partial_page = [make_peer("peer-100", "Peer 100")]
         adapter._rest.agent_api_peers.list_agent_peers = AsyncMock(
-            side_effect=[page1, page2]
+            side_effect=[peers_page(full_page), peers_page(partial_page)]
         )
 
         peers = await adapter._fetch_all_peers()

--- a/tests/integrations/a2a/gateway/test_adapter.py
+++ b/tests/integrations/a2a/gateway/test_adapter.py
@@ -287,6 +287,8 @@ class TestGatewayExecution:
         terminal = await queue.dequeue_event()
         assert initial.status.state == TaskState.TASK_STATE_WORKING
         assert terminal.status.state == TaskState.TASK_STATE_FAILED
+        assert terminal.status.message.parts[0].text == "A2A request failed"
+        assert "Band unavailable" not in terminal.status.message.parts[0].text
         assert adapter._pending_tasks == {}
 
     @pytest.mark.asyncio

--- a/tests/integrations/a2a/gateway/test_server.py
+++ b/tests/integrations/a2a/gateway/test_server.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import suppress
 from uuid import uuid4
 
@@ -19,6 +19,7 @@ from httpx import ASGITransport
 
 from band.integrations.a2a.gateway.server import SERVER_STOP_TIMEOUT_S, GatewayServer
 from tests.integrations.a2a.gateway.helpers import make_peer
+from tests.lifecycle import elapsed, held_open, running
 
 
 class FakeExecutor(AgentExecutor):
@@ -42,13 +43,17 @@ class FakeExecutor(AgentExecutor):
         raise NotImplementedError
 
 
-def build_server() -> GatewayServer:
+def build_server(
+    *,
+    port: int = 10000,
+    executor_factory: Callable[[str], AgentExecutor] | None = None,
+) -> GatewayServer:
     peer = make_peer("uuid-weather", "Weather Agent", "Gets weather info")
     return GatewayServer(
         peers={"weather-agent": peer},
-        gateway_url="http://localhost:10000",
-        port=10000,
-        executor_factory=lambda _slug: FakeExecutor(),
+        gateway_url=f"http://localhost:{port}",
+        port=port,
+        executor_factory=executor_factory or (lambda _slug: FakeExecutor()),
     )
 
 
@@ -406,21 +411,10 @@ async def test_start_returns_only_once_the_server_is_listening() -> None:
     """A caller dialing in right after ``on_started()`` returns (e.g. a real
     A2A client, or one of the E2E smokes) must not race a socket that isn't
     accepting connections yet."""
-    peer = make_peer("uuid-weather", "Weather Agent", "Gets weather info")
-    server = GatewayServer(
-        peers={"weather-agent": peer},
-        gateway_url="http://localhost:0",
-        port=0,
-        executor_factory=lambda _slug: FakeExecutor(),
-    )
-
-    await server.start()
-    try:
+    async with running(build_server(port=0)) as server:
         async with httpx.AsyncClient() as client:
             response = await client.get(f"http://127.0.0.1:{server.bound_port}/peers")
         assert response.status_code == 200
-    finally:
-        await server.stop()
 
 
 class DelayedTwoStepExecutor(AgentExecutor):
@@ -458,24 +452,17 @@ async def test_a_second_server_is_not_poisoned_by_a_prior_servers_shutdown() -> 
     the flag from test_disables_sse_starlette_automatic_graceful_drain: a
     second GatewayServer's live stream, opened only after a first one has
     stopped in the same process, must still deliver every event."""
-    first = GatewayServer(
-        peers={"weather-agent": make_peer("uuid-weather", "Weather Agent", "")},
-        gateway_url="http://localhost:0",
-        port=0,
-        executor_factory=lambda _slug: FakeExecutor(),
-    )
-    await first.start()
-    port1 = first.bound_port
-    async with httpx.AsyncClient(timeout=None) as client:
-        async with client.stream(
-            "POST",
-            f"http://127.0.0.1:{port1}/agents/weather-agent/message:stream",
-            headers={"A2A-Version": "1.0"},
-            json=hello_message_body(),
-        ) as response:
-            async for _ in response.aiter_bytes():
-                pass
-    await first.stop()
+    async with running(build_server(port=0)) as first:
+        port1 = first.bound_port
+        async with httpx.AsyncClient(timeout=None) as client:
+            async with client.stream(
+                "POST",
+                f"http://127.0.0.1:{port1}/agents/weather-agent/message:stream",
+                headers={"A2A-Version": "1.0"},
+                json=hello_message_body(),
+            ) as response:
+                async for _ in response.aiter_bytes():
+                    pass
 
     second = GatewayServer(
         peers={"other-agent": make_peer("uuid-other", "Other Agent", "")},
@@ -483,8 +470,7 @@ async def test_a_second_server_is_not_poisoned_by_a_prior_servers_shutdown() -> 
         port=0,
         executor_factory=lambda _slug: DelayedTwoStepExecutor(),
     )
-    await second.start()
-    try:
+    async with running(second):
         port2 = second.bound_port
         events: list[str] = []
         async with httpx.AsyncClient(timeout=None) as client:
@@ -502,8 +488,6 @@ async def test_a_second_server_is_not_poisoned_by_a_prior_servers_shutdown() -> 
             f"got {len(events)} events, expected 3 (task, working, completed) -- "
             "the second server's stream was cut short by the first server's shutdown"
         )
-    finally:
-        await second.stop()
 
 
 class NeverFinishingExecutor(AgentExecutor):
@@ -536,51 +520,36 @@ async def test_stop_returns_promptly_with_a_still_open_message_stream() -> None:
     outside and mask a real hang as a false pass) -- same rationale as
     LocalMCPServer's own equivalent regression test.
     """
-    peer = make_peer("uuid-weather", "Weather Agent", "Gets weather info")
-    server = GatewayServer(
-        peers={"weather-agent": peer},
-        gateway_url="http://localhost:0",
-        port=0,
-        executor_factory=lambda _slug: NeverFinishingExecutor(),
+    server = build_server(
+        port=0, executor_factory=lambda _slug: NeverFinishingExecutor()
     )
-    await server.start()
-    port = server.bound_port
+    async with running(server):
+        port = server.bound_port
 
-    connection_ready = asyncio.Event()
+        async def connect(ready: asyncio.Event) -> None:
+            with suppress(Exception):
+                # timeout=None: httpx's default 5s read timeout would otherwise
+                # give up waiting for the next chunk and disconnect on its own
+                # around the same mark as SERVER_STOP_TIMEOUT_S -- masking a
+                # real server-side hang as a false pass, since the connection
+                # would end for the wrong reason (a bored client) rather than
+                # proving stop() itself is bounded.
+                async with (
+                    httpx.AsyncClient(timeout=None) as client,
+                    client.stream(
+                        "POST",
+                        f"http://127.0.0.1:{port}/agents/weather-agent/message:stream",
+                        headers={"A2A-Version": "1.0"},
+                        json=hello_message_body(),
+                    ) as response,
+                ):
+                    async for _ in response.aiter_bytes():
+                        ready.set()
 
-    async def hold_connection_open() -> None:
-        with suppress(Exception):
-            # timeout=None: httpx's default 5s read timeout would otherwise
-            # give up waiting for the next chunk and disconnect on its own
-            # around the same mark as SERVER_STOP_TIMEOUT_S -- masking a real
-            # server-side hang as a false pass, since the connection would
-            # end for the wrong reason (a bored client) rather than proving
-            # stop() itself is bounded.
-            async with (
-                httpx.AsyncClient(timeout=None) as client,
-                client.stream(
-                    "POST",
-                    f"http://127.0.0.1:{port}/agents/weather-agent/message:stream",
-                    headers={"A2A-Version": "1.0"},
-                    json=hello_message_body(),
-                ) as response,
-            ):
-                async for _ in response.aiter_bytes():
-                    connection_ready.set()
+        async with held_open(connect):
+            stop_elapsed = await elapsed(server.stop())
 
-    holder = asyncio.create_task(hold_connection_open())
-    try:
-        await asyncio.wait_for(connection_ready.wait(), timeout=5.0)
-
-        started_at = asyncio.get_running_loop().time()
-        await server.stop()
-        elapsed = asyncio.get_running_loop().time() - started_at
-
-        assert elapsed < SERVER_STOP_TIMEOUT_S + 5.0, (
-            f"stop() took {elapsed:.1f}s -- graceful shutdown is not "
+        assert stop_elapsed < SERVER_STOP_TIMEOUT_S + 5.0, (
+            f"stop() took {stop_elapsed:.1f}s -- graceful shutdown is not "
             "bounded by SERVER_STOP_TIMEOUT_S"
         )
-    finally:
-        holder.cancel()
-        with suppress(asyncio.CancelledError):
-            await holder

--- a/tests/integrations/a2a/gateway/test_server.py
+++ b/tests/integrations/a2a/gateway/test_server.py
@@ -16,9 +16,7 @@ from a2a.helpers import new_task_from_user_message
 from a2a.types import TaskState, TaskStatus, TaskStatusUpdateEvent
 from a2a.utils.constants import PROTOCOL_VERSION_0_3
 from httpx import ASGITransport
-from sse_starlette.sse import AppStatus
 
-import band.integrations.a2a.gateway.server as gateway_server_module
 from band.integrations.a2a.gateway.server import SERVER_STOP_TIMEOUT_S, GatewayServer
 from tests.integrations.a2a.gateway.helpers import make_peer
 
@@ -418,56 +416,11 @@ async def test_start_returns_only_once_the_server_is_listening() -> None:
 
     await server.start()
     try:
-        assert server._uvicorn.started
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"http://127.0.0.1:{server.bound_port}/peers")
+        assert response.status_code == 200
     finally:
         await server.stop()
-
-
-async def test_start_cleans_up_when_startup_wait_fails(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A failed startup wait must still tell uvicorn to exit and clear
-    server state, not leave a listening socket and stray task behind."""
-
-    async def failing_wait_until_started(*args: object, **kwargs: object) -> None:
-        raise TimeoutError("simulated startup failure")
-
-    monkeypatch.setattr(
-        gateway_server_module, "wait_until_started", failing_wait_until_started
-    )
-
-    peer = make_peer("uuid-weather", "Weather Agent", "Gets weather info")
-    server = GatewayServer(
-        peers={"weather-agent": peer},
-        gateway_url="http://localhost:0",
-        port=0,
-        executor_factory=lambda _slug: FakeExecutor(),
-    )
-
-    with pytest.raises(TimeoutError, match="simulated startup failure"):
-        await server.start()
-
-    assert server._uvicorn is None
-    assert server._server_task is None
-
-
-def test_disables_sse_starlette_automatic_graceful_drain() -> None:
-    """AppStatus.should_exit is process-global with no notion of "which
-    server" -- a GatewayServer.stop() sets its own uvicorn.Server.should_exit
-    directly, and sse_starlette's shutdown watcher promotes that to the
-    global flag, cancelling every later GatewayServer's SSE streams in the
-    same process. Importing this module must disable that."""
-    assert AppStatus.enable_automatic_graceful_drain is False
-
-    original_should_exit = AppStatus.should_exit
-    original_handler = AppStatus.original_handler
-    AppStatus.original_handler = None
-    try:
-        AppStatus.handle_exit(0, None)
-        assert AppStatus.should_exit is False
-    finally:
-        AppStatus.should_exit = original_should_exit
-        AppStatus.original_handler = original_handler
 
 
 class DelayedTwoStepExecutor(AgentExecutor):
@@ -512,7 +465,7 @@ async def test_a_second_server_is_not_poisoned_by_a_prior_servers_shutdown() -> 
         executor_factory=lambda _slug: FakeExecutor(),
     )
     await first.start()
-    port1 = first._uvicorn.servers[0].sockets[0].getsockname()[1]
+    port1 = first.bound_port
     async with httpx.AsyncClient(timeout=None) as client:
         async with client.stream(
             "POST",
@@ -532,7 +485,7 @@ async def test_a_second_server_is_not_poisoned_by_a_prior_servers_shutdown() -> 
     )
     await second.start()
     try:
-        port2 = second._uvicorn.servers[0].sockets[0].getsockname()[1]
+        port2 = second.bound_port
         events: list[str] = []
         async with httpx.AsyncClient(timeout=None) as client:
             async with client.stream(
@@ -591,7 +544,7 @@ async def test_stop_returns_promptly_with_a_still_open_message_stream() -> None:
         executor_factory=lambda _slug: NeverFinishingExecutor(),
     )
     await server.start()
-    port = server._uvicorn.servers[0].sockets[0].getsockname()[1]
+    port = server.bound_port
 
     connection_ready = asyncio.Event()
 

--- a/tests/integrations/a2a/gateway/test_server.py
+++ b/tests/integrations/a2a/gateway/test_server.py
@@ -410,6 +410,25 @@ async def test_v03_jsonrpc_stream_accepts_legacy_payload(
     assert "text/event-stream" in response.headers["content-type"]
 
 
+async def test_start_returns_only_once_the_server_is_listening() -> None:
+    """A caller dialing in right after ``on_started()`` returns (e.g. a real
+    A2A client, or one of the E2E smokes) must not race a socket that isn't
+    accepting connections yet."""
+    peer = make_peer("uuid-weather", "Weather Agent", "Gets weather info")
+    server = GatewayServer(
+        peers={"weather-agent": peer},
+        gateway_url="http://localhost:0",
+        port=0,
+        executor_factory=lambda _slug: FakeExecutor(),
+    )
+
+    await server.start()
+    try:
+        assert server._uvicorn.started
+    finally:
+        await server.stop()
+
+
 class NeverFinishingExecutor(AgentExecutor):
     """Enqueues one event, then never returns -- holding the SSE response
     open indefinitely, the way a real long-running agent task would."""
@@ -451,13 +470,6 @@ async def test_stop_returns_promptly_with_a_still_open_message_stream() -> None:
         executor_factory=lambda _slug: NeverFinishingExecutor(),
     )
     await server.start()
-    # start() doesn't wait for uvicorn's own startup phase to finish -- it
-    # only schedules serve() as a background task. Poll for it directly
-    # since GatewayServer exposes no readiness signal of its own.
-    for _ in range(50):
-        if server._uvicorn.started:
-            break
-        await asyncio.sleep(0.05)
     port = server._uvicorn.servers[0].sockets[0].getsockname()[1]
 
     connection_ready = asyncio.Event()

--- a/tests/integrations/a2a/gateway/test_server.py
+++ b/tests/integrations/a2a/gateway/test_server.py
@@ -182,6 +182,79 @@ async def test_jsonrpc_method_errors_are_upstream_owned(
     assert response.json()["error"]["code"] == -32601
 
 
+async def test_malformed_json_body_falls_through_to_upstream_dispatch(
+    gateway_client: httpx.AsyncClient,
+) -> None:
+    """A body ``request.json()`` can't parse degrades ``method`` to ``None``,
+    which skips the closed-method guard entirely -- the upstream dispatcher
+    owns reporting the parse error, same as any other non-blocked method."""
+    response = await gateway_client.post(
+        "/agents/weather-agent",
+        headers={"A2A-Version": "1.0", "Content-Type": "application/json"},
+        content=b"{not valid json",
+    )
+
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == -32700
+
+
+async def test_non_scalar_request_id_is_normalized_to_null(
+    gateway_client: httpx.AsyncClient,
+) -> None:
+    response = await gateway_client.post(
+        "/agents/weather-agent",
+        headers={"A2A-Version": "1.0"},
+        json={
+            "jsonrpc": "2.0",
+            "id": [1, 2, 3],
+            "method": "ListTasks",
+            "params": {},
+        },
+    )
+
+    body = response.json()
+    assert body["id"] is None, "a non-str/int id must not be echoed back verbatim"
+    assert body["error"]["code"] == -32601
+
+
+async def test_send_streaming_message_runs_through_official_handler(
+    gateway_client: httpx.AsyncClient,
+) -> None:
+    response = await gateway_client.post(
+        "/agents/weather-agent",
+        headers={"A2A-Version": "1.0"},
+        json={
+            "jsonrpc": "2.0",
+            "id": "request-1",
+            "method": "SendStreamingMessage",
+            "params": {
+                "message": {
+                    "role": "ROLE_USER",
+                    "messageId": "message-1",
+                    "parts": [{"text": "Hello"}],
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert "text/event-stream" in response.headers["content-type"]
+
+
+@pytest.mark.parametrize("method", ["GetTask", "CancelTask"])
+async def test_task_methods_without_id_are_rejected_by_upstream_handler(
+    gateway_client: httpx.AsyncClient, method: str
+) -> None:
+    response = await gateway_client.post(
+        "/agents/weather-agent",
+        headers={"A2A-Version": "1.0"},
+        json={"jsonrpc": "2.0", "id": "request-1", "method": method, "params": {}},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == -32602
+
+
 async def test_jsonrpc_send_runs_through_official_handler_and_executor(
     gateway_client: httpx.AsyncClient,
 ) -> None:

--- a/tests/integrations/a2a/gateway/test_server.py
+++ b/tests/integrations/a2a/gateway/test_server.py
@@ -16,15 +16,8 @@ from a2a.helpers import new_task_from_user_message
 from a2a.types import TaskState, TaskStatus, TaskStatusUpdateEvent
 from a2a.utils.constants import PROTOCOL_VERSION_0_3
 from httpx import ASGITransport
+from sse_starlette.sse import AppStatus
 
-# Side effect, not used directly: importing this module disables
-# sse_starlette's automatic graceful drain process-wide (see its own
-# AppStatus.disable_automatic_graceful_drain() call) -- the exact real-world
-# coexistence (an ACP/opencode backend in the same process as this gateway)
-# that test_stop_returns_promptly_with_a_still_open_message_stream guards
-# against. Imported explicitly so the test is deterministic regardless of
-# whether some other test file happened to import it first.
-import band.integrations.mcp.local_server  # noqa: F401
 from band.integrations.a2a.gateway.server import SERVER_STOP_TIMEOUT_S, GatewayServer
 from tests.integrations.a2a.gateway.helpers import make_peer
 
@@ -429,6 +422,108 @@ async def test_start_returns_only_once_the_server_is_listening() -> None:
         await server.stop()
 
 
+def test_disables_sse_starlette_automatic_graceful_drain() -> None:
+    """AppStatus.should_exit is process-global with no notion of "which
+    server" -- a GatewayServer.stop() sets its own uvicorn.Server.should_exit
+    directly, and sse_starlette's shutdown watcher promotes that to the
+    global flag, cancelling every later GatewayServer's SSE streams in the
+    same process. Importing this module must disable that."""
+    assert AppStatus.enable_automatic_graceful_drain is False
+
+    original_should_exit = AppStatus.should_exit
+    original_handler = AppStatus.original_handler
+    AppStatus.original_handler = None
+    try:
+        AppStatus.handle_exit(0, None)
+        assert AppStatus.should_exit is False
+    finally:
+        AppStatus.should_exit = original_should_exit
+        AppStatus.original_handler = original_handler
+
+
+class DelayedTwoStepExecutor(AgentExecutor):
+    """Task, then a working update, then (after a pause) completion -- three
+    distinct SSE events, so a stream cut short is distinguishable from a
+    healthy one."""
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        if context.message is None:
+            raise ValueError("A2A request is missing its message")
+        task = new_task_from_user_message(context.message)
+        await event_queue.enqueue_event(task)
+        await event_queue.enqueue_event(
+            TaskStatusUpdateEvent(
+                task_id=task.id,
+                context_id=task.context_id,
+                status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+            )
+        )
+        await asyncio.sleep(0.3)
+        await event_queue.enqueue_event(
+            TaskStatusUpdateEvent(
+                task_id=task.id,
+                context_id=task.context_id,
+                status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+            )
+        )
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        raise NotImplementedError
+
+
+async def test_a_second_server_is_not_poisoned_by_a_prior_servers_shutdown() -> None:
+    """Regression, reproducing the real failure directly rather than just
+    the flag from test_disables_sse_starlette_automatic_graceful_drain: a
+    second GatewayServer's live stream, opened only after a first one has
+    stopped in the same process, must still deliver every event."""
+    first = GatewayServer(
+        peers={"weather-agent": make_peer("uuid-weather", "Weather Agent", "")},
+        gateway_url="http://localhost:0",
+        port=0,
+        executor_factory=lambda _slug: FakeExecutor(),
+    )
+    await first.start()
+    port1 = first._uvicorn.servers[0].sockets[0].getsockname()[1]
+    async with httpx.AsyncClient(timeout=None) as client:
+        async with client.stream(
+            "POST",
+            f"http://127.0.0.1:{port1}/agents/weather-agent/message:stream",
+            headers={"A2A-Version": "1.0"},
+            json=hello_message_body(),
+        ) as response:
+            async for _ in response.aiter_bytes():
+                pass
+    await first.stop()
+
+    second = GatewayServer(
+        peers={"other-agent": make_peer("uuid-other", "Other Agent", "")},
+        gateway_url="http://localhost:0",
+        port=0,
+        executor_factory=lambda _slug: DelayedTwoStepExecutor(),
+    )
+    await second.start()
+    try:
+        port2 = second._uvicorn.servers[0].sockets[0].getsockname()[1]
+        events: list[str] = []
+        async with httpx.AsyncClient(timeout=None) as client:
+            async with client.stream(
+                "POST",
+                f"http://127.0.0.1:{port2}/agents/other-agent/message:stream",
+                headers={"A2A-Version": "1.0"},
+                json=hello_message_body(),
+            ) as response:
+                async for line in response.aiter_lines():
+                    if line.startswith("data:"):
+                        events.append(line)
+
+        assert len(events) >= 3, (
+            f"got {len(events)} events, expected 3 (task, working, completed) -- "
+            "the second server's stream was cut short by the first server's shutdown"
+        )
+    finally:
+        await second.stop()
+
+
 class NeverFinishingExecutor(AgentExecutor):
     """Enqueues one event, then never returns -- holding the SSE response
     open indefinitely, the way a real long-running agent task would."""
@@ -449,13 +544,10 @@ class NeverFinishingExecutor(AgentExecutor):
 
 @pytest.mark.timeout(SERVER_STOP_TIMEOUT_S + 15.0)
 async def test_stop_returns_promptly_with_a_still_open_message_stream() -> None:
-    """Regression: sse_starlette's cooperative shutdown drain is a process-
-    global switch that band.integrations.mcp.local_server permanently
-    disables the moment it's imported anywhere in the process -- a real
-    coexistence scenario (an ACP/opencode backend sharing the process with
-    this gateway). A live message:stream connection then has no other way
-    to end on its own, so stop() must bound its wait via
-    timeout_graceful_shutdown instead of hanging forever.
+    """Regression: gateway/server.py disables sse_starlette's cooperative
+    shutdown drain, so a live message:stream connection has no other way to
+    end on its own -- stop() must bound its wait via timeout_graceful_shutdown
+    instead of hanging forever.
 
     Measures wall-clock time around a bare ``await server.stop()`` (no
     wrapping ``asyncio.wait_for``, which would cancel ``stop()`` from the

--- a/tests/integrations/a2a/gateway/test_server.py
+++ b/tests/integrations/a2a/gateway/test_server.py
@@ -448,10 +448,9 @@ class DelayedTwoStepExecutor(AgentExecutor):
 
 
 async def test_a_second_server_is_not_poisoned_by_a_prior_servers_shutdown() -> None:
-    """Regression, reproducing the real failure directly rather than just
-    the flag from test_disables_sse_starlette_automatic_graceful_drain: a
-    second GatewayServer's live stream, opened only after a first one has
-    stopped in the same process, must still deliver every event."""
+    """Regression: a second GatewayServer's live stream, opened only after a
+    first one has stopped in the same process, must still deliver every
+    event."""
     async with running(build_server(port=0)) as first:
         port1 = first.bound_port
         async with httpx.AsyncClient(timeout=None) as client:
@@ -510,15 +509,12 @@ class NeverFinishingExecutor(AgentExecutor):
 
 @pytest.mark.timeout(SERVER_STOP_TIMEOUT_S + 15.0)
 async def test_stop_returns_promptly_with_a_still_open_message_stream() -> None:
-    """Regression: gateway/server.py disables sse_starlette's cooperative
-    shutdown drain, so a live message:stream connection has no other way to
-    end on its own -- stop() must bound its wait via timeout_graceful_shutdown
-    instead of hanging forever.
+    """Regression: disabling sse_starlette's drain means a live
+    message:stream connection has no other way to end -- stop() must bound
+    its wait via timeout_graceful_shutdown instead of hanging forever.
 
-    Measures wall-clock time around a bare ``await server.stop()`` (no
-    wrapping ``asyncio.wait_for``, which would cancel ``stop()`` from the
-    outside and mask a real hang as a false pass) -- same rationale as
-    LocalMCPServer's own equivalent regression test.
+    Measures wall-clock time around a bare ``server.stop()`` (wrapping it
+    in ``asyncio.wait_for`` would cancel it externally and mask a real hang).
     """
     server = build_server(
         port=0, executor_factory=lambda _slug: NeverFinishingExecutor()

--- a/tests/integrations/a2a/gateway/test_server.py
+++ b/tests/integrations/a2a/gateway/test_server.py
@@ -18,6 +18,7 @@ from a2a.utils.constants import PROTOCOL_VERSION_0_3
 from httpx import ASGITransport
 from sse_starlette.sse import AppStatus
 
+import band.integrations.a2a.gateway.server as gateway_server_module
 from band.integrations.a2a.gateway.server import SERVER_STOP_TIMEOUT_S, GatewayServer
 from tests.integrations.a2a.gateway.helpers import make_peer
 
@@ -420,6 +421,34 @@ async def test_start_returns_only_once_the_server_is_listening() -> None:
         assert server._uvicorn.started
     finally:
         await server.stop()
+
+
+async def test_start_cleans_up_when_startup_wait_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed startup wait must still tell uvicorn to exit and clear
+    server state, not leave a listening socket and stray task behind."""
+
+    async def failing_wait_until_started(*args: object, **kwargs: object) -> None:
+        raise TimeoutError("simulated startup failure")
+
+    monkeypatch.setattr(
+        gateway_server_module, "wait_until_started", failing_wait_until_started
+    )
+
+    peer = make_peer("uuid-weather", "Weather Agent", "Gets weather info")
+    server = GatewayServer(
+        peers={"weather-agent": peer},
+        gateway_url="http://localhost:0",
+        port=0,
+        executor_factory=lambda _slug: FakeExecutor(),
+    )
+
+    with pytest.raises(TimeoutError, match="simulated startup failure"):
+        await server.start()
+
+    assert server._uvicorn is None
+    assert server._server_task is None
 
 
 def test_disables_sse_starlette_automatic_graceful_drain() -> None:

--- a/tests/integrations/a2a/test_adapter.py
+++ b/tests/integrations/a2a/test_adapter.py
@@ -22,6 +22,7 @@ from a2a.types import (
 
 from band.core.types import PlatformMessage
 from band.integrations.a2a import A2AAdapter, A2AAuth, A2ASessionState
+from band.integrations.a2a.adapter import _SSE_READ_TIMEOUT_S
 from band.testing import FakeAgentTools
 
 
@@ -143,10 +144,12 @@ class TestA2AAdapterStartup:
         await adapter.cleanup_all()
 
     @pytest.mark.asyncio
-    async def test_owned_http_client_has_no_read_timeout(self) -> None:
+    async def test_owned_http_client_has_a_generous_bounded_read_timeout(self) -> None:
         """A real remote turn (a live LLM call, a tool loop) routinely leaves
         several seconds of silence between SSE events -- httpx's 5s default
-        read timeout would misreport that as a dead connection."""
+        read timeout would misreport that as a dead connection. The bound
+        must still be finite, though, so a peer that hangs after accepting
+        the connection fails the turn instead of blocking the room forever."""
         adapter = A2AAdapter(remote_url="http://localhost:10000")
         client = MagicMock()
 
@@ -157,7 +160,7 @@ class TestA2AAdapterStartup:
             await adapter.on_started("Agent", "Description")
 
         assert adapter._http_client is not None
-        assert adapter._http_client.timeout.read is None
+        assert adapter._http_client.timeout.read == _SSE_READ_TIMEOUT_S
 
         client.close = AsyncMock()
         await adapter.cleanup_all()

--- a/tests/integrations/a2a/test_adapter.py
+++ b/tests/integrations/a2a/test_adapter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -100,6 +102,25 @@ async def stream(*events: StreamResponse):
         yield event
 
 
+@asynccontextmanager
+async def started_adapter(
+    adapter: A2AAdapter,
+) -> AsyncIterator[tuple[MagicMock, MagicMock]]:
+    """Start ``adapter`` against a patched ``ClientFactory`` and clean it up
+    afterward -- yields ``(client, factory_type)`` so a test states only its
+    own setup and assertions, not the patch/cleanup dance."""
+    client = MagicMock()
+    with patch("band.integrations.a2a.adapter.ClientFactory") as factory_type:
+        factory = factory_type.return_value
+        factory.create_from_url = AsyncMock(return_value=client)
+        await adapter.on_started("Agent", "Description")
+    try:
+        yield client, factory_type
+    finally:
+        client.close = AsyncMock()
+        await adapter.cleanup_all()
+
+
 class TestA2AAuth:
     def test_to_headers_combines_authentication_methods(self) -> None:
         auth = A2AAuth(
@@ -122,26 +143,18 @@ class TestA2AAdapterStartup:
             remote_url="http://localhost:10000",
             auth=A2AAuth(api_key="key"),
         )
-        client = MagicMock()
 
-        with patch("band.integrations.a2a.adapter.ClientFactory") as factory_type:
-            factory = factory_type.return_value
-            factory.create_from_url = AsyncMock(return_value=client)
-
-            await adapter.on_started("Agent", "Description")
-
-        assert adapter._client is client
-        config = factory_type.call_args.args[0]
-        assert config.streaming is True
-        assert adapter._http_client is not None
-        assert adapter._http_client.headers["X-API-Key"] == "key"
-        assert config.httpx_client is adapter._http_client, (
-            "the factory must receive the adapter's own client — this identity "
-            "is what carries auth to card resolution and every A2A request"
-        )
-
-        client.close = AsyncMock()
-        await adapter.cleanup_all()
+        async with started_adapter(adapter) as (client, factory_type):
+            assert adapter._client is client
+            config = factory_type.call_args.args[0]
+            assert config.streaming is True
+            assert adapter._http_client is not None
+            assert adapter._http_client.headers["X-API-Key"] == "key"
+            assert config.httpx_client is adapter._http_client, (
+                "the factory must receive the adapter's own client — this "
+                "identity is what carries auth to card resolution and every "
+                "A2A request"
+            )
 
     @pytest.mark.asyncio
     async def test_owned_http_client_has_a_generous_bounded_read_timeout(self) -> None:
@@ -151,19 +164,10 @@ class TestA2AAdapterStartup:
         must still be finite, though, so a peer that hangs after accepting
         the connection fails the turn instead of blocking the room forever."""
         adapter = A2AAdapter(remote_url="http://localhost:10000")
-        client = MagicMock()
 
-        with patch("band.integrations.a2a.adapter.ClientFactory") as factory_type:
-            factory = factory_type.return_value
-            factory.create_from_url = AsyncMock(return_value=client)
-
-            await adapter.on_started("Agent", "Description")
-
-        assert adapter._http_client is not None
-        assert adapter._http_client.timeout.read == _SSE_READ_TIMEOUT_S
-
-        client.close = AsyncMock()
-        await adapter.cleanup_all()
+        async with started_adapter(adapter):
+            assert adapter._http_client is not None
+            assert adapter._http_client.timeout.read == _SSE_READ_TIMEOUT_S
 
 
 class TestA2AAdapterMessageFlow:

--- a/tests/integrations/a2a/test_adapter.py
+++ b/tests/integrations/a2a/test_adapter.py
@@ -284,6 +284,32 @@ class TestA2AAdapterMessageFlow:
         assert adapter._task_senders == {}
 
     @pytest.mark.asyncio
+    async def test_auth_required_task_is_posted_as_error_event(
+        self, adapter: A2AAdapter
+    ) -> None:
+        tools = FakeAgentTools()
+
+        await adapter._handle_event(
+            task_event(
+                make_task(
+                    TaskState.TASK_STATE_AUTH_REQUIRED,
+                    status_message="Please authenticate",
+                )
+            ),
+            tools,
+            "room-123",
+            "user-456",
+            "Test User",
+        )
+
+        error_events = [
+            event for event in tools.events_sent if event["message_type"] == "error"
+        ]
+        assert error_events, "an auth-required task must produce an error event"
+        assert error_events[-1]["content"] == "Please authenticate"
+        assert error_events[-1]["metadata"]["a2a_state"] == "TASK_STATE_AUTH_REQUIRED"
+
+    @pytest.mark.asyncio
     async def test_input_required_is_forwarded_and_persisted(
         self, adapter: A2AAdapter
     ) -> None:
@@ -438,6 +464,28 @@ class TestA2AAdapterShutdown:
         await adapter.cleanup_all()
 
         assert http_client.is_closed, "owned httpx client must be closed"
+        assert adapter._client is None
+        assert adapter._http_client is None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_all_closes_http_transport_even_if_client_close_fails(
+        self,
+    ) -> None:
+        """A broken remote client must not leak the owned httpx transport."""
+        adapter = A2AAdapter(remote_url="http://localhost:10000")
+        adapter._client = MagicMock()
+        adapter._client.close = AsyncMock(
+            side_effect=RuntimeError("client close failed")
+        )
+        adapter._http_client = httpx.AsyncClient()
+        http_client = adapter._http_client
+
+        with pytest.raises(RuntimeError, match="client close failed"):
+            await adapter.cleanup_all()
+
+        assert http_client.is_closed, (
+            "http transport must close even if client.close() raises"
+        )
         assert adapter._client is None
         assert adapter._http_client is None
 

--- a/tests/integrations/a2a/test_adapter.py
+++ b/tests/integrations/a2a/test_adapter.py
@@ -142,6 +142,26 @@ class TestA2AAdapterStartup:
         client.close = AsyncMock()
         await adapter.cleanup_all()
 
+    @pytest.mark.asyncio
+    async def test_owned_http_client_has_no_read_timeout(self) -> None:
+        """A real remote turn (a live LLM call, a tool loop) routinely leaves
+        several seconds of silence between SSE events -- httpx's 5s default
+        read timeout would misreport that as a dead connection."""
+        adapter = A2AAdapter(remote_url="http://localhost:10000")
+        client = MagicMock()
+
+        with patch("band.integrations.a2a.adapter.ClientFactory") as factory_type:
+            factory = factory_type.return_value
+            factory.create_from_url = AsyncMock(return_value=client)
+
+            await adapter.on_started("Agent", "Description")
+
+        assert adapter._http_client is not None
+        assert adapter._http_client.timeout.read is None
+
+        client.close = AsyncMock()
+        await adapter.cleanup_all()
+
 
 class TestA2AAdapterMessageFlow:
     @pytest.fixture

--- a/tests/integrations/a2a/test_protocol.py
+++ b/tests/integrations/a2a/test_protocol.py
@@ -78,6 +78,38 @@ def test_appended_artifact_chunks_are_combined_before_response_extraction() -> N
     assert task_response_text(task) == "Part one. \nPart two."
 
 
+def test_artifact_overwrite_replaces_existing_artifact_content() -> None:
+    first = StreamResponse(
+        artifact_update={
+            "task_id": "task-123",
+            "context_id": "context-123",
+            "artifact": Artifact(
+                artifact_id="artifact-123",
+                parts=[Part(text="stale content")],
+            ),
+            "append": False,
+        }
+    )
+    overwrite = StreamResponse(
+        artifact_update={
+            "task_id": "task-123",
+            "context_id": "context-123",
+            "artifact": Artifact(
+                artifact_id="artifact-123",
+                parts=[Part(text="fresh content")],
+            ),
+            "append": False,
+        }
+    )
+
+    task = apply_task_stream_event(None, first)
+    task = apply_task_stream_event(task, overwrite)
+
+    assert task is not None
+    assert len(task.artifacts) == 1
+    assert task_response_text(task) == "fresh content"
+
+
 def test_task_stream_snapshot_does_not_alias_the_event() -> None:
     event = StreamResponse(
         task=Task(

--- a/tests/integrations/mcp/test_local_server.py
+++ b/tests/integrations/mcp/test_local_server.py
@@ -15,7 +15,6 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import CallToolResult, TextContent
 from pydantic import BaseModel
-from sse_starlette.sse import AppStatus
 
 from band.core.exceptions import BandToolError
 from band.integrations.mcp.engine import (
@@ -194,31 +193,6 @@ class TestLocalMcpServer:
             host="0.0.0.0",
         )
         assert server._host == "0.0.0.0"
-
-    def test_disables_sse_starlette_automatic_graceful_drain(self) -> None:
-        """Regression, traced live on Windows CI: sse_starlette's
-        AppStatus.should_exit is a bare process-global class attribute with
-        no notion of "which server" -- ANY OTHER uvicorn.Server's signal
-        handler firing handle_exit() anywhere in the process (not just
-        ours) used to latch it, closing every subsequent SSE response --
-        including a fresh, healthy LocalMCPServer's that never touched that
-        other server -- right after its headers. Importing local_server
-        must disable the automatic drain so handle_exit() (the real
-        2-argument signal-handler call, not our own) becomes a no-op for
-        this flag; original_handler is swapped out for the duration since
-        it expects a bound Server instance, not this direct call.
-        """
-        assert AppStatus.enable_automatic_graceful_drain is False
-
-        original_should_exit = AppStatus.should_exit
-        original_handler = AppStatus.original_handler
-        AppStatus.original_handler = None
-        try:
-            AppStatus.handle_exit(0, None)
-            assert AppStatus.should_exit is False
-        finally:
-            AppStatus.should_exit = original_should_exit
-            AppStatus.original_handler = original_handler
 
     @pytest.mark.asyncio
     async def test_serves_sse_tools_on_localhost(self) -> None:

--- a/tests/integrations/mcp/test_local_server.py
+++ b/tests/integrations/mcp/test_local_server.py
@@ -219,19 +219,16 @@ class TestLocalMcpServer:
     async def test_stop_returns_promptly_with_a_still_open_sse_connection(
         self,
     ) -> None:
-        """Regression: an MCP client (e.g. OpenCode) holds its `/sse` GET open
-        for the life of its own session and may never close it after we ask
-        it to deregister. uvicorn's own graceful-shutdown wait is unbounded by
-        default, so ``stop()`` used to hang forever waiting for a connection
-        that never closes on its own; it must now force it closed instead.
+        """Regression: an MCP client (e.g. OpenCode) holds its `/sse` GET
+        open for the life of its session and may never close it -- stop()
+        must force it closed rather than hang on uvicorn's unbounded default
+        graceful-shutdown wait.
 
-        Measures wall-clock time around a bare ``await server.stop()`` (no
-        wrapping ``asyncio.wait_for``, which would cancel ``stop()`` from the
-        outside and let its own ``except CancelledError`` swallow that
-        cancellation -- masking a real hang as a false pass). The
-        ``pytest.mark.timeout`` above is the sole backstop, matching how the
-        live baseline run actually surfaced this hang (pytest-timeout, not an
-        internal asyncio timeout).
+        Measures wall-clock time around a bare ``server.stop()`` (wrapping
+        it in ``asyncio.wait_for`` would cancel it externally and mask a
+        real hang). ``pytest.mark.timeout`` above is the backstop, matching
+        how this hang is actually caught (pytest-timeout, not an asyncio
+        timeout).
         """
         server = LocalMCPServer(
             name="test-local-mcp-stop",
@@ -334,11 +331,10 @@ class TestLocalMcpServer:
     async def test_start_forwards_real_host_to_build_engine(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Regression (found live via the Letta lane): build_engine must be
-        told the real bind host, or FastMCP wrongly assumes loopback and
-        locks DNS-rebinding protection to 127.0.0.1/localhost only -- even
-        for a server explicitly bound to a non-loopback host for a Docker
-        callback (see LocalMCPServer's own class docstring)."""
+        """Regression: build_engine must be told the real bind host, or
+        FastMCP wrongly assumes loopback and locks DNS-rebinding protection
+        to 127.0.0.1/localhost only -- even for a non-loopback Docker-
+        callback bind (see LocalMCPServer's class docstring)."""
         import band.integrations.mcp.local_server as local_server_mod
 
         seen_hosts: list[str] = []

--- a/tests/integrations/mcp/test_local_server.py
+++ b/tests/integrations/mcp/test_local_server.py
@@ -31,6 +31,8 @@ from band.integrations.mcp.local_server import (
 from band.runtime.custom_tools import get_custom_tool_name
 from band.runtime.tools import AgentTools
 
+from tests.lifecycle import elapsed, held_open, running
+
 
 class EchoInput(BaseModel):
     """Echo text back to the caller."""
@@ -203,8 +205,7 @@ class TestLocalMcpServer:
             port_max=0,
         )
 
-        await server.start()
-        try:
+        async with running(server):
             assert server.url.startswith(f"http://{LOCAL_MCP_HOST}:")
 
             async with sse_client(server.url) as (read_stream, write_stream):
@@ -212,8 +213,6 @@ class TestLocalMcpServer:
                     await session.initialize()
                     await _session_lists_only_echo(session)
                     await _call_echo(session, "hello")
-        finally:
-            await server.stop()
 
     @pytest.mark.timeout(SERVER_STOP_TIMEOUT_S + 15.0)
     @pytest.mark.asyncio
@@ -240,34 +239,23 @@ class TestLocalMcpServer:
             port_min=0,
             port_max=0,
         )
-        await server.start()
+        async with running(server):
 
-        connection_ready = asyncio.Event()
+            async def connect(ready: asyncio.Event) -> None:
+                with suppress(Exception):
+                    async with sse_client(server.url) as (read_stream, write_stream):
+                        async with ClientSession(read_stream, write_stream) as session:
+                            await session.initialize()
+                            ready.set()
+                            await asyncio.sleep(60)  # never closes on its own
 
-        async def hold_connection_open() -> None:
-            with suppress(Exception):
-                async with sse_client(server.url) as (read_stream, write_stream):
-                    async with ClientSession(read_stream, write_stream) as session:
-                        await session.initialize()
-                        connection_ready.set()
-                        await asyncio.sleep(60)  # never closes on its own
+            async with held_open(connect):
+                stop_elapsed = await elapsed(server.stop())
 
-        holder = asyncio.create_task(hold_connection_open())
-        try:
-            await asyncio.wait_for(connection_ready.wait(), timeout=5.0)
-
-            started_at = asyncio.get_running_loop().time()
-            await server.stop()
-            elapsed = asyncio.get_running_loop().time() - started_at
-
-            assert elapsed < SERVER_STOP_TIMEOUT_S + 5.0, (
-                f"stop() took {elapsed:.1f}s -- graceful shutdown is not "
+            assert stop_elapsed < SERVER_STOP_TIMEOUT_S + 5.0, (
+                f"stop() took {stop_elapsed:.1f}s -- graceful shutdown is not "
                 "bounded by SERVER_STOP_TIMEOUT_S"
             )
-        finally:
-            holder.cancel()
-            with suppress(asyncio.CancelledError):
-                await holder
 
     # 30s default barely fits on GitHub Actions Python 3.12 runners — the
     # streamable-HTTP loopback initialization spends most of that on uvicorn
@@ -283,8 +271,7 @@ class TestLocalMcpServer:
             port_max=0,
         )
 
-        await server.start()
-        try:
+        async with running(server):
             assert server.http_url.startswith(f"http://{LOCAL_MCP_HOST}:")
 
             async with streamablehttp_client(server.http_url) as (
@@ -296,8 +283,6 @@ class TestLocalMcpServer:
                     await session.initialize()
                     await _session_lists_only_echo(session)
                     await _call_echo(session, "hello")
-        finally:
-            await server.stop()
 
     @pytest.mark.asyncio
     async def test_stop_cleans_up_state_even_if_serve_task_crashed(self) -> None:
@@ -387,10 +372,8 @@ class TestLocalMcpServer:
             port_min=0,
             port_max=0,
         )
-        try:
-            await server.start()
-        finally:
-            await server.stop()
+        async with running(server):
+            pass
 
         assert seen_hosts == ["0.0.0.0"]
 
@@ -471,8 +454,7 @@ class TestLocalMcpServer:
 
         await server.start()
         await server.stop()
-        await server.start()
-        try:
+        async with running(server):
             async with streamablehttp_client(server.http_url) as (
                 read_stream,
                 write_stream,
@@ -481,5 +463,3 @@ class TestLocalMcpServer:
                 async with ClientSession(read_stream, write_stream) as session:
                     await session.initialize()
                     await _call_echo(session, "hi")
-        finally:
-            await server.stop()

--- a/tests/integrations/test_uvicorn_server.py
+++ b/tests/integrations/test_uvicorn_server.py
@@ -1,8 +1,9 @@
-"""Behavior tests for the shared uvicorn startup wait.
+"""Behavior tests for the shared embedded-uvicorn-server lifecycle.
 
-``mcp.local_server`` and ``a2a.gateway.server`` each embed their own uvicorn
-server and both wait on this one helper before reporting started -- these
-tests live here, once, instead of being duplicated per caller.
+``mcp.local_server``, ``a2a.gateway.server``, and the A2A baseline test
+fixture each embed their own uvicorn server -- ``wait_until_started`` and
+``ManagedUvicornServer`` live here, once, instead of every caller
+re-deriving (and re-testing) the same startup/shutdown correctness.
 """
 
 from __future__ import annotations
@@ -10,14 +11,23 @@ from __future__ import annotations
 import asyncio
 from contextlib import suppress
 
+import httpx
 import pytest
+from sse_starlette.sse import AppStatus
 
-from band.integrations.uvicorn_server import wait_until_started
+from band.integrations.uvicorn_server import ManagedUvicornServer, wait_until_started
 
 
 class FakeUvicornServer:
     def __init__(self, *, started: bool = False) -> None:
         self.started = started
+
+
+async def _minimal_asgi_app(scope: dict, receive: object, send: object) -> None:
+    if scope["type"] != "http":
+        return
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"ok"})
 
 
 @pytest.mark.asyncio
@@ -62,6 +72,22 @@ async def test_surfaces_a_serve_task_failure_immediately() -> None:
 
 
 @pytest.mark.asyncio
+async def test_surfaces_a_clean_task_completion_that_never_started() -> None:
+    """A serve task that ends without ever setting ``started`` -- e.g. an
+    early shutdown signal, not a raised exception -- must be treated as
+    fatal immediately too; only distinguishing "done and raised" from "done"
+    would still busy-wait the full timeout on this path."""
+    server = FakeUvicornServer()
+    serve_task = asyncio.create_task(asyncio.sleep(0))
+
+    start = asyncio.get_running_loop().time()
+    with pytest.raises(RuntimeError, match="ended before ever starting"):
+        await wait_until_started(server, serve_task, timeout_s=30.0)
+
+    assert asyncio.get_running_loop().time() - start < 1.0
+
+
+@pytest.mark.asyncio
 async def test_times_out_if_the_server_never_reports_ready() -> None:
     server = FakeUvicornServer()
     serve_task = asyncio.create_task(asyncio.sleep(10))
@@ -72,3 +98,90 @@ async def test_times_out_if_the_server_never_reports_ready() -> None:
         serve_task.cancel()
         with suppress(asyncio.CancelledError):
             await serve_task
+
+
+@pytest.mark.asyncio
+async def test_managed_server_starts_and_bound_port_resolves_real_port() -> None:
+    server = ManagedUvicornServer(
+        _minimal_asgi_app,
+        host="127.0.0.1",
+        port=0,
+        start_timeout_s=5.0,
+        stop_timeout_s=5,
+    )
+    await server.start()
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"http://127.0.0.1:{server.bound_port}/")
+        assert response.status_code == 200
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_before_start_is_a_no_op() -> None:
+    server = ManagedUvicornServer(
+        _minimal_asgi_app,
+        host="127.0.0.1",
+        port=0,
+        start_timeout_s=5.0,
+        stop_timeout_s=5,
+    )
+    await server.stop()  # must not raise
+    with pytest.raises(RuntimeError, match="has not started"):
+        _ = server.bound_port
+
+
+@pytest.mark.asyncio
+async def test_start_cleans_up_when_the_startup_wait_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed/timed-out startup wait must still tell uvicorn to exit and
+    clear server state, not leave a listening socket and stray task behind."""
+    import band.integrations.uvicorn_server as uvicorn_server_module
+
+    async def failing_wait_until_started(*args: object, **kwargs: object) -> None:
+        raise TimeoutError("simulated startup failure")
+
+    monkeypatch.setattr(
+        uvicorn_server_module, "wait_until_started", failing_wait_until_started
+    )
+
+    server = ManagedUvicornServer(
+        _minimal_asgi_app,
+        host="127.0.0.1",
+        port=0,
+        start_timeout_s=5.0,
+        stop_timeout_s=5,
+    )
+
+    with pytest.raises(TimeoutError, match="simulated startup failure"):
+        await server.start()
+
+    with pytest.raises(RuntimeError, match="has not started"):
+        _ = server.bound_port
+
+
+def test_disables_sse_starlette_automatic_graceful_drain() -> None:
+    """Regression, traced live on Windows CI: sse_starlette's
+    AppStatus.should_exit is a bare process-global class attribute with no
+    notion of "which server" -- ANY OTHER uvicorn.Server's signal handler
+    firing handle_exit() anywhere in the process (not just ours) used to
+    latch it, closing every subsequent SSE response -- including a fresh,
+    healthy server's that never touched that other one -- right after its
+    headers. Importing this module must disable the automatic drain so
+    handle_exit() (the real 2-argument signal-handler call, not our own)
+    becomes a no-op for this flag; original_handler is swapped out for the
+    duration since it expects a bound Server instance, not this direct call.
+    """
+    assert AppStatus.enable_automatic_graceful_drain is False
+
+    original_should_exit = AppStatus.should_exit
+    original_handler = AppStatus.original_handler
+    AppStatus.original_handler = None
+    try:
+        AppStatus.handle_exit(0, None)
+        assert AppStatus.should_exit is False
+    finally:
+        AppStatus.should_exit = original_should_exit
+        AppStatus.original_handler = original_handler

--- a/tests/integrations/test_uvicorn_server.py
+++ b/tests/integrations/test_uvicorn_server.py
@@ -9,13 +9,14 @@ re-deriving (and re-testing) the same startup/shutdown correctness.
 from __future__ import annotations
 
 import asyncio
-from contextlib import suppress
 
 import httpx
 import pytest
 from sse_starlette.sse import AppStatus
 
 from band.integrations.uvicorn_server import ManagedUvicornServer, wait_until_started
+
+from tests.lifecycle import backgrounded, running
 
 
 class FakeUvicornServer:
@@ -33,22 +34,18 @@ async def _minimal_asgi_app(scope: dict, receive: object, send: object) -> None:
 @pytest.mark.asyncio
 async def test_returns_once_the_server_flips_ready() -> None:
     server = FakeUvicornServer()
-    serve_task = asyncio.create_task(asyncio.sleep(10))
 
     async def flip_ready_soon() -> None:
         await asyncio.sleep(0.1)
         server.started = True
 
-    flipper = asyncio.create_task(flip_ready_soon())
-    try:
+    async with (
+        backgrounded(asyncio.sleep(10)) as serve_task,
+        backgrounded(flip_ready_soon()),
+    ):
         await asyncio.wait_for(
             wait_until_started(server, serve_task, timeout_s=5.0), timeout=2.0
         )
-    finally:
-        for task in (serve_task, flipper):
-            task.cancel()
-            with suppress(asyncio.CancelledError):
-                await task
 
 
 @pytest.mark.asyncio
@@ -90,14 +87,9 @@ async def test_surfaces_a_clean_task_completion_that_never_started() -> None:
 @pytest.mark.asyncio
 async def test_times_out_if_the_server_never_reports_ready() -> None:
     server = FakeUvicornServer()
-    serve_task = asyncio.create_task(asyncio.sleep(10))
-    try:
+    async with backgrounded(asyncio.sleep(10)) as serve_task:
         with pytest.raises(TimeoutError):
             await wait_until_started(server, serve_task, timeout_s=0.2)
-    finally:
-        serve_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await serve_task
 
 
 @pytest.mark.asyncio
@@ -109,13 +101,10 @@ async def test_managed_server_starts_and_bound_port_resolves_real_port() -> None
         start_timeout_s=5.0,
         stop_timeout_s=5,
     )
-    await server.start()
-    try:
+    async with running(server):
         async with httpx.AsyncClient() as client:
             response = await client.get(f"http://127.0.0.1:{server.bound_port}/")
         assert response.status_code == 200
-    finally:
-        await server.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/integrations/test_uvicorn_server.py
+++ b/tests/integrations/test_uvicorn_server.py
@@ -1,0 +1,74 @@
+"""Behavior tests for the shared uvicorn startup wait.
+
+``mcp.local_server`` and ``a2a.gateway.server`` each embed their own uvicorn
+server and both wait on this one helper before reporting started -- these
+tests live here, once, instead of being duplicated per caller.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+
+import pytest
+
+from band.integrations.uvicorn_server import wait_until_started
+
+
+class FakeUvicornServer:
+    def __init__(self, *, started: bool = False) -> None:
+        self.started = started
+
+
+@pytest.mark.asyncio
+async def test_returns_once_the_server_flips_ready() -> None:
+    server = FakeUvicornServer()
+    serve_task = asyncio.create_task(asyncio.sleep(10))
+
+    async def flip_ready_soon() -> None:
+        await asyncio.sleep(0.1)
+        server.started = True
+
+    flipper = asyncio.create_task(flip_ready_soon())
+    try:
+        await asyncio.wait_for(
+            wait_until_started(server, serve_task, timeout_s=5.0), timeout=2.0
+        )
+    finally:
+        for task in (serve_task, flipper):
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+
+@pytest.mark.asyncio
+async def test_surfaces_a_serve_task_failure_immediately() -> None:
+    """A serve task that dies before the server ever reports ready (e.g. a
+    port already in use) must surface its real exception right away --
+    busy-waiting the full timeout and raising a generic one instead would
+    hide the actual cause."""
+
+    async def fail_immediately() -> None:
+        raise OSError("address already in use")
+
+    server = FakeUvicornServer()
+    serve_task = asyncio.create_task(fail_immediately())
+
+    start = asyncio.get_running_loop().time()
+    with pytest.raises(OSError, match="address already in use"):
+        await wait_until_started(server, serve_task, timeout_s=30.0)
+
+    assert asyncio.get_running_loop().time() - start < 1.0
+
+
+@pytest.mark.asyncio
+async def test_times_out_if_the_server_never_reports_ready() -> None:
+    server = FakeUvicornServer()
+    serve_task = asyncio.create_task(asyncio.sleep(10))
+    try:
+        with pytest.raises(TimeoutError):
+            await wait_until_started(server, serve_task, timeout_s=0.2)
+    finally:
+        serve_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await serve_task

--- a/tests/integrations/test_uvicorn_server.py
+++ b/tests/integrations/test_uvicorn_server.py
@@ -152,16 +152,12 @@ async def test_start_cleans_up_when_the_startup_wait_fails(
 
 
 def test_disables_sse_starlette_automatic_graceful_drain() -> None:
-    """Regression, traced live on Windows CI: sse_starlette's
-    AppStatus.should_exit is a bare process-global class attribute with no
-    notion of "which server" -- ANY OTHER uvicorn.Server's signal handler
-    firing handle_exit() anywhere in the process (not just ours) used to
-    latch it, closing every subsequent SSE response -- including a fresh,
-    healthy server's that never touched that other one -- right after its
-    headers. Importing this module must disable the automatic drain so
-    handle_exit() (the real 2-argument signal-handler call, not our own)
-    becomes a no-op for this flag; original_handler is swapped out for the
-    duration since it expects a bound Server instance, not this direct call.
+    """Regression: AppStatus.should_exit is a process-global with no notion
+    of "which server" -- any uvicorn.Server's handle_exit() latches it,
+    cutting off every other embedded server's SSE responses too. Importing
+    this module must disable the automatic drain so handle_exit() (the real
+    signal-handler call) is a no-op for this flag; original_handler is
+    swapped since it expects a bound Server, not this direct call.
     """
     assert AppStatus.enable_automatic_graceful_drain is False
 

--- a/tests/lifecycle.py
+++ b/tests/lifecycle.py
@@ -1,0 +1,60 @@
+"""Generic async lifecycle helpers for tests driving a background
+server or task end to end."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
+from contextlib import asynccontextmanager, suppress
+from typing import Any, Protocol
+
+
+class Startable(Protocol):
+    async def start(self) -> None: ...
+    async def stop(self) -> None: ...
+
+
+@asynccontextmanager
+async def running(server: Startable) -> AsyncIterator[Startable]:
+    """Start ``server``, yield it, and always stop it -- even on failure."""
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+@asynccontextmanager
+async def backgrounded(
+    coro: Coroutine[Any, Any, object],
+) -> AsyncIterator[asyncio.Task[object]]:
+    """Run ``coro`` as a background task for the block; always cancelled
+    and awaited afterward, even on failure."""
+    task = asyncio.create_task(coro)
+    try:
+        yield task
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+@asynccontextmanager
+async def held_open(
+    connect: Callable[[asyncio.Event], Awaitable[None]],
+) -> AsyncIterator[None]:
+    """Run ``connect`` in the background until it signals its ready event,
+    keeping whatever connection it opens alive for the block."""
+    ready = asyncio.Event()
+    async with backgrounded(connect(ready)):
+        await asyncio.wait_for(ready.wait(), timeout=5.0)
+        yield
+
+
+async def elapsed(coro: Awaitable[None]) -> float:
+    """Wall-clock seconds ``coro`` took -- for asserting a bounded-shutdown
+    guarantee without an external ``wait_for`` that would mask a real hang
+    by cancelling the call from outside."""
+    start = asyncio.get_running_loop().time()
+    await coro
+    return asyncio.get_running_loop().time() - start

--- a/tests/lifecycle.py
+++ b/tests/lifecycle.py
@@ -10,6 +10,10 @@ from typing import Any, Protocol
 
 
 class Startable(Protocol):
+    """``stop()`` must be a safe no-op if ``start()`` was never called or
+    failed partway -- ``running()`` below relies on that to clean up
+    unconditionally after a failed start."""
+
     async def start(self) -> None: ...
     async def stop(self) -> None: ...
 
@@ -17,8 +21,8 @@ class Startable(Protocol):
 @asynccontextmanager
 async def running(server: Startable) -> AsyncIterator[Startable]:
     """Start ``server``, yield it, and always stop it -- even on failure."""
-    await server.start()
     try:
+        await server.start()
         yield server
     finally:
         await server.stop()


### PR DESCRIPTION
## Summary

- Fills unit test gaps across the outbound `A2AAdapter` and `A2AGatewayAdapter`:
  peer-not-found resolution, peer-list pagination, artifact-overwrite
  reduction, `TASK_STATE_AUTH_REQUIRED` handling, and gateway JSON-RPC edge
  cases (malformed body, non-scalar request id, `SendStreamingMessage`,
  missing-id task methods, partial room-creation state).
- Adds three live baseline E2E smokes under
  `tests/e2e/baseline/smoke/adapters/` (A2A is a protocol bridge, not a
  matrix adapter, so these follow the `test_parlant.py` pattern):
  - `test_a2a.py` — `A2AAdapter` against a scripted, non-Band A2A
    counterparty fixture (`a2aServer.py`, built on a2a-sdk's own server
    primitives, no LLM key needed).
  - `test_a2a_gateway.py` — the official a2a-sdk reference client driving a
    live `A2AGatewayAdapter` that exposes a real Anthropic-backed Band peer.
  - `test_a2a_roundtrip.py` — the full Band-to-Band shape: Band Agent A
    (`A2AAdapter`) → live gateway → Band Agent B (Anthropic) → reply
    relayed back.
- Extracts `ManagedUvicornServer` (`band.integrations.uvicorn_server`), a
  shared "run an ASGI app on a background uvicorn server, wait for
  readiness, tear it down" lifecycle used by `GatewayServer`,
  `LocalMCPServer`, and the A2A test counterparty fixture.
- Adds `tests/lifecycle.py` (`running`, `backgrounded`, `held_open`,
  `elapsed`) so tests that drive a background server/task read as "given a
  running X, assert Y" instead of hand-rolled setup/teardown.

## Bugs fixed

- `A2AGatewayAdapter._execute_a2a`: a REST failure while posting to Band
  left the remote A2A caller stuck on a WORKING task forever, since no
  terminal FAILED event was ever published on that path. Now calls
  `pending.fail(...)` with a stable, non-sensitive message before
  re-raising (the raw exception is logged, not sent to the external caller).
- `A2AAdapter.cleanup_all`: an exception from the A2A client's `close()`
  skipped closing the owned httpx transport, leaking it on shutdown. Now
  closed in a `finally`.
- `A2AAdapter`'s owned httpx client left `read` unbounded, so a genuinely
  hung remote peer (accepts the connection, then never responds) could
  block a room forever — nothing in `band/runtime/execution.py` bounds an
  in-flight adapter cycle. Bounded to a generous-but-finite
  `_SSE_READ_TIMEOUT_S` (300s) instead.
- `GatewayServer.start()` returned as soon as `serve()` was scheduled,
  before uvicorn was actually listening, so a caller dialing in right after
  (a real A2A client, or the new smokes) could hit connection-refused.
  `start()` now waits for uvicorn's ready signal, bounded by a timeout, and
  unwinds the task/socket if that wait fails or times out.
- The A2A gateway leaked `sse_starlette`'s process-global shutdown flag
  across instances: `sse_starlette`'s background watcher promotes whichever
  `uvicorn.Server` owns the process's SIGTERM slot to a process-global
  switch, and `GatewayServer.stop()` sets `should_exit` directly (never via
  a real signal) — so once any gateway in a process stopped, every later
  gateway's SSE streams in that process got cancelled immediately.
  `band.integrations.mcp.local_server` had already hit and fixed the
  identical bug for itself; the gateway now disables the same
  process-global switch directly instead of depending on that other module
  happening to be imported first.
- `tests.lifecycle.running()` called `start()` before its `try`/`finally`,
  so a failing `start()` skipped `stop()` entirely; `start()` now runs
  inside the `try` so cleanup always happens.
- `GatewayServer.start()` and `A2AGatewayAdapter.on_started` logged the
  *requested* port instead of the OS-resolved `bound_port`, which is
  misleading for an ephemeral (`port=0`) bind.

## Test plan

- `uv run ruff check .` / `uv run ruff format .`
- `uv run pyrefly check` (0 errors)
- `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/ -q`
  (5294 passed, 123 skipped, 0 failed)
- `E2E_TESTS_ENABLED=true uv run pytest tests/e2e/baseline/smoke/adapters/test_a2a.py tests/e2e/baseline/smoke/adapters/test_a2a_gateway.py tests/e2e/baseline/smoke/adapters/test_a2a_roundtrip.py -v -s --no-cov`
  against a live platform + `ANTHROPIC_API_KEY` — all 4 tests pass
- Reverted the gateway shutdown-leak fix and reran to confirm the
  regression test actually catches it (`RemoteProtocolError: incomplete
  chunked read`), then restored the fix

Closes [INT-1357](https://linear.app/thenvoi/issue/INT-1357/a2a-adapter-add-live-e2e-coverage-fill-unit-test-gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnZ59Puicp5HazTjWGZd5A
