### PR TITLE
fix: isolate self-hosted Letta MCP tools

### DIFF
--- a/.github/scripts/setup-letta.sh
+++ b/.github/scripts/setup-letta.sh
@@ -20,11 +20,17 @@ LETTA_IMAGE="letta/letta:0.16.8@sha256:aa66c3eeee13d2dfc40c650d709b550237ee31bfc
 # handle, but forwarding the key lets LETTA_MODEL select an anthropic/* one.
 # The port binds loopback only — the tests run on the same host, and the test
 # server is unauthenticated.
+#
+# LETTA_NO_DEFAULT_ACTOR=true turns an unresolvable user_id header into a
+# loud error instead of a silent fallback to the default org/user — needed
+# so a broken org-scoping resolution in the adapter fails the live test
+# loudly instead of silently passing (see LettaAdapterConfig.org_scoped).
 docker run -d --name letta-server \
   -p 127.0.0.1:8283:8283 \
   --add-host=host.docker.internal:host-gateway \
   -e OPENAI_API_KEY="${OPENAI_API_KEY:?OPENAI_API_KEY is required for the Letta server}" \
   -e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
+  -e LETTA_NO_DEFAULT_ACTOR=true \
   "$LETTA_IMAGE"
 
 wait_healthy() {

--- a/docker/letta/runner.py
+++ b/docker/letta/runner.py
@@ -13,6 +13,14 @@ Environment variables:
     LETTA_MODEL                Model ID (e.g., openai/gpt-5.4)
     LETTA_MODE                 Operating mode: per_room or shared (default: per_room)
     LETTA_PROJECT              Letta Cloud project name (optional, ignored for self-hosted)
+    LETTA_ORG_SCOPED           Self-hosted only: provision a dedicated Letta org+user
+                               per instance so MCP tool storage never collides between
+                               instances sharing one server (default: auto-on for
+                               self-hosted, off for Cloud; set "false" to opt out).
+                               Recommend also setting LETTA_NO_DEFAULT_ACTOR=true on the
+                               Letta *server* process itself — it turns an unresolvable
+                               user_id into a loud error instead of a silent fallback
+                               to the default org, which would defeat this scoping.
     LETTA_EMBEDDING            Embedding model for agent create (required by Letta's
                                Docker server, e.g. openai/text-embedding-3-small)
     MCP_SERVER_URL             External band-mcp server URL. When set, the adapter
@@ -82,6 +90,7 @@ class LettaRunnerSettings(BaseSettings):
     letta_model: str | None = None  # LETTA_MODEL
     letta_mode: str | None = None  # LETTA_MODE
     letta_project: str | None = None  # LETTA_PROJECT
+    letta_org_scoped: str | None = None  # LETTA_ORG_SCOPED
     letta_embedding: str | None = None  # LETTA_EMBEDDING
     letta_mcp_advertised_host: str | None = None  # LETTA_MCP_ADVERTISED_HOST
     mcp_server_url: str | None = None  # MCP_SERVER_URL
@@ -181,6 +190,11 @@ async def main() -> None:
     mcp_server_url = resolve(settings.mcp_server_url, "mcp_server_url")
     mcp_server_name = resolve(settings.mcp_server_name, "mcp_server_name")
     letta_project = resolve(settings.letta_project, "letta_project")
+    # LettaAdapterConfig.org_scoped is bool | None (unlike the str | None
+    # fields resolve() otherwise threads through); pydantic's lenient
+    # str->bool coercion accepts this resolved string ("true"/"false") fine,
+    # but it's not a literal copy-paste of a str | None passthrough.
+    letta_org_scoped = resolve(settings.letta_org_scoped, "letta_org_scoped")
 
     # An explicit MCP_SERVER_URL selects an external band-mcp; otherwise the
     # adapter self-hosts its own Band MCP server in-process.
@@ -207,6 +221,7 @@ async def main() -> None:
             embedding=letta_embedding,
             mcp=mcp_config,
             project=letta_project,
+            org_scoped=letta_org_scoped,
             custom_section="",
             include_base_instructions=True,
         ),

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -27,8 +27,10 @@ from band.integrations.letta.config import (
     LettaAdapterConfig,
     LettaMCPConfig,
     MCPTransport,
+    is_letta_cloud_url,
 )
 from band.integrations.letta.mcp import LettaMCPBridge, bounded_teardown
+from band.integrations.letta.orgscope import resolve_org_scoped_headers
 from band.integrations.letta.prompts import render_tool_enforcement
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
@@ -200,7 +202,33 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
             client_kwargs["api_key"] = self.config.provider_key
         if self.config.project:
             client_kwargs["project"] = self.config.project
+
+        # Self-hosted Letta dedupes MCP-discovered Tool rows by
+        # (name, organization_id): with no user_id header, every instance
+        # resolves to the same default org, and a second instance's MCP
+        # registration silently re-points the first instance's tool row to
+        # its own server. Scoping each instance to its own org+user closes
+        # that collision. Cloud is never scoped (org_scoped=True against it
+        # is already rejected at config construction — see LettaAdapterConfig).
+        org_scoped = (
+            self.config.org_scoped
+            if self.config.org_scoped is not None
+            else not is_letta_cloud_url(self.config.base_url)
+        )
+        if org_scoped:
+            client_kwargs["default_headers"] = await resolve_org_scoped_headers(
+                base_url=self.config.base_url,
+                agent_name=agent_name,
+                bearer_token=self.config.provider_key,
+            )
         self._client = AsyncLetta(**client_kwargs)
+        if org_scoped:
+            # A fresh org has zero Tool rows; base tools (send_message, etc.)
+            # are seeded lazily only by this list call (GET /v1/tools/ with
+            # upsert_base_tools). Nothing else in this adapter's flow reaches
+            # it, so the first agents.create(include_base_tools=True) in a
+            # fresh org would otherwise raise before the agent exists.
+            await self._client.tools.list()
 
         # Fail loud at startup if the tool path cannot be wired — the adapter
         # is useless without it.

--- a/src/band/integrations/letta/config.py
+++ b/src/band/integrations/letta/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass
 from typing import Any, Literal
+from urllib.parse import urlsplit
 
 from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -13,6 +14,20 @@ from band.core.exceptions import BandConfigError
 from band.integrations.mcp.local_server import LOCAL_MCP_HOST
 
 MCPTransport = Literal["sse", "streamable_http"]
+
+# Single source of truth for the Letta Cloud endpoint: both the base_url
+# field default and self-hosted detection (org_scoped auto-detection, the
+# Cloud+org_scoped=True construction guard) read this constant.
+LETTA_CLOUD_BASE_URL = "https://api.letta.com"
+_LETTA_CLOUD_HOSTNAME = urlsplit(LETTA_CLOUD_BASE_URL).hostname
+
+
+def is_letta_cloud_url(base_url: str) -> bool:
+    """Whether ``base_url`` points at Letta Cloud rather than a self-hosted server."""
+    try:
+        return urlsplit(base_url).hostname == _LETTA_CLOUD_HOSTNAME
+    except ValueError:
+        return False
 
 
 @dataclass
@@ -102,7 +117,7 @@ class LettaAdapterConfig(BaseSettings):
     provider_key: str | None = Field(
         default=None, validation_alias=AliasChoices("LETTA_API_KEY")
     )  # Required for Letta Cloud; omit for self-hosted
-    base_url: str = "https://api.letta.com"
+    base_url: str = LETTA_CLOUD_BASE_URL
     custom_section: str = ""
     include_base_instructions: bool = True
     persona: str | None = None
@@ -112,6 +127,19 @@ class LettaAdapterConfig(BaseSettings):
 
     # Letta Cloud project scoping (ignored for self-hosted)
     project: str | None = None
+
+    # Self-hosted only: provision a dedicated Letta organization + user per
+    # adapter instance so MCP tool storage never collides between instances
+    # sharing one server (Letta dedupes MCP-discovered Tool rows by
+    # (name, organization_id); with no scoping, a second instance silently
+    # re-points the first instance's tool to its own MCP server). None
+    # (default) auto-enables for a self-hosted base_url and stays off for
+    # Letta Cloud. Explicit False is the only meaningful override — it opts
+    # a self-hosted deployment back out. Explicit True against Letta Cloud
+    # raises BandConfigError at construction (see _reject_org_scoped_cloud
+    # below): Cloud does not expose the admin API this needs, so honoring it
+    # would fail deep inside on_started instead of failing loud up front.
+    org_scoped: bool | None = None
 
     # Embedding model passed on agent create. Letta's Docker server requires
     # one; Cloud picks its own default when None.
@@ -190,4 +218,16 @@ class LettaAdapterConfig(BaseSettings):
             )
             self.mcp_server_url = None
             self.mcp_server_name = None
+        return self
+
+    @model_validator(mode="after")
+    def _reject_org_scoped_cloud(self) -> LettaAdapterConfig:
+        if self.org_scoped and is_letta_cloud_url(self.base_url):
+            raise BandConfigError(
+                "org_scoped=True is not supported against Letta Cloud "
+                f"(base_url={self.base_url!r}) — it provisions organizations "
+                "and users via a self-hosted-only admin API that Letta Cloud "
+                "does not expose. Leave org_scoped unset (Cloud stays "
+                "unscoped) or set base_url to a self-hosted server."
+            )
         return self

--- a/src/band/integrations/letta/orgscope.py
+++ b/src/band/integrations/letta/orgscope.py
@@ -1,0 +1,137 @@
+"""Self-hosted-only Letta organization/user provisioning for MCP isolation.
+
+Letta dedupes MCP-discovered ``Tool`` rows by ``(name, organization_id)``. On
+a shared self-hosted server, every ``LettaAdapter`` instance that never sets
+a ``user_id`` header resolves to the same default org, so a second
+instance's MCP registration silently re-points the first instance's tool row
+to its own server. Provisioning a dedicated organization + user per instance
+and sending its ``user_id`` in every request (``AsyncLetta(default_headers=
+{"user_id": ...})``) isolates MCP server + tool storage between instances.
+
+The admin API this needs (``/v1/admin/orgs/``, ``/v1/admin/users/``) is not
+exposed by the ``letta_client`` SDK, hence the raw ``httpx`` calls here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_ADMIN_PREFIX = "/v1/admin"
+_DEFAULT_TIMEOUT_S = 30.0
+_Match = Callable[[dict], bool]
+
+
+class LettaOrgScopeClient:
+    """Minimal async client for Letta's self-hosted admin org/user API."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        bearer_token: str | None,
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._headers = (
+            {"Authorization": f"Bearer {bearer_token}"} if bearer_token else {}
+        )
+        self._timeout_s = timeout_s
+
+    async def find_or_create_organization(self, name: str) -> str:
+        """The id of the organization named ``name``, creating it if absent."""
+        async with self._client() as client:
+            existing = await self._paginated_find(
+                client, f"{_ADMIN_PREFIX}/orgs/", match=lambda org: org["name"] == name
+            )
+            if existing is not None:
+                return existing["id"]
+            response = await client.post(f"{_ADMIN_PREFIX}/orgs/", json={"name": name})
+            response.raise_for_status()
+            org = response.json()
+            logger.info("Created Letta organization %r (id=%s)", name, org["id"])
+            return org["id"]
+
+    async def find_or_create_user(self, name: str, *, organization_id: str) -> str:
+        """The id of the user named ``name`` under ``organization_id``.
+
+        Matches on both name and organization_id: ``GET /v1/admin/users/``
+        lists across the entire instance, not just one organization, and
+        neither Organization nor User has a database-level unique
+        constraint on name — a same-named user under a different org is a
+        real possibility, not a hypothetical one, and matching by name
+        alone would adopt it (landing in the wrong org).
+        """
+        async with self._client() as client:
+            existing = await self._paginated_find(
+                client,
+                f"{_ADMIN_PREFIX}/users/",
+                match=lambda user: (
+                    user["name"] == name and user["organization_id"] == organization_id
+                ),
+            )
+            if existing is not None:
+                return existing["id"]
+            response = await client.post(
+                f"{_ADMIN_PREFIX}/users/",
+                json={"name": name, "organization_id": organization_id},
+            )
+            response.raise_for_status()
+            user = response.json()
+            logger.info(
+                "Created Letta user %r (id=%s) in organization %s",
+                name,
+                user["id"],
+                organization_id,
+            )
+            return user["id"]
+
+    def _client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=self._base_url,
+            headers=self._headers,
+            timeout=self._timeout_s,
+        )
+
+    @staticmethod
+    async def _paginated_find(
+        client: httpx.AsyncClient,
+        path: str,
+        *,
+        match: _Match,
+    ) -> dict | None:
+        """The first item on ``path`` satisfying ``match``, paging via ``after``."""
+        after: str | None = None
+        while True:
+            response = await client.get(
+                path, params={"after": after} if after else None
+            )
+            response.raise_for_status()
+            page: list[dict] = response.json()
+            if not page:
+                return None
+            found = next((item for item in page if match(item)), None)
+            if found is not None:
+                return found
+            after = page[-1]["id"]
+
+
+async def resolve_org_scoped_headers(
+    *, base_url: str, agent_name: str, bearer_token: str | None
+) -> dict[str, str]:
+    """Provision/reuse this instance's dedicated org+user; return {"user_id": ...}."""
+    if not agent_name.strip():
+        raise ValueError(
+            "agent_name must be non-blank to derive a Letta org-scoped identity"
+        )
+    scope_name = f"band-{agent_name}"
+    scope_client = LettaOrgScopeClient(base_url=base_url, bearer_token=bearer_token)
+    organization_id = await scope_client.find_or_create_organization(scope_name)
+    user_id = await scope_client.find_or_create_user(
+        scope_name, organization_id=organization_id
+    )
+    return {"user_id": user_id}

--- a/tests/adapters/test_deprecation_shims.py
+++ b/tests/adapters/test_deprecation_shims.py
@@ -158,6 +158,30 @@ class TestLettaApiKeyShim:
             LettaAdapterConfig(provider_key="new-key", api_key="old-key")
 
 
+class TestLettaOrgScopedConfig:
+    """org_scoped=True against Letta Cloud must fail at construction.
+
+    Letta Cloud does not expose the self-hosted-only admin API org_scoped
+    needs; honoring it would only fail deep inside on_started's real httpx
+    calls instead of failing loud up front.
+    """
+
+    @pytest.mark.parametrize(
+        "base_url", ["https://api.letta.com", "https://API.LETTA.COM/"]
+    )
+    def test_letta_org_scoped_and_cloud_conflict(self, base_url: str) -> None:
+        from band.adapters.letta import LettaAdapterConfig
+
+        with pytest.raises(BandConfigError, match="org_scoped=True"):
+            LettaAdapterConfig(base_url=base_url, org_scoped=True)
+
+    def test_letta_org_scoped_true_on_self_hosted_is_accepted(self) -> None:
+        from band.adapters.letta import LettaAdapterConfig
+
+        config = LettaAdapterConfig(base_url="http://localhost:8283", org_scoped=True)
+        assert config.org_scoped is True
+
+
 class TestLettaMCPKwargShim:
     """Legacy Letta MCP kwargs must populate the nested MCP config."""
 

--- a/tests/adapters/test_letta_mcp.py
+++ b/tests/adapters/test_letta_mcp.py
@@ -13,6 +13,7 @@ import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pytest_httpx import HTTPXMock
 
 from band.adapters.letta import (
     LettaAdapter,
@@ -191,6 +192,173 @@ class TestLettaAdapterOnStarted:
         with patch.dict("sys.modules", {"letta_client": mock_letta_module}):
             with pytest.raises(RuntimeError, match="MCP server registration failed"):
                 await adapter.on_started("TestBot", "A test bot")
+
+    @pytest.mark.asyncio
+    async def test_on_started_self_hosted_org_scoped_by_default(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        """A self-hosted base_url auto-enables org scoping: a dedicated
+        org+user is provisioned and its user_id becomes the client's default
+        header — this is what isolates MCP tool storage between instances."""
+        base_url = "http://localhost:8283"
+        adapter = LettaAdapter(
+            config=LettaAdapterConfig(
+                base_url=base_url, mcp=LettaMCPConfig(mode="external")
+            )
+        )
+
+        httpx_mock.add_response(method="GET", url=f"{base_url}/v1/admin/orgs/", json=[])
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{base_url}/v1/admin/orgs/",
+            json={"id": "org-1", "name": "band-TestBot"},
+        )
+        httpx_mock.add_response(
+            method="GET", url=f"{base_url}/v1/admin/users/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{base_url}/v1/admin/users/",
+            json={"id": "user-1", "name": "band-TestBot", "organization_id": "org-1"},
+        )
+
+        mock_client = AsyncMock()
+        mock_server = make_mock_mcp_server()
+        mock_client.mcp_servers.create.return_value = mock_server
+        mock_client.mcp_servers.tools.list.return_value = []
+
+        mock_letta_module = MagicMock()
+        mock_letta_module.AsyncLetta = MagicMock(return_value=mock_client)
+
+        with patch.dict("sys.modules", {"letta_client": mock_letta_module}):
+            await adapter.on_started("TestBot", "A test bot")
+
+        mock_letta_module.AsyncLetta.assert_called_once_with(
+            base_url=base_url,
+            default_headers={"user_id": "user-1"},
+        )
+        # Base tools must be force-seeded for the fresh org before any room
+        # can reach agents.create(include_base_tools=True).
+        mock_client.tools.list.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "base_url", ["https://api.letta.com", "https://API.LETTA.COM/"]
+    )
+    async def test_on_started_cloud_stays_unscoped(self, base_url: str) -> None:
+        """Regression guard: a Cloud base_url must never invoke org-scope
+        resolution — the Cloud path stays byte-for-byte unchanged."""
+        adapter = LettaAdapter(
+            config=LettaAdapterConfig(
+                base_url=base_url, mcp=LettaMCPConfig(mode="external")
+            )
+        )
+
+        mock_client = AsyncMock()
+        mock_server = make_mock_mcp_server()
+        mock_client.mcp_servers.create.return_value = mock_server
+        mock_client.mcp_servers.tools.list.return_value = []
+
+        mock_letta_module = MagicMock()
+        mock_letta_module.AsyncLetta = MagicMock(return_value=mock_client)
+
+        with (
+            patch.dict("sys.modules", {"letta_client": mock_letta_module}),
+            patch("band.adapters.letta.resolve_org_scoped_headers") as mock_resolve,
+        ):
+            await adapter.on_started("TestBot", "A test bot")
+
+        mock_resolve.assert_not_called()
+        mock_letta_module.AsyncLetta.assert_called_once_with(
+            base_url=base_url,
+        )
+        mock_client.tools.list.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_started_org_scoped_false_opts_out_on_self_hosted(
+        self,
+    ) -> None:
+        """org_scoped=False is the escape hatch: it opts a self-hosted
+        deployment back out of org scoping."""
+        adapter = LettaAdapter(
+            config=LettaAdapterConfig(
+                base_url="http://localhost:8283",
+                org_scoped=False,
+                mcp=LettaMCPConfig(mode="external"),
+            )
+        )
+
+        mock_client = AsyncMock()
+        mock_server = make_mock_mcp_server()
+        mock_client.mcp_servers.create.return_value = mock_server
+        mock_client.mcp_servers.tools.list.return_value = []
+
+        mock_letta_module = MagicMock()
+        mock_letta_module.AsyncLetta = MagicMock(return_value=mock_client)
+
+        with (
+            patch.dict("sys.modules", {"letta_client": mock_letta_module}),
+            patch("band.adapters.letta.resolve_org_scoped_headers") as mock_resolve,
+        ):
+            await adapter.on_started("TestBot", "A test bot")
+
+        mock_resolve.assert_not_called()
+        mock_letta_module.AsyncLetta.assert_called_once_with(
+            base_url="http://localhost:8283",
+        )
+
+    @pytest.mark.asyncio
+    async def test_on_started_two_instances_resolve_distinct_user_ids(
+        self,
+    ) -> None:
+        """Two adapter instances against the same self-hosted server must
+        resolve distinct org-scoped identities — the actual collision-
+        avoidance property this fix exists to provide."""
+        base_url = "http://localhost:8283"
+
+        def make_adapter() -> LettaAdapter:
+            return LettaAdapter(
+                config=LettaAdapterConfig(
+                    base_url=base_url, mcp=LettaMCPConfig(mode="external")
+                )
+            )
+
+        async def fake_resolve(
+            *, base_url: str, agent_name: str, bearer_token: str | None
+        ) -> dict[str, str]:
+            return {"user_id": f"user-{agent_name}"}
+
+        mock_client_a = AsyncMock()
+        mock_client_a.mcp_servers.create.return_value = make_mock_mcp_server()
+        mock_client_a.mcp_servers.tools.list.return_value = []
+        mock_client_b = AsyncMock()
+        mock_client_b.mcp_servers.create.return_value = make_mock_mcp_server()
+        mock_client_b.mcp_servers.tools.list.return_value = []
+
+        mock_letta_module = MagicMock()
+        mock_letta_module.AsyncLetta = MagicMock(
+            side_effect=[mock_client_a, mock_client_b]
+        )
+
+        with (
+            patch.dict("sys.modules", {"letta_client": mock_letta_module}),
+            patch(
+                "band.adapters.letta.resolve_org_scoped_headers",
+                side_effect=fake_resolve,
+            ),
+        ):
+            await make_adapter().on_started("AgentA", "Bot A")
+            await make_adapter().on_started("AgentB", "Bot B")
+
+        headers_a = mock_letta_module.AsyncLetta.call_args_list[0].kwargs[
+            "default_headers"
+        ]
+        headers_b = mock_letta_module.AsyncLetta.call_args_list[1].kwargs[
+            "default_headers"
+        ]
+        assert headers_a == {"user_id": "user-AgentA"}
+        assert headers_b == {"user_id": "user-AgentB"}
+        assert headers_a != headers_b
 
     @pytest.mark.asyncio
     async def test_on_started_import_error(self) -> None:

--- a/tests/adapters/test_letta_orgscope.py
+++ b/tests/adapters/test_letta_orgscope.py
@@ -1,0 +1,231 @@
+"""Unit tests for Letta self-hosted org/user provisioning (INT-985).
+
+Interception is the maintained ``pytest-httpx`` ``httpx_mock`` fixture (the
+pattern in ``tests/platform/test_link_credentials.py``) — it patches httpx
+globally, so it observes ``LettaOrgScopeClient``'s real per-call
+``httpx.AsyncClient`` with no injected seam.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from band.integrations.letta.orgscope import (
+    LettaOrgScopeClient,
+    resolve_org_scoped_headers,
+)
+
+_BASE_URL = "http://localhost:8283"
+
+
+def _client(*, bearer_token: str | None = None) -> LettaOrgScopeClient:
+    return LettaOrgScopeClient(base_url=_BASE_URL, bearer_token=bearer_token)
+
+
+class TestFindOrCreateOrganization:
+    async def test_no_match_creates(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET", url=f"{_BASE_URL}/v1/admin/orgs/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/orgs/",
+            json={"id": "org-new", "name": "band-x"},
+        )
+
+        org_id = await _client().find_or_create_organization("band-x")
+
+        assert org_id == "org-new"
+
+    async def test_match_on_first_page_skips_create(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/orgs/",
+            json=[{"id": "org-1", "name": "band-x"}],
+        )
+
+        org_id = await _client().find_or_create_organization("band-x")
+
+        assert org_id == "org-1"
+        assert len(httpx_mock.get_requests(method="POST")) == 0
+
+    async def test_match_on_second_page_paginates(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/orgs/",
+            json=[{"id": "org-1", "name": "other"}],
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/orgs/?after=org-1",
+            json=[{"id": "org-2", "name": "band-x"}],
+        )
+
+        org_id = await _client().find_or_create_organization("band-x")
+
+        assert org_id == "org-2"
+        assert len(httpx_mock.get_requests(method="GET")) == 2
+        assert len(httpx_mock.get_requests(method="POST")) == 0
+
+
+class TestFindOrCreateUser:
+    async def test_no_match_creates(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET", url=f"{_BASE_URL}/v1/admin/users/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/users/",
+            json={"id": "user-new", "name": "band-x", "organization_id": "org-1"},
+        )
+
+        user_id = await _client().find_or_create_user("band-x", organization_id="org-1")
+
+        assert user_id == "user-new"
+        create_request = httpx_mock.get_requests(method="POST")[0]
+        assert json.loads(create_request.content) == {
+            "name": "band-x",
+            "organization_id": "org-1",
+        }
+
+    async def test_match_on_first_page_skips_create(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/users/",
+            json=[{"id": "user-1", "name": "band-x", "organization_id": "org-1"}],
+        )
+
+        user_id = await _client().find_or_create_user("band-x", organization_id="org-1")
+
+        assert user_id == "user-1"
+        assert len(httpx_mock.get_requests(method="POST")) == 0
+
+    async def test_match_on_second_page_paginates(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/users/",
+            json=[{"id": "user-1", "name": "other", "organization_id": "org-1"}],
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/users/?after=user-1",
+            json=[{"id": "user-2", "name": "band-x", "organization_id": "org-1"}],
+        )
+
+        user_id = await _client().find_or_create_user("band-x", organization_id="org-1")
+
+        assert user_id == "user-2"
+        assert len(httpx_mock.get_requests(method="POST")) == 0
+
+    async def test_same_name_different_org_is_not_a_match(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        """Regression guard: a same-named user under a different org must not
+        be adopted — that would land this instance in the wrong org, exactly
+        the collision this fix exists to prevent (GET /v1/admin/users/ lists
+        across the whole instance, not one organization).
+        """
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/users/",
+            json=[{"id": "user-X", "name": "band-Bob", "organization_id": "org-X"}],
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/users/?after=user-X",
+            json=[],
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/users/",
+            json={"id": "user-Y", "name": "band-Bob", "organization_id": "org-Y"},
+        )
+
+        user_id = await _client().find_or_create_user(
+            "band-Bob", organization_id="org-Y"
+        )
+
+        assert user_id == "user-Y"
+        assert user_id != "user-X"
+
+
+class TestAuthPassthrough:
+    async def test_bearer_token_sent_when_set(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET", url=f"{_BASE_URL}/v1/admin/orgs/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/orgs/",
+            json={"id": "org-1", "name": "band-x"},
+        )
+
+        await _client(bearer_token="secret").find_or_create_organization("band-x")
+
+        for request in httpx_mock.get_requests():
+            assert request.headers["Authorization"] == "Bearer secret"
+
+    async def test_no_authorization_header_when_unset(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            method="GET", url=f"{_BASE_URL}/v1/admin/orgs/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/orgs/",
+            json={"id": "org-1", "name": "band-x"},
+        )
+
+        await _client(bearer_token=None).find_or_create_organization("band-x")
+
+        for request in httpx_mock.get_requests():
+            assert "Authorization" not in request.headers
+
+
+class TestResolveOrgScopedHeaders:
+    async def test_end_to_end_provisions_org_then_user(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            method="GET", url=f"{_BASE_URL}/v1/admin/orgs/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/orgs/",
+            json={"id": "org-1", "name": "band-my-agent"},
+        )
+        httpx_mock.add_response(
+            method="GET", url=f"{_BASE_URL}/v1/admin/users/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/users/",
+            json={"id": "user-1", "name": "band-my-agent", "organization_id": "org-1"},
+        )
+
+        headers = await resolve_org_scoped_headers(
+            base_url=_BASE_URL, agent_name="my-agent", bearer_token=None
+        )
+
+        assert headers == {"user_id": "user-1"}
+        assert len(httpx_mock.get_requests(url=f"{_BASE_URL}/v1/admin/orgs/")) == 2
+        assert len(httpx_mock.get_requests(url=f"{_BASE_URL}/v1/admin/users/")) == 2
+
+    @pytest.mark.parametrize("agent_name", ["", "   ", "\t\n"])
+    async def test_blank_agent_name_raises_before_any_http_call(
+        self, httpx_mock: HTTPXMock, agent_name: str
+    ) -> None:
+        with pytest.raises(ValueError, match="agent_name"):
+            await resolve_org_scoped_headers(
+                base_url=_BASE_URL, agent_name=agent_name, bearer_token=None
+            )
+
+        assert httpx_mock.get_requests() == []

--- a/tests/e2e/baseline/smoke/matrix/test_rehydration_partial.py
+++ b/tests/e2e/baseline/smoke/matrix/test_rehydration_partial.py
@@ -88,14 +88,6 @@ from tests.e2e.baseline.toolkit.user_ops import UserOps
             "(langgraph-adapter behaviour under investigation)",
         ),
         ExcludedAdapter(
-            Adapter.LETTA,
-            "self-hosted Letta shares one org-wide send-message tool across "
-            "co-located agents, so a second live agent's reply routes through the "
-            "most-recently-registered adapter's MCP server and posts under the "
-            "wrong identity — the stayer-scoped reply is never observed. Needs "
-            "per-instance tool-name isolation to run two Letta agents in one org",
-        ),
-        ExcludedAdapter(
             Adapter.CREWAI_FLOW,
             "terminal echo flow with no memory — cannot rehydrate context across a "
             "reboot",

--- a/tests/integration/test_letta_live.py
+++ b/tests/integration/test_letta_live.py
@@ -26,8 +26,12 @@ Run with:
 
 from __future__ import annotations
 
+from uuid import uuid4
+
 import pytest
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from band.integrations.letta.orgscope import resolve_org_scoped_headers
 
 pytestmark = pytest.mark.requires_api
 
@@ -52,19 +56,43 @@ LETTA_EMBEDDING = _SETTINGS.letta_embedding
 LETTA_MCP_ADVERTISED_HOST = _SETTINGS.letta_mcp_advertised_host
 
 
-def _make_client() -> object:
+# A fixed name for the raw-client tests below: they all share one Letta
+# org/user (as opposed to test_two_instances_stay_isolated_in_shared_org,
+# which deliberately uses two).
+_RAW_CLIENT_AGENT_NAME = "IntegrationBotRawClient"
+
+
+async def _make_client() -> object:
+    """An org-scoped Letta client, matching how the adapter builds its own.
+
+    Once CI's Letta server sets LETTA_NO_DEFAULT_ACTOR=true (see
+    .github/scripts/setup-letta.sh), a client with no user_id header raises
+    on every call instead of silently falling back to the default org — so
+    this helper must resolve org-scoped headers the same way the adapter's
+    on_started does, not rely on the default org.
+    """
     from letta_client import AsyncLetta
 
-    client_kwargs: dict[str, str] = {"base_url": LETTA_BASE_URL}
+    client_kwargs: dict[str, object] = {"base_url": LETTA_BASE_URL}
     if LETTA_API_KEY:
         client_kwargs["api_key"] = LETTA_API_KEY
-    return AsyncLetta(**client_kwargs)
+    client_kwargs["default_headers"] = await resolve_org_scoped_headers(
+        base_url=LETTA_BASE_URL,
+        agent_name=_RAW_CLIENT_AGENT_NAME,
+        bearer_token=LETTA_API_KEY or None,
+    )
+    client = AsyncLetta(**client_kwargs)
+    # A fresh org has zero Tool rows; force the lazy base-tool seed (see
+    # LettaAdapter.on_started) before these tests' agents.create(
+    # include_base_tools=True) calls, which would otherwise raise.
+    await client.tools.list()
+    return client
 
 
 @pytest.mark.asyncio
 async def test_existing_agent_message() -> None:
     """Send a message to a pre-existing Letta agent and verify response."""
-    client = _make_client()
+    client = await _make_client()
 
     # Create a temporary agent for this test
     # The server rejects an agent create without a model; the Docker server
@@ -127,9 +155,89 @@ async def test_adapter_self_hosted_mcp_registration() -> None:
 
 
 @pytest.mark.asyncio
+async def test_two_instances_stay_isolated_in_shared_org() -> None:
+    """Two adapter instances on one shared self-hosted Letta stay isolated.
+
+    Regression test for the org+user scoping fix (INT-985): without it,
+    Letta dedupes MCP-discovered Tool rows by (name, organization_id), so a
+    second instance's registration silently re-points the first instance's
+    band_send_message tool row to its own MCP server — the first instance's
+    agent then routes tool calls into the wrong instance's identity.
+    """
+    from letta_client import NotFoundError
+
+    from band.adapters.letta import LettaAdapter, LettaAdapterConfig, LettaMCPConfig
+
+    loopback = LETTA_MCP_ADVERTISED_HOST in ("127.0.0.1", "localhost")
+    # A unique suffix per run guarantees each adapter lands in a genuinely
+    # fresh org (not an already-seeded one from a prior run), which is what
+    # makes the agents.create() calls below a real proof of the base-tool
+    # bootstrap in on_started.
+    suffix = uuid4().hex[:8]
+
+    def make_adapter() -> LettaAdapter:
+        return LettaAdapter(
+            config=LettaAdapterConfig(
+                base_url=LETTA_BASE_URL,
+                provider_key=LETTA_API_KEY or None,
+                model=LETTA_MODEL,
+                embedding=LETTA_EMBEDDING,
+                mcp=LettaMCPConfig(
+                    bind_host="127.0.0.1" if loopback else "0.0.0.0",
+                    advertised_host=LETTA_MCP_ADVERTISED_HOST,
+                ),
+            ),
+        )
+
+    async def send_message_tool_metadata(adapter: LettaAdapter) -> dict:
+        tools = await adapter._client.tools.list()
+        tool = next(t for t in tools if t.name == adapter._mcp.send_message_tool)
+        assert tool.metadata is not None
+        return tool.metadata
+
+    adapter_a = make_adapter()
+    adapter_b = make_adapter()
+    try:
+        await adapter_a.on_started(f"IsolationBotA-{suffix}", "Isolation test bot A")
+        meta_a_before = await send_message_tool_metadata(adapter_a)
+
+        await adapter_b.on_started(f"IsolationBotB-{suffix}", "Isolation test bot B")
+        meta_b = await send_message_tool_metadata(adapter_b)
+
+        user_id_a = adapter_a._client.default_headers["user_id"]
+        user_id_b = adapter_b._client.default_headers["user_id"]
+        assert user_id_a != user_id_b
+
+        # B registering its own MCP server must not repoint A's tool row —
+        # the exact collision this fix exists to prevent.
+        meta_a_after = await send_message_tool_metadata(adapter_a)
+        assert meta_a_before["mcp"]["server_id"] == meta_a_after["mcp"]["server_id"]
+        assert meta_a_after["mcp"]["server_id"] != meta_b["mcp"]["server_id"]
+
+        # Fresh-org agent creation succeeds for both — proves the tools.list()
+        # bootstrap in on_started actually seeded base tools; without it this
+        # raises before either agent exists.
+        agent_id_a = await adapter_a._create_agent()
+        agent_id_b = await adapter_b._create_agent()
+
+        # Cross-org visibility: neither instance's client can retrieve the
+        # other's agent, but each can retrieve its own.
+        with pytest.raises(NotFoundError):
+            await adapter_b._client.agents.retrieve(agent_id_a)
+        await adapter_a._client.agents.retrieve(agent_id_a)
+
+        with pytest.raises(NotFoundError):
+            await adapter_a._client.agents.retrieve(agent_id_b)
+        await adapter_b._client.agents.retrieve(agent_id_b)
+    finally:
+        await adapter_a.cleanup_all()
+        await adapter_b.cleanup_all()
+
+
+@pytest.mark.asyncio
 async def test_conversations_api() -> None:
     """Test the Conversations API for shared agent mode."""
-    client = _make_client()
+    client = await _make_client()
 
     # Create agent
     # The server rejects an agent create without a model; the Docker server


### PR DESCRIPTION
## Summary
- provision a dedicated self-hosted Letta organization and user per adapter instance, preventing MCP tool rows from being repointed across agents
- use normalized Letta Cloud hostname detection so equivalent Cloud URLs never take the self-hosted admin path
- re-enable the Letta partial-rehydration matrix scenario and add unit/live integration coverage

## Verification
- `uv run pytest tests/adapters/test_letta_mcp.py tests/adapters/test_deprecation_shims.py tests/adapters/test_letta_orgscope.py -q --no-cov`
- `uv run ruff check ...`
- `uv run pyrefly check src/band/adapters/letta.py src/band/integrations/letta/config.py`

Closes INT-985