### PR TITLE
fix: Isolate self-hosted Letta MCP tool storage per adapter instance

### DIFF
--- a/.github/scripts/setup-letta.sh
+++ b/.github/scripts/setup-letta.sh
@@ -20,11 +20,17 @@ LETTA_IMAGE="letta/letta:0.16.8@sha256:aa66c3eeee13d2dfc40c650d709b550237ee31bfc
 # handle, but forwarding the key lets LETTA_MODEL select an anthropic/* one.
 # The port binds loopback only — the tests run on the same host, and the test
 # server is unauthenticated.
+#
+# LETTA_NO_DEFAULT_ACTOR=true turns an unresolvable user_id header into a
+# loud error instead of a silent fallback to the default org/user — needed
+# so a broken org-scoping resolution in the adapter fails the live test
+# loudly instead of silently passing (see LettaAdapterConfig.org_scoped).
 docker run -d --name letta-server \
   -p 127.0.0.1:8283:8283 \
   --add-host=host.docker.internal:host-gateway \
   -e OPENAI_API_KEY="${OPENAI_API_KEY:?OPENAI_API_KEY is required for the Letta server}" \
   -e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
+  -e LETTA_NO_DEFAULT_ACTOR=true \
   "$LETTA_IMAGE"
 
 wait_healthy() {

--- a/docker/letta/runner.py
+++ b/docker/letta/runner.py
@@ -13,6 +13,14 @@ Environment variables:
     LETTA_MODEL                Model ID (e.g., openai/gpt-5.4)
     LETTA_MODE                 Operating mode: per_room or shared (default: per_room)
     LETTA_PROJECT              Letta Cloud project name (optional, ignored for self-hosted)
+    LETTA_ORG_SCOPED           Self-hosted only: provision a dedicated Letta org+user
+                               per instance so MCP tool storage never collides between
+                               instances sharing one server (default: auto-on for
+                               self-hosted, off for Cloud; set "false" to opt out).
+                               Recommend also setting LETTA_NO_DEFAULT_ACTOR=true on the
+                               Letta *server* process itself — it turns an unresolvable
+                               user_id into a loud error instead of a silent fallback
+                               to the default org, which would defeat this scoping.
     LETTA_EMBEDDING            Embedding model for agent create (required by Letta's
                                Docker server, e.g. openai/text-embedding-3-small)
     MCP_SERVER_URL             External band-mcp server URL. When set, the adapter
@@ -82,6 +90,7 @@ class LettaRunnerSettings(BaseSettings):
     letta_model: str | None = None  # LETTA_MODEL
     letta_mode: str | None = None  # LETTA_MODE
     letta_project: str | None = None  # LETTA_PROJECT
+    letta_org_scoped: str | None = None  # LETTA_ORG_SCOPED
     letta_embedding: str | None = None  # LETTA_EMBEDDING
     letta_mcp_advertised_host: str | None = None  # LETTA_MCP_ADVERTISED_HOST
     mcp_server_url: str | None = None  # MCP_SERVER_URL
@@ -181,6 +190,11 @@ async def main() -> None:
     mcp_server_url = resolve(settings.mcp_server_url, "mcp_server_url")
     mcp_server_name = resolve(settings.mcp_server_name, "mcp_server_name")
     letta_project = resolve(settings.letta_project, "letta_project")
+    # LettaAdapterConfig.org_scoped is bool | None (unlike the str | None
+    # fields resolve() otherwise threads through); pydantic's lenient
+    # str->bool coercion accepts this resolved string ("true"/"false") fine,
+    # but it's not a literal copy-paste of a str | None passthrough.
+    letta_org_scoped = resolve(settings.letta_org_scoped, "letta_org_scoped")
 
     # An explicit MCP_SERVER_URL selects an external band-mcp; otherwise the
     # adapter self-hosts its own Band MCP server in-process.
@@ -207,6 +221,7 @@ async def main() -> None:
             embedding=letta_embedding,
             mcp=mcp_config,
             project=letta_project,
+            org_scoped=letta_org_scoped,
             custom_section="",
             include_base_instructions=True,
         ),

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -24,10 +24,10 @@ from band.core.types import (
     TurnUsage,
 )
 from band.integrations.letta.config import (
-    LETTA_CLOUD_BASE_URL,
     LettaAdapterConfig,
     LettaMCPConfig,
     MCPTransport,
+    is_letta_cloud_url,
 )
 from band.integrations.letta.mcp import LettaMCPBridge, bounded_teardown
 from band.integrations.letta.orgscope import resolve_org_scoped_headers
@@ -213,7 +213,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         org_scoped = (
             self.config.org_scoped
             if self.config.org_scoped is not None
-            else self.config.base_url.rstrip("/") != LETTA_CLOUD_BASE_URL.rstrip("/")
+            else not is_letta_cloud_url(self.config.base_url)
         )
         if org_scoped:
             client_kwargs["default_headers"] = await resolve_org_scoped_headers(

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -187,6 +187,30 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
             features=self.features,
         )
 
+        self._client = await self._build_client(agent_name)
+
+        # Fail loud at startup if the tool path cannot be wired — the adapter
+        # is useless without it.
+        await self._mcp.ensure_ready(self._client)
+
+        logger.info(
+            "Letta adapter started for agent: %s (mode=%s, mcp=%s)",
+            agent_name,
+            self.config.mode,
+            self.config.mcp.mode,
+        )
+
+    async def _build_client(self, agent_name: str) -> Any:
+        """Construct the AsyncLetta SDK client, org-scoped for self-hosted servers.
+
+        Self-hosted Letta dedupes MCP-discovered Tool rows by
+        (name, organization_id): with no user_id header, every instance
+        resolves to the same default org, and a second instance's MCP
+        registration silently re-points the first instance's tool row to
+        its own server. Scoping each instance to its own org+user closes
+        that collision. Cloud is never scoped (org_scoped=True against it
+        is already rejected at config construction — see LettaAdapterConfig).
+        """
         try:
             from letta_client import AsyncLetta  # type: ignore[import-not-found]  # optional dependency
         except ImportError:
@@ -203,13 +227,6 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         if self.config.project:
             client_kwargs["project"] = self.config.project
 
-        # Self-hosted Letta dedupes MCP-discovered Tool rows by
-        # (name, organization_id): with no user_id header, every instance
-        # resolves to the same default org, and a second instance's MCP
-        # registration silently re-points the first instance's tool row to
-        # its own server. Scoping each instance to its own org+user closes
-        # that collision. Cloud is never scoped (org_scoped=True against it
-        # is already rejected at config construction — see LettaAdapterConfig).
         org_scoped = (
             self.config.org_scoped
             if self.config.org_scoped is not None
@@ -221,25 +238,16 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                 agent_name=agent_name,
                 bearer_token=self.config.provider_key,
             )
-        self._client = AsyncLetta(**client_kwargs)
+
+        client = AsyncLetta(**client_kwargs)
         if org_scoped:
             # A fresh org has zero Tool rows; base tools (send_message, etc.)
             # are seeded lazily only by this list call (GET /v1/tools/ with
             # upsert_base_tools). Nothing else in this adapter's flow reaches
             # it, so the first agents.create(include_base_tools=True) in a
             # fresh org would otherwise raise before the agent exists.
-            await self._client.tools.list()
-
-        # Fail loud at startup if the tool path cannot be wired — the adapter
-        # is useless without it.
-        await self._mcp.ensure_ready(self._client)
-
-        logger.info(
-            "Letta adapter started for agent: %s (mode=%s, mcp=%s)",
-            agent_name,
-            self.config.mode,
-            self.config.mcp.mode,
-        )
+            await client.tools.list()
+        return client
 
     # ------------------------------------------------------------------
     # Message handling

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -24,11 +24,13 @@ from band.core.types import (
     TurnUsage,
 )
 from band.integrations.letta.config import (
+    LETTA_CLOUD_BASE_URL,
     LettaAdapterConfig,
     LettaMCPConfig,
     MCPTransport,
 )
 from band.integrations.letta.mcp import LettaMCPBridge, bounded_teardown
+from band.integrations.letta.orgscope import resolve_org_scoped_headers
 from band.integrations.letta.prompts import render_tool_enforcement
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
@@ -200,7 +202,33 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
             client_kwargs["api_key"] = self.config.provider_key
         if self.config.project:
             client_kwargs["project"] = self.config.project
+
+        # Self-hosted Letta dedupes MCP-discovered Tool rows by
+        # (name, organization_id): with no user_id header, every instance
+        # resolves to the same default org, and a second instance's MCP
+        # registration silently re-points the first instance's tool row to
+        # its own server. Scoping each instance to its own org+user closes
+        # that collision. Cloud is never scoped (org_scoped=True against it
+        # is already rejected at config construction — see LettaAdapterConfig).
+        org_scoped = (
+            self.config.org_scoped
+            if self.config.org_scoped is not None
+            else self.config.base_url.rstrip("/") != LETTA_CLOUD_BASE_URL.rstrip("/")
+        )
+        if org_scoped:
+            client_kwargs["default_headers"] = await resolve_org_scoped_headers(
+                base_url=self.config.base_url,
+                agent_name=agent_name,
+                bearer_token=self.config.provider_key,
+            )
         self._client = AsyncLetta(**client_kwargs)
+        if org_scoped:
+            # A fresh org has zero Tool rows; base tools (send_message, etc.)
+            # are seeded lazily only by this list call (GET /v1/tools/ with
+            # upsert_base_tools). Nothing else in this adapter's flow reaches
+            # it, so the first agents.create(include_base_tools=True) in a
+            # fresh org would otherwise raise before the agent exists.
+            await self._client.tools.list()
 
         # Fail loud at startup if the tool path cannot be wired — the adapter
         # is useless without it.

--- a/src/band/integrations/letta/config.py
+++ b/src/band/integrations/letta/config.py
@@ -14,6 +14,11 @@ from band.integrations.mcp.local_server import LOCAL_MCP_HOST
 
 MCPTransport = Literal["sse", "streamable_http"]
 
+# Single source of truth for the Letta Cloud endpoint: both the base_url
+# field default and self-hosted detection (org_scoped auto-detection, the
+# Cloud+org_scoped=True construction guard) read this constant.
+LETTA_CLOUD_BASE_URL = "https://api.letta.com"
+
 
 @dataclass
 class LettaMCPConfig:
@@ -102,7 +107,7 @@ class LettaAdapterConfig(BaseSettings):
     provider_key: str | None = Field(
         default=None, validation_alias=AliasChoices("LETTA_API_KEY")
     )  # Required for Letta Cloud; omit for self-hosted
-    base_url: str = "https://api.letta.com"
+    base_url: str = LETTA_CLOUD_BASE_URL
     custom_section: str = ""
     include_base_instructions: bool = True
     persona: str | None = None
@@ -112,6 +117,19 @@ class LettaAdapterConfig(BaseSettings):
 
     # Letta Cloud project scoping (ignored for self-hosted)
     project: str | None = None
+
+    # Self-hosted only: provision a dedicated Letta organization + user per
+    # adapter instance so MCP tool storage never collides between instances
+    # sharing one server (Letta dedupes MCP-discovered Tool rows by
+    # (name, organization_id); with no scoping, a second instance silently
+    # re-points the first instance's tool to its own MCP server). None
+    # (default) auto-enables for a self-hosted base_url and stays off for
+    # Letta Cloud. Explicit False is the only meaningful override — it opts
+    # a self-hosted deployment back out. Explicit True against Letta Cloud
+    # raises BandConfigError at construction (see _reject_org_scoped_cloud
+    # below): Cloud does not expose the admin API this needs, so honoring it
+    # would fail deep inside on_started instead of failing loud up front.
+    org_scoped: bool | None = None
 
     # Embedding model passed on agent create. Letta's Docker server requires
     # one; Cloud picks its own default when None.
@@ -190,4 +208,17 @@ class LettaAdapterConfig(BaseSettings):
             )
             self.mcp_server_url = None
             self.mcp_server_name = None
+        return self
+
+    @model_validator(mode="after")
+    def _reject_org_scoped_cloud(self) -> LettaAdapterConfig:
+        is_cloud = self.base_url.rstrip("/") == LETTA_CLOUD_BASE_URL.rstrip("/")
+        if self.org_scoped and is_cloud:
+            raise BandConfigError(
+                "org_scoped=True is not supported against Letta Cloud "
+                f"(base_url={self.base_url!r}) — it provisions organizations "
+                "and users via a self-hosted-only admin API that Letta Cloud "
+                "does not expose. Leave org_scoped unset (Cloud stays "
+                "unscoped) or set base_url to a self-hosted server."
+            )
         return self

--- a/src/band/integrations/letta/config.py
+++ b/src/band/integrations/letta/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass
 from typing import Any, Literal
+from urllib.parse import urlsplit
 
 from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -18,6 +19,20 @@ MCPTransport = Literal["sse", "streamable_http"]
 # field default and self-hosted detection (org_scoped auto-detection, the
 # Cloud+org_scoped=True construction guard) read this constant.
 LETTA_CLOUD_BASE_URL = "https://api.letta.com"
+_LETTA_CLOUD_HOSTNAME = urlsplit(LETTA_CLOUD_BASE_URL).hostname
+
+
+def is_letta_cloud_url(base_url: str) -> bool:
+    """Whether ``base_url`` points at Letta Cloud rather than a self-hosted server.
+
+    Compares hostnames, not raw strings, so casing and a trailing slash never
+    cause a Cloud URL to be misclassified as self-hosted; ``.strip()`` closes
+    the same gap for incidental whitespace (e.g. an unquoted .env value).
+    """
+    try:
+        return urlsplit(base_url.strip()).hostname == _LETTA_CLOUD_HOSTNAME
+    except ValueError:
+        return False
 
 
 @dataclass
@@ -212,8 +227,7 @@ class LettaAdapterConfig(BaseSettings):
 
     @model_validator(mode="after")
     def _reject_org_scoped_cloud(self) -> LettaAdapterConfig:
-        is_cloud = self.base_url.rstrip("/") == LETTA_CLOUD_BASE_URL.rstrip("/")
-        if self.org_scoped and is_cloud:
+        if self.org_scoped and is_letta_cloud_url(self.base_url):
             raise BandConfigError(
                 "org_scoped=True is not supported against Letta Cloud "
                 f"(base_url={self.base_url!r}) — it provisions organizations "

--- a/src/band/integrations/letta/config.py
+++ b/src/band/integrations/letta/config.py
@@ -28,9 +28,16 @@ def is_letta_cloud_url(base_url: str) -> bool:
     Compares hostnames, not raw strings, so casing and a trailing slash never
     cause a Cloud URL to be misclassified as self-hosted; ``.strip()`` closes
     the same gap for incidental whitespace (e.g. an unquoted .env value).
+    ``urlsplit`` only parses a hostname out of a scheme-relative or absolute
+    URL, so a scheme-less value (e.g. a ``LETTA_BASE_URL`` config typo like
+    ``"api.letta.com"``) gets a synthetic ``//`` prefix first — otherwise its
+    hostname reads back ``None``, silently misclassifying Cloud as self-hosted.
     """
+    url = base_url.strip()
+    if "://" not in url:
+        url = f"//{url}"
     try:
-        return urlsplit(base_url.strip()).hostname == _LETTA_CLOUD_HOSTNAME
+        return urlsplit(url).hostname == _LETTA_CLOUD_HOSTNAME
     except ValueError:
         return False
 

--- a/src/band/integrations/letta/orgscope.py
+++ b/src/band/integrations/letta/orgscope.py
@@ -23,6 +23,12 @@ logger = logging.getLogger(__name__)
 
 _ADMIN_PREFIX = "/v1/admin"
 _DEFAULT_TIMEOUT_S = 30.0
+# Bounds _paginated_find against a pagination cursor that keeps advancing
+# without ever emptying or stalling -- a second, undiscovered quirk in
+# Letta's admin API pagination (the same surface that already produced the
+# null-created_at stall this client works around) would otherwise hang here
+# forever instead of failing loud.
+_MAX_PAGINATION_PAGES = 10_000
 _Match = Callable[[dict], bool]
 
 
@@ -118,7 +124,7 @@ class LettaOrgScopeClient:
         response shape this client does not otherwise need to know).
         """
         after: str | None = None
-        while True:
+        for _ in range(_MAX_PAGINATION_PAGES):
             response = await client.get(
                 path, params={"after": after} if after else None
             )
@@ -133,6 +139,10 @@ class LettaOrgScopeClient:
             if next_after == after:
                 return None
             after = next_after
+        raise RuntimeError(
+            f"Letta admin API pagination for {path!r} did not terminate after "
+            f"{_MAX_PAGINATION_PAGES} pages"
+        )
 
 
 async def resolve_org_scoped_headers(

--- a/src/band/integrations/letta/orgscope.py
+++ b/src/band/integrations/letta/orgscope.py
@@ -1,0 +1,152 @@
+"""Self-hosted-only Letta organization/user provisioning for MCP isolation.
+
+Letta dedupes MCP-discovered ``Tool`` rows by ``(name, organization_id)``. On
+a shared self-hosted server, every ``LettaAdapter`` instance that never sets
+a ``user_id`` header resolves to the same default org, so a second
+instance's MCP registration silently re-points the first instance's tool row
+to its own server. Provisioning a dedicated organization + user per instance
+and sending its ``user_id`` in every request (``AsyncLetta(default_headers=
+{"user_id": ...})``) isolates MCP server + tool storage between instances.
+
+The admin API this needs (``/v1/admin/orgs/``, ``/v1/admin/users/``) is not
+exposed by the ``letta_client`` SDK, hence the raw ``httpx`` calls here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_ADMIN_PREFIX = "/v1/admin"
+_DEFAULT_TIMEOUT_S = 30.0
+_Match = Callable[[dict], bool]
+
+
+class LettaOrgScopeClient:
+    """Minimal async client for Letta's self-hosted admin org/user API."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        bearer_token: str | None,
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._headers = (
+            {"Authorization": f"Bearer {bearer_token}"} if bearer_token else {}
+        )
+        self._timeout_s = timeout_s
+
+    async def find_or_create_organization(self, name: str) -> str:
+        """The id of the organization named ``name``, creating it if absent."""
+        async with self._client() as client:
+            existing = await self._paginated_find(
+                client, f"{_ADMIN_PREFIX}/orgs/", match=lambda org: org["name"] == name
+            )
+            if existing is not None:
+                return existing["id"]
+            response = await client.post(f"{_ADMIN_PREFIX}/orgs/", json={"name": name})
+            response.raise_for_status()
+            org = response.json()
+            logger.info("Created Letta organization %r (id=%s)", name, org["id"])
+            return org["id"]
+
+    async def find_or_create_user(self, name: str, *, organization_id: str) -> str:
+        """The id of the user named ``name`` under ``organization_id``.
+
+        Matches on both name and organization_id: ``GET /v1/admin/users/``
+        lists across the entire instance, not just one organization, and
+        neither Organization nor User has a database-level unique
+        constraint on name — a same-named user under a different org is a
+        real possibility, not a hypothetical one, and matching by name
+        alone would adopt it (landing in the wrong org).
+        """
+        async with self._client() as client:
+            existing = await self._paginated_find(
+                client,
+                f"{_ADMIN_PREFIX}/users/",
+                match=lambda user: (
+                    user["name"] == name and user["organization_id"] == organization_id
+                ),
+            )
+            if existing is not None:
+                return existing["id"]
+            response = await client.post(
+                f"{_ADMIN_PREFIX}/users/",
+                json={"name": name, "organization_id": organization_id},
+            )
+            response.raise_for_status()
+            user = response.json()
+            logger.info(
+                "Created Letta user %r (id=%s) in organization %s",
+                name,
+                user["id"],
+                organization_id,
+            )
+            return user["id"]
+
+    def _client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=self._base_url,
+            headers=self._headers,
+            timeout=self._timeout_s,
+        )
+
+    @staticmethod
+    async def _paginated_find(
+        client: httpx.AsyncClient,
+        path: str,
+        *,
+        match: _Match,
+    ) -> dict | None:
+        """The first item on ``path`` satisfying ``match``, paging via ``after``.
+
+        Letta's own seeded default user has a null ``created_at``, and its
+        ``after``-cursor pagination silently drops the boundary filter
+        whenever ``after`` resolves to a null-``created_at`` row (confirmed
+        against ``letta/orm/sqlalchemy_base.py``'s ``_list_preprocess``) --
+        the next "page" comes back as the same unfiltered list again, always
+        ending on that same row once more. Advancing ``after`` to an
+        unchanged value is the signal that pagination has stalled; treating
+        it as exhaustion avoids looping forever instead of trying to detect
+        the null-created_at row directly (an implementation detail of a
+        response shape this client does not otherwise need to know).
+        """
+        after: str | None = None
+        while True:
+            response = await client.get(
+                path, params={"after": after} if after else None
+            )
+            response.raise_for_status()
+            page: list[dict] = response.json()
+            if not page:
+                return None
+            found = next((item for item in page if match(item)), None)
+            if found is not None:
+                return found
+            next_after = page[-1]["id"]
+            if next_after == after:
+                return None
+            after = next_after
+
+
+async def resolve_org_scoped_headers(
+    *, base_url: str, agent_name: str, bearer_token: str | None
+) -> dict[str, str]:
+    """Provision/reuse this instance's dedicated org+user; return {"user_id": ...}."""
+    if not agent_name.strip():
+        raise ValueError(
+            "agent_name must be non-blank to derive a Letta org-scoped identity"
+        )
+    scope_name = f"band-{agent_name}"
+    scope_client = LettaOrgScopeClient(base_url=base_url, bearer_token=bearer_token)
+    organization_id = await scope_client.find_or_create_organization(scope_name)
+    user_id = await scope_client.find_or_create_user(
+        scope_name, organization_id=organization_id
+    )
+    return {"user_id": user_id}

--- a/src/band/integrations/letta/orgscope.py
+++ b/src/band/integrations/letta/orgscope.py
@@ -15,7 +15,7 @@ exposed by the ``letta_client`` SDK, hence the raw ``httpx`` calls here.
 from __future__ import annotations
 
 import logging
-from typing import Callable
+from typing import Any, Callable
 
 import httpx
 
@@ -42,25 +42,23 @@ class LettaOrgScopeClient:
         bearer_token: str | None,
         timeout_s: float = _DEFAULT_TIMEOUT_S,
     ) -> None:
-        self._base_url = base_url.rstrip("/")
-        self._headers = (
-            {"Authorization": f"Bearer {bearer_token}"} if bearer_token else {}
+        headers = {"Authorization": f"Bearer {bearer_token}"} if bearer_token else {}
+        self._http = httpx.AsyncClient(
+            base_url=base_url.rstrip("/"), headers=headers, timeout=timeout_s
         )
-        self._timeout_s = timeout_s
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
 
     async def find_or_create_organization(self, name: str) -> str:
         """The id of the organization named ``name``, creating it if absent."""
-        async with self._client() as client:
-            existing = await self._paginated_find(
-                client, f"{_ADMIN_PREFIX}/orgs/", match=lambda org: org["name"] == name
-            )
-            if existing is not None:
-                return existing["id"]
-            response = await client.post(f"{_ADMIN_PREFIX}/orgs/", json={"name": name})
-            response.raise_for_status()
-            org = response.json()
-            logger.info("Created Letta organization %r (id=%s)", name, org["id"])
-            return org["id"]
+        org = await self._find_or_create(
+            f"{_ADMIN_PREFIX}/orgs/",
+            match=lambda org: org["name"] == name,
+            payload={"name": name},
+            log_label=f"organization {name!r}",
+        )
+        return org["id"]
 
     async def find_or_create_user(self, name: str, *, organization_id: str) -> str:
         """The id of the user named ``name`` under ``organization_id``.
@@ -72,44 +70,36 @@ class LettaOrgScopeClient:
         real possibility, not a hypothetical one, and matching by name
         alone would adopt it (landing in the wrong org).
         """
-        async with self._client() as client:
-            existing = await self._paginated_find(
-                client,
-                f"{_ADMIN_PREFIX}/users/",
-                match=lambda user: (
-                    user["name"] == name and user["organization_id"] == organization_id
-                ),
-            )
-            if existing is not None:
-                return existing["id"]
-            response = await client.post(
-                f"{_ADMIN_PREFIX}/users/",
-                json={"name": name, "organization_id": organization_id},
-            )
-            response.raise_for_status()
-            user = response.json()
-            logger.info(
-                "Created Letta user %r (id=%s) in organization %s",
-                name,
-                user["id"],
-                organization_id,
-            )
-            return user["id"]
-
-    def _client(self) -> httpx.AsyncClient:
-        return httpx.AsyncClient(
-            base_url=self._base_url,
-            headers=self._headers,
-            timeout=self._timeout_s,
+        user = await self._find_or_create(
+            f"{_ADMIN_PREFIX}/users/",
+            match=lambda user: (
+                user["name"] == name and user["organization_id"] == organization_id
+            ),
+            payload={"name": name, "organization_id": organization_id},
+            log_label=f"user {name!r} in organization {organization_id}",
         )
+        return user["id"]
 
-    @staticmethod
-    async def _paginated_find(
-        client: httpx.AsyncClient,
+    async def _find_or_create(
+        self,
         path: str,
         *,
         match: _Match,
-    ) -> dict | None:
+        payload: dict[str, Any],
+        log_label: str,
+    ) -> dict:
+        """The first item on ``path`` matching ``match``, creating one from
+        ``payload`` if none does."""
+        existing = await self._paginated_find(path, match=match)
+        if existing is not None:
+            return existing
+        response = await self._http.post(path, json=payload)
+        response.raise_for_status()
+        created = response.json()
+        logger.info("Created Letta %s (id=%s)", log_label, created["id"])
+        return created
+
+    async def _paginated_find(self, path: str, *, match: _Match) -> dict | None:
         """The first item on ``path`` satisfying ``match``, paging via ``after``.
 
         Letta's own seeded default user has a null ``created_at``, and its
@@ -125,7 +115,7 @@ class LettaOrgScopeClient:
         """
         after: str | None = None
         for _ in range(_MAX_PAGINATION_PAGES):
-            response = await client.get(
+            response = await self._http.get(
                 path, params={"after": after} if after else None
             )
             response.raise_for_status()
@@ -155,8 +145,11 @@ async def resolve_org_scoped_headers(
         )
     scope_name = f"band-{agent_name}"
     scope_client = LettaOrgScopeClient(base_url=base_url, bearer_token=bearer_token)
-    organization_id = await scope_client.find_or_create_organization(scope_name)
-    user_id = await scope_client.find_or_create_user(
-        scope_name, organization_id=organization_id
-    )
+    try:
+        organization_id = await scope_client.find_or_create_organization(scope_name)
+        user_id = await scope_client.find_or_create_user(
+            scope_name, organization_id=organization_id
+        )
+    finally:
+        await scope_client.aclose()
     return {"user_id": user_id}

--- a/tests/adapters/lettakit.py
+++ b/tests/adapters/lettakit.py
@@ -1,8 +1,9 @@
 """Shared factories for the Letta adapter tests.
 
 Mock builders for Letta API objects (messages, responses, agents,
-conversations, MCP servers/tools, async streams) and platform messages,
-used by both ``test_letta_adapter.py`` and ``test_letta_mcp.py``.
+conversations, MCP servers/tools, async streams) and platform messages, used
+by ``test_letta_adapter.py``, ``test_letta_mcp.py``, and
+``test_letta_orgscope.py``.
 """
 
 from __future__ import annotations
@@ -11,6 +12,8 @@ from datetime import datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
+
+from pytest_httpx import HTTPXMock
 
 from band.integrations.letta.prompts import render_tool_enforcement
 from band.core.types import PlatformMessage
@@ -125,6 +128,35 @@ def default_enforcement(room_id: str | None = None) -> str:
     """The enforcement preamble with the default (band_*) tool names."""
     return render_tool_enforcement(
         "band_send_message", "band_send_event", room_id=room_id
+    )
+
+
+def mock_org_user_provisioned(
+    httpx_mock: HTTPXMock,
+    *,
+    base_url: str,
+    org_id: str,
+    user_id: str,
+    name: str,
+) -> None:
+    """Wire httpx_mock for a fresh org+user provisioned under ``name``.
+
+    Matches the one-shot "no existing org/user" happy path that
+    ``resolve_org_scoped_headers`` exercises the first time an agent name is
+    seen. Tests covering pagination or name-conflict edge cases stay inline
+    next to what they cover — only the plain happy path is shared here.
+    """
+    httpx_mock.add_response(method="GET", url=f"{base_url}/v1/admin/orgs/", json=[])
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{base_url}/v1/admin/orgs/",
+        json={"id": org_id, "name": name},
+    )
+    httpx_mock.add_response(method="GET", url=f"{base_url}/v1/admin/users/", json=[])
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{base_url}/v1/admin/users/",
+        json={"id": user_id, "name": name, "organization_id": org_id},
     )
 
 

--- a/tests/adapters/test_deprecation_shims.py
+++ b/tests/adapters/test_deprecation_shims.py
@@ -158,6 +158,27 @@ class TestLettaApiKeyShim:
             LettaAdapterConfig(provider_key="new-key", api_key="old-key")
 
 
+class TestLettaOrgScopedConfig:
+    """org_scoped=True against Letta Cloud must fail at construction.
+
+    Letta Cloud does not expose the self-hosted-only admin API org_scoped
+    needs; honoring it would only fail deep inside on_started's real httpx
+    calls instead of failing loud up front.
+    """
+
+    def test_letta_org_scoped_and_cloud_conflict(self) -> None:
+        from band.adapters.letta import LettaAdapterConfig
+
+        with pytest.raises(BandConfigError, match="org_scoped=True"):
+            LettaAdapterConfig(org_scoped=True)
+
+    def test_letta_org_scoped_true_on_self_hosted_is_accepted(self) -> None:
+        from band.adapters.letta import LettaAdapterConfig
+
+        config = LettaAdapterConfig(base_url="http://localhost:8283", org_scoped=True)
+        assert config.org_scoped is True
+
+
 class TestLettaMCPKwargShim:
     """Legacy Letta MCP kwargs must populate the nested MCP config."""
 

--- a/tests/adapters/test_deprecation_shims.py
+++ b/tests/adapters/test_deprecation_shims.py
@@ -166,11 +166,19 @@ class TestLettaOrgScopedConfig:
     calls instead of failing loud up front.
     """
 
-    def test_letta_org_scoped_and_cloud_conflict(self) -> None:
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.letta.com",
+            "https://API.LETTA.COM/",
+            "  https://api.letta.com  ",
+        ],
+    )
+    def test_letta_org_scoped_and_cloud_conflict(self, base_url: str) -> None:
         from band.adapters.letta import LettaAdapterConfig
 
         with pytest.raises(BandConfigError, match="org_scoped=True"):
-            LettaAdapterConfig(org_scoped=True)
+            LettaAdapterConfig(base_url=base_url, org_scoped=True)
 
     def test_letta_org_scoped_true_on_self_hosted_is_accepted(self) -> None:
         from band.adapters.letta import LettaAdapterConfig

--- a/tests/adapters/test_deprecation_shims.py
+++ b/tests/adapters/test_deprecation_shims.py
@@ -172,6 +172,7 @@ class TestLettaOrgScopedConfig:
             "https://api.letta.com",
             "https://API.LETTA.COM/",
             "  https://api.letta.com  ",
+            "api.letta.com",
         ],
     )
     def test_letta_org_scoped_and_cloud_conflict(self, base_url: str) -> None:

--- a/tests/adapters/test_letta_mcp.py
+++ b/tests/adapters/test_letta_mcp.py
@@ -242,11 +242,21 @@ class TestLettaAdapterOnStarted:
         mock_client.tools.list.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_on_started_cloud_stays_unscoped(self) -> None:
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.letta.com",
+            "https://API.LETTA.COM/",
+            "  https://api.letta.com  ",
+        ],
+    )
+    async def test_on_started_cloud_stays_unscoped(self, base_url: str) -> None:
         """Regression guard: a Cloud base_url must never invoke org-scope
         resolution — the Cloud path stays byte-for-byte unchanged."""
         adapter = LettaAdapter(
-            config=LettaAdapterConfig(mcp=LettaMCPConfig(mode="external"))
+            config=LettaAdapterConfig(
+                base_url=base_url, mcp=LettaMCPConfig(mode="external")
+            )
         )
 
         mock_client = AsyncMock()
@@ -265,7 +275,7 @@ class TestLettaAdapterOnStarted:
 
         mock_resolve.assert_not_called()
         mock_letta_module.AsyncLetta.assert_called_once_with(
-            base_url="https://api.letta.com",
+            base_url=base_url,
         )
         mock_client.tools.list.assert_not_called()
 

--- a/tests/adapters/test_letta_mcp.py
+++ b/tests/adapters/test_letta_mcp.py
@@ -13,6 +13,7 @@ import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pytest_httpx import HTTPXMock
 
 from band.adapters.letta import (
     LettaAdapter,
@@ -191,6 +192,168 @@ class TestLettaAdapterOnStarted:
         with patch.dict("sys.modules", {"letta_client": mock_letta_module}):
             with pytest.raises(RuntimeError, match="MCP server registration failed"):
                 await adapter.on_started("TestBot", "A test bot")
+
+    @pytest.mark.asyncio
+    async def test_on_started_self_hosted_org_scoped_by_default(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        """A self-hosted base_url auto-enables org scoping: a dedicated
+        org+user is provisioned and its user_id becomes the client's default
+        header — this is what isolates MCP tool storage between instances."""
+        base_url = "http://localhost:8283"
+        adapter = LettaAdapter(
+            config=LettaAdapterConfig(
+                base_url=base_url, mcp=LettaMCPConfig(mode="external")
+            )
+        )
+
+        httpx_mock.add_response(method="GET", url=f"{base_url}/v1/admin/orgs/", json=[])
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{base_url}/v1/admin/orgs/",
+            json={"id": "org-1", "name": "band-TestBot"},
+        )
+        httpx_mock.add_response(
+            method="GET", url=f"{base_url}/v1/admin/users/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{base_url}/v1/admin/users/",
+            json={"id": "user-1", "name": "band-TestBot", "organization_id": "org-1"},
+        )
+
+        mock_client = AsyncMock()
+        mock_server = make_mock_mcp_server()
+        mock_client.mcp_servers.create.return_value = mock_server
+        mock_client.mcp_servers.tools.list.return_value = []
+
+        mock_letta_module = MagicMock()
+        mock_letta_module.AsyncLetta = MagicMock(return_value=mock_client)
+
+        with patch.dict("sys.modules", {"letta_client": mock_letta_module}):
+            await adapter.on_started("TestBot", "A test bot")
+
+        mock_letta_module.AsyncLetta.assert_called_once_with(
+            base_url=base_url,
+            default_headers={"user_id": "user-1"},
+        )
+        # Base tools must be force-seeded for the fresh org before any room
+        # can reach agents.create(include_base_tools=True).
+        mock_client.tools.list.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_on_started_cloud_stays_unscoped(self) -> None:
+        """Regression guard: a Cloud base_url must never invoke org-scope
+        resolution — the Cloud path stays byte-for-byte unchanged."""
+        adapter = LettaAdapter(
+            config=LettaAdapterConfig(mcp=LettaMCPConfig(mode="external"))
+        )
+
+        mock_client = AsyncMock()
+        mock_server = make_mock_mcp_server()
+        mock_client.mcp_servers.create.return_value = mock_server
+        mock_client.mcp_servers.tools.list.return_value = []
+
+        mock_letta_module = MagicMock()
+        mock_letta_module.AsyncLetta = MagicMock(return_value=mock_client)
+
+        with (
+            patch.dict("sys.modules", {"letta_client": mock_letta_module}),
+            patch("band.adapters.letta.resolve_org_scoped_headers") as mock_resolve,
+        ):
+            await adapter.on_started("TestBot", "A test bot")
+
+        mock_resolve.assert_not_called()
+        mock_letta_module.AsyncLetta.assert_called_once_with(
+            base_url="https://api.letta.com",
+        )
+        mock_client.tools.list.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_started_org_scoped_false_opts_out_on_self_hosted(
+        self,
+    ) -> None:
+        """org_scoped=False is the escape hatch: it opts a self-hosted
+        deployment back out of org scoping."""
+        adapter = LettaAdapter(
+            config=LettaAdapterConfig(
+                base_url="http://localhost:8283",
+                org_scoped=False,
+                mcp=LettaMCPConfig(mode="external"),
+            )
+        )
+
+        mock_client = AsyncMock()
+        mock_server = make_mock_mcp_server()
+        mock_client.mcp_servers.create.return_value = mock_server
+        mock_client.mcp_servers.tools.list.return_value = []
+
+        mock_letta_module = MagicMock()
+        mock_letta_module.AsyncLetta = MagicMock(return_value=mock_client)
+
+        with (
+            patch.dict("sys.modules", {"letta_client": mock_letta_module}),
+            patch("band.adapters.letta.resolve_org_scoped_headers") as mock_resolve,
+        ):
+            await adapter.on_started("TestBot", "A test bot")
+
+        mock_resolve.assert_not_called()
+        mock_letta_module.AsyncLetta.assert_called_once_with(
+            base_url="http://localhost:8283",
+        )
+
+    @pytest.mark.asyncio
+    async def test_on_started_two_instances_resolve_distinct_user_ids(
+        self,
+    ) -> None:
+        """Two adapter instances against the same self-hosted server must
+        resolve distinct org-scoped identities — the actual collision-
+        avoidance property this fix exists to provide."""
+        base_url = "http://localhost:8283"
+
+        def make_adapter() -> LettaAdapter:
+            return LettaAdapter(
+                config=LettaAdapterConfig(
+                    base_url=base_url, mcp=LettaMCPConfig(mode="external")
+                )
+            )
+
+        async def fake_resolve(
+            *, base_url: str, agent_name: str, bearer_token: str | None
+        ) -> dict[str, str]:
+            return {"user_id": f"user-{agent_name}"}
+
+        mock_client_a = AsyncMock()
+        mock_client_a.mcp_servers.create.return_value = make_mock_mcp_server()
+        mock_client_a.mcp_servers.tools.list.return_value = []
+        mock_client_b = AsyncMock()
+        mock_client_b.mcp_servers.create.return_value = make_mock_mcp_server()
+        mock_client_b.mcp_servers.tools.list.return_value = []
+
+        mock_letta_module = MagicMock()
+        mock_letta_module.AsyncLetta = MagicMock(
+            side_effect=[mock_client_a, mock_client_b]
+        )
+
+        with (
+            patch.dict("sys.modules", {"letta_client": mock_letta_module}),
+            patch(
+                "band.adapters.letta.resolve_org_scoped_headers",
+                side_effect=fake_resolve,
+            ),
+        ):
+            await make_adapter().on_started("AgentA", "Bot A")
+            await make_adapter().on_started("AgentB", "Bot B")
+
+        headers_a = mock_letta_module.AsyncLetta.call_args_list[0].kwargs[
+            "default_headers"
+        ]
+        headers_b = mock_letta_module.AsyncLetta.call_args_list[1].kwargs[
+            "default_headers"
+        ]
+        assert headers_a == {"user_id": "user-AgentA"}
+        assert headers_b == {"user_id": "user-AgentB"}
+        assert headers_a != headers_b
 
     @pytest.mark.asyncio
     async def test_on_started_import_error(self) -> None:

--- a/tests/adapters/test_letta_mcp.py
+++ b/tests/adapters/test_letta_mcp.py
@@ -32,6 +32,7 @@ from tests.adapters.lettakit import (
     make_mock_mcp_tool,
     make_mock_tool_page,
     make_platform_message,
+    mock_org_user_provisioned,
 )
 
 
@@ -207,19 +208,12 @@ class TestLettaAdapterOnStarted:
             )
         )
 
-        httpx_mock.add_response(method="GET", url=f"{base_url}/v1/admin/orgs/", json=[])
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{base_url}/v1/admin/orgs/",
-            json={"id": "org-1", "name": "band-TestBot"},
-        )
-        httpx_mock.add_response(
-            method="GET", url=f"{base_url}/v1/admin/users/", json=[]
-        )
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{base_url}/v1/admin/users/",
-            json={"id": "user-1", "name": "band-TestBot", "organization_id": "org-1"},
+        mock_org_user_provisioned(
+            httpx_mock,
+            base_url=base_url,
+            org_id="org-1",
+            user_id="user-1",
+            name="band-TestBot",
         )
 
         mock_client = AsyncMock()
@@ -311,59 +305,6 @@ class TestLettaAdapterOnStarted:
         mock_letta_module.AsyncLetta.assert_called_once_with(
             base_url="http://localhost:8283",
         )
-
-    @pytest.mark.asyncio
-    async def test_on_started_two_instances_resolve_distinct_user_ids(
-        self,
-    ) -> None:
-        """Two adapter instances against the same self-hosted server must
-        resolve distinct org-scoped identities — the actual collision-
-        avoidance property this fix exists to provide."""
-        base_url = "http://localhost:8283"
-
-        def make_adapter() -> LettaAdapter:
-            return LettaAdapter(
-                config=LettaAdapterConfig(
-                    base_url=base_url, mcp=LettaMCPConfig(mode="external")
-                )
-            )
-
-        async def fake_resolve(
-            *, base_url: str, agent_name: str, bearer_token: str | None
-        ) -> dict[str, str]:
-            return {"user_id": f"user-{agent_name}"}
-
-        mock_client_a = AsyncMock()
-        mock_client_a.mcp_servers.create.return_value = make_mock_mcp_server()
-        mock_client_a.mcp_servers.tools.list.return_value = []
-        mock_client_b = AsyncMock()
-        mock_client_b.mcp_servers.create.return_value = make_mock_mcp_server()
-        mock_client_b.mcp_servers.tools.list.return_value = []
-
-        mock_letta_module = MagicMock()
-        mock_letta_module.AsyncLetta = MagicMock(
-            side_effect=[mock_client_a, mock_client_b]
-        )
-
-        with (
-            patch.dict("sys.modules", {"letta_client": mock_letta_module}),
-            patch(
-                "band.adapters.letta.resolve_org_scoped_headers",
-                side_effect=fake_resolve,
-            ),
-        ):
-            await make_adapter().on_started("AgentA", "Bot A")
-            await make_adapter().on_started("AgentB", "Bot B")
-
-        headers_a = mock_letta_module.AsyncLetta.call_args_list[0].kwargs[
-            "default_headers"
-        ]
-        headers_b = mock_letta_module.AsyncLetta.call_args_list[1].kwargs[
-            "default_headers"
-        ]
-        assert headers_a == {"user_id": "user-AgentA"}
-        assert headers_b == {"user_id": "user-AgentB"}
-        assert headers_a != headers_b
 
     @pytest.mark.asyncio
     async def test_on_started_import_error(self) -> None:

--- a/tests/adapters/test_letta_orgscope.py
+++ b/tests/adapters/test_letta_orgscope.py
@@ -1,0 +1,267 @@
+"""Unit tests for Letta self-hosted org/user provisioning (INT-985).
+
+Interception is the maintained ``pytest-httpx`` ``httpx_mock`` fixture (the
+pattern in ``tests/platform/test_link_credentials.py``) — it patches httpx
+globally, so it observes ``LettaOrgScopeClient``'s real per-call
+``httpx.AsyncClient`` with no injected seam.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from band.integrations.letta.orgscope import (
+    LettaOrgScopeClient,
+    resolve_org_scoped_headers,
+)
+
+_BASE_URL = "http://localhost:8283"
+
+
+def _client(*, bearer_token: str | None = None) -> LettaOrgScopeClient:
+    return LettaOrgScopeClient(base_url=_BASE_URL, bearer_token=bearer_token)
+
+
+class TestFindOrCreateOrganization:
+    async def test_no_match_creates(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET", url=f"{_BASE_URL}/v1/admin/orgs/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/orgs/",
+            json={"id": "org-new", "name": "band-x"},
+        )
+
+        org_id = await _client().find_or_create_organization("band-x")
+
+        assert org_id == "org-new"
+
+    async def test_match_on_first_page_skips_create(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/orgs/",
+            json=[{"id": "org-1", "name": "band-x"}],
+        )
+
+        org_id = await _client().find_or_create_organization("band-x")
+
+        assert org_id == "org-1"
+        assert len(httpx_mock.get_requests(method="POST")) == 0
+
+    async def test_match_on_second_page_paginates(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/orgs/",
+            json=[{"id": "org-1", "name": "other"}],
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/orgs/?after=org-1",
+            json=[{"id": "org-2", "name": "band-x"}],
+        )
+
+        org_id = await _client().find_or_create_organization("band-x")
+
+        assert org_id == "org-2"
+        assert len(httpx_mock.get_requests(method="GET")) == 2
+        assert len(httpx_mock.get_requests(method="POST")) == 0
+
+
+class TestFindOrCreateUser:
+    async def test_no_match_creates(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET", url=f"{_BASE_URL}/v1/admin/users/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/users/",
+            json={"id": "user-new", "name": "band-x", "organization_id": "org-1"},
+        )
+
+        user_id = await _client().find_or_create_user("band-x", organization_id="org-1")
+
+        assert user_id == "user-new"
+        create_request = httpx_mock.get_requests(method="POST")[0]
+        assert json.loads(create_request.content) == {
+            "name": "band-x",
+            "organization_id": "org-1",
+        }
+
+    async def test_match_on_first_page_skips_create(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/users/",
+            json=[{"id": "user-1", "name": "band-x", "organization_id": "org-1"}],
+        )
+
+        user_id = await _client().find_or_create_user("band-x", organization_id="org-1")
+
+        assert user_id == "user-1"
+        assert len(httpx_mock.get_requests(method="POST")) == 0
+
+    async def test_match_on_second_page_paginates(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/users/",
+            json=[{"id": "user-1", "name": "other", "organization_id": "org-1"}],
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/users/?after=user-1",
+            json=[{"id": "user-2", "name": "band-x", "organization_id": "org-1"}],
+        )
+
+        user_id = await _client().find_or_create_user("band-x", organization_id="org-1")
+
+        assert user_id == "user-2"
+        assert len(httpx_mock.get_requests(method="POST")) == 0
+
+    async def test_same_name_different_org_is_not_a_match(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        """Regression guard: a same-named user under a different org must not
+        be adopted — that would land this instance in the wrong org, exactly
+        the collision this fix exists to prevent (GET /v1/admin/users/ lists
+        across the whole instance, not one organization).
+        """
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/users/",
+            json=[{"id": "user-X", "name": "band-Bob", "organization_id": "org-X"}],
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/users/?after=user-X",
+            json=[],
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/users/",
+            json={"id": "user-Y", "name": "band-Bob", "organization_id": "org-Y"},
+        )
+
+        user_id = await _client().find_or_create_user(
+            "band-Bob", organization_id="org-Y"
+        )
+
+        assert user_id == "user-Y"
+        assert user_id != "user-X"
+
+    async def test_stalled_after_cursor_terminates_instead_of_looping_forever(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        """Regression guard: Letta's own seeded default user has a null
+        created_at, and GET /v1/admin/users/ silently drops the after
+        boundary filter whenever after resolves to that row (confirmed live
+        against letta/letta:0.16.8) -- the "next page" comes back as the
+        exact same unfiltered list, forever. Without stall detection this
+        hangs instead of concluding "not found".
+        """
+        stalled_page = [
+            {
+                "id": "user-default",
+                "name": "default_user",
+                "organization_id": "org-default",
+            }
+        ]
+        httpx_mock.add_response(
+            method="GET", url=f"{_BASE_URL}/v1/admin/users/", json=stalled_page
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{_BASE_URL}/v1/admin/users/?after=user-default",
+            json=stalled_page,
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/users/",
+            json={"id": "user-new", "name": "band-x", "organization_id": "org-1"},
+        )
+
+        user_id = await _client().find_or_create_user("band-x", organization_id="org-1")
+
+        assert user_id == "user-new"
+        assert len(httpx_mock.get_requests(method="GET")) == 2
+
+
+class TestAuthPassthrough:
+    async def test_bearer_token_sent_when_set(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET", url=f"{_BASE_URL}/v1/admin/orgs/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/orgs/",
+            json={"id": "org-1", "name": "band-x"},
+        )
+
+        await _client(bearer_token="secret").find_or_create_organization("band-x")
+
+        for request in httpx_mock.get_requests():
+            assert request.headers["Authorization"] == "Bearer secret"
+
+    async def test_no_authorization_header_when_unset(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            method="GET", url=f"{_BASE_URL}/v1/admin/orgs/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/orgs/",
+            json={"id": "org-1", "name": "band-x"},
+        )
+
+        await _client(bearer_token=None).find_or_create_organization("band-x")
+
+        for request in httpx_mock.get_requests():
+            assert "Authorization" not in request.headers
+
+
+class TestResolveOrgScopedHeaders:
+    async def test_end_to_end_provisions_org_then_user(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        httpx_mock.add_response(
+            method="GET", url=f"{_BASE_URL}/v1/admin/orgs/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/orgs/",
+            json={"id": "org-1", "name": "band-my-agent"},
+        )
+        httpx_mock.add_response(
+            method="GET", url=f"{_BASE_URL}/v1/admin/users/", json=[]
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{_BASE_URL}/v1/admin/users/",
+            json={"id": "user-1", "name": "band-my-agent", "organization_id": "org-1"},
+        )
+
+        headers = await resolve_org_scoped_headers(
+            base_url=_BASE_URL, agent_name="my-agent", bearer_token=None
+        )
+
+        assert headers == {"user_id": "user-1"}
+        assert len(httpx_mock.get_requests(url=f"{_BASE_URL}/v1/admin/orgs/")) == 2
+        assert len(httpx_mock.get_requests(url=f"{_BASE_URL}/v1/admin/users/")) == 2
+
+    @pytest.mark.parametrize("agent_name", ["", "   ", "\t\n"])
+    async def test_blank_agent_name_raises_before_any_http_call(
+        self, httpx_mock: HTTPXMock, agent_name: str
+    ) -> None:
+        with pytest.raises(ValueError, match="agent_name"):
+            await resolve_org_scoped_headers(
+                base_url=_BASE_URL, agent_name=agent_name, bearer_token=None
+            )
+
+        assert httpx_mock.get_requests() == []

--- a/tests/adapters/test_letta_orgscope.py
+++ b/tests/adapters/test_letta_orgscope.py
@@ -13,10 +13,12 @@ import json
 import pytest
 from pytest_httpx import HTTPXMock
 
+from band.integrations.letta import orgscope
 from band.integrations.letta.orgscope import (
     LettaOrgScopeClient,
     resolve_org_scoped_headers,
 )
+from tests.adapters.lettakit import mock_org_user_provisioned
 
 _BASE_URL = "http://localhost:8283"
 
@@ -191,6 +193,24 @@ class TestFindOrCreateUser:
         assert user_id == "user-new"
         assert len(httpx_mock.get_requests(method="GET")) == 2
 
+    async def test_pagination_gives_up_after_max_pages(
+        self, httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression guard: a cursor that keeps advancing without ever
+        emptying or stalling must not loop forever — a page-count circuit
+        breaker bounds it and fails loud instead."""
+        monkeypatch.setattr(orgscope, "_MAX_PAGINATION_PAGES", 2)
+        for i in range(2):
+            after = f"?after=user-{i - 1}" if i else ""
+            httpx_mock.add_response(
+                method="GET",
+                url=f"{_BASE_URL}/v1/admin/users/{after}",
+                json=[{"id": f"user-{i}", "name": "other", "organization_id": "org-1"}],
+            )
+
+        with pytest.raises(RuntimeError, match="did not terminate"):
+            await _client().find_or_create_user("band-x", organization_id="org-1")
+
 
 class TestAuthPassthrough:
     async def test_bearer_token_sent_when_set(self, httpx_mock: HTTPXMock) -> None:
@@ -230,21 +250,12 @@ class TestResolveOrgScopedHeaders:
     async def test_end_to_end_provisions_org_then_user(
         self, httpx_mock: HTTPXMock
     ) -> None:
-        httpx_mock.add_response(
-            method="GET", url=f"{_BASE_URL}/v1/admin/orgs/", json=[]
-        )
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{_BASE_URL}/v1/admin/orgs/",
-            json={"id": "org-1", "name": "band-my-agent"},
-        )
-        httpx_mock.add_response(
-            method="GET", url=f"{_BASE_URL}/v1/admin/users/", json=[]
-        )
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{_BASE_URL}/v1/admin/users/",
-            json={"id": "user-1", "name": "band-my-agent", "organization_id": "org-1"},
+        mock_org_user_provisioned(
+            httpx_mock,
+            base_url=_BASE_URL,
+            org_id="org-1",
+            user_id="user-1",
+            name="band-my-agent",
         )
 
         headers = await resolve_org_scoped_headers(

--- a/tests/adapters/test_letta_orgscope.py
+++ b/tests/adapters/test_letta_orgscope.py
@@ -1,8 +1,8 @@
-"""Unit tests for Letta self-hosted org/user provisioning (INT-985).
+"""Unit tests for Letta self-hosted org/user provisioning.
 
 Interception is the maintained ``pytest-httpx`` ``httpx_mock`` fixture (the
 pattern in ``tests/platform/test_link_credentials.py``) — it patches httpx
-globally, so it observes ``LettaOrgScopeClient``'s real per-call
+globally, so it observes ``LettaOrgScopeClient``'s real
 ``httpx.AsyncClient`` with no injected seam.
 """
 

--- a/tests/e2e/baseline/smoke/matrix/test_rehydration_partial.py
+++ b/tests/e2e/baseline/smoke/matrix/test_rehydration_partial.py
@@ -88,14 +88,6 @@ from tests.e2e.baseline.toolkit.user_ops import UserOps
             "(langgraph-adapter behaviour under investigation)",
         ),
         ExcludedAdapter(
-            Adapter.LETTA,
-            "self-hosted Letta shares one org-wide send-message tool across "
-            "co-located agents, so a second live agent's reply routes through the "
-            "most-recently-registered adapter's MCP server and posts under the "
-            "wrong identity — the stayer-scoped reply is never observed. Needs "
-            "per-instance tool-name isolation to run two Letta agents in one org",
-        ),
-        ExcludedAdapter(
             Adapter.CREWAI_FLOW,
             "terminal echo flow with no memory — cannot rehydrate context across a "
             "reboot",

--- a/tests/e2e/baseline/smoke/matrix/test_rehydration_partial.py
+++ b/tests/e2e/baseline/smoke/matrix/test_rehydration_partial.py
@@ -37,14 +37,15 @@ rehydration itself works — the gap is specific to replying after a reboot in a
 live multi-agent room). Tracked as a langgraph-adapter behaviour to investigate;
 excluded here so the scenario stays green for the adapters that support it.
 
-Excludes ``letta`` for a different reason confirmed live: the self-hosted Letta
-adapter registers its Band MCP tool server per instance, but Letta stores MCP tools
-by name at organization scope and re-points the shared ``band_send_message`` row to
-whichever instance registered most recently. With two Letta agents live in one org,
-the rebooted agent *does* answer, but its send routes through the peer's MCP server
-and posts under the peer's identity, so the stayer-scoped reply is never observed.
-Fixing it needs per-instance tool-name isolation (or per-agent Letta project/org
-scoping); until then two Letta agents cannot keep separate identities in one org.
+``letta`` was previously excluded here for a different reason, confirmed live: the
+self-hosted Letta adapter registered its Band MCP tool server per instance, but
+Letta stored MCP tools by name at organization scope and re-pointed the shared
+``band_send_message`` row to whichever instance registered most recently. With two
+Letta agents live in one org, the rebooted agent *did* answer, but its send routed
+through the peer's MCP server and posted under the peer's identity, so the
+stayer-scoped reply was never observed. INT-985 fixed this by provisioning each
+adapter instance its own Letta organization/user, so ``letta`` now runs this
+scenario like every other adapter.
 
 Wording note: a neutral "note", not a "secret code" (models refuse to echo a
 credential-shaped value — an unrelated false failure).

--- a/tests/e2e/baseline/smoke/matrix/test_rehydration_partial.py
+++ b/tests/e2e/baseline/smoke/matrix/test_rehydration_partial.py
@@ -43,7 +43,7 @@ Letta stored MCP tools by name at organization scope and re-pointed the shared
 ``band_send_message`` row to whichever instance registered most recently. With two
 Letta agents live in one org, the rebooted agent *did* answer, but its send routed
 through the peer's MCP server and posted under the peer's identity, so the
-stayer-scoped reply was never observed. INT-985 fixed this by provisioning each
+stayer-scoped reply was never observed. This was fixed by provisioning each
 adapter instance its own Letta organization/user, so ``letta`` now runs this
 scenario like every other adapter.
 

--- a/tests/integration/test_letta_live.py
+++ b/tests/integration/test_letta_live.py
@@ -26,8 +26,12 @@ Run with:
 
 from __future__ import annotations
 
+from uuid import uuid4
+
 import pytest
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from band.integrations.letta.orgscope import resolve_org_scoped_headers
 
 pytestmark = pytest.mark.requires_api
 
@@ -52,19 +56,43 @@ LETTA_EMBEDDING = _SETTINGS.letta_embedding
 LETTA_MCP_ADVERTISED_HOST = _SETTINGS.letta_mcp_advertised_host
 
 
-def _make_client() -> object:
+# A fixed name for the raw-client tests below: they all share one Letta
+# org/user (as opposed to test_two_instances_stay_isolated_in_shared_org,
+# which deliberately uses two).
+_RAW_CLIENT_AGENT_NAME = "IntegrationBotRawClient"
+
+
+async def _make_client() -> object:
+    """An org-scoped Letta client, matching how the adapter builds its own.
+
+    Once CI's Letta server sets LETTA_NO_DEFAULT_ACTOR=true (see
+    .github/scripts/setup-letta.sh), a client with no user_id header raises
+    on every call instead of silently falling back to the default org — so
+    this helper must resolve org-scoped headers the same way the adapter's
+    on_started does, not rely on the default org.
+    """
     from letta_client import AsyncLetta
 
-    client_kwargs: dict[str, str] = {"base_url": LETTA_BASE_URL}
+    client_kwargs: dict[str, object] = {"base_url": LETTA_BASE_URL}
     if LETTA_API_KEY:
         client_kwargs["api_key"] = LETTA_API_KEY
-    return AsyncLetta(**client_kwargs)
+    client_kwargs["default_headers"] = await resolve_org_scoped_headers(
+        base_url=LETTA_BASE_URL,
+        agent_name=_RAW_CLIENT_AGENT_NAME,
+        bearer_token=LETTA_API_KEY or None,
+    )
+    client = AsyncLetta(**client_kwargs)
+    # A fresh org has zero Tool rows; force the lazy base-tool seed (see
+    # LettaAdapter.on_started) before these tests' agents.create(
+    # include_base_tools=True) calls, which would otherwise raise.
+    await client.tools.list()
+    return client
 
 
 @pytest.mark.asyncio
 async def test_existing_agent_message() -> None:
     """Send a message to a pre-existing Letta agent and verify response."""
-    client = _make_client()
+    client = await _make_client()
 
     # Create a temporary agent for this test
     # The server rejects an agent create without a model; the Docker server
@@ -127,9 +155,94 @@ async def test_adapter_self_hosted_mcp_registration() -> None:
 
 
 @pytest.mark.asyncio
+async def test_two_instances_stay_isolated_in_shared_org() -> None:
+    """Two adapter instances on one shared self-hosted Letta stay isolated.
+
+    Regression test for the org+user scoping fix (INT-985): without it,
+    Letta dedupes MCP-discovered Tool rows by (name, organization_id), so a
+    second instance's registration silently re-points the first instance's
+    band_send_message tool row to its own MCP server — the first instance's
+    agent then routes tool calls into the wrong instance's identity.
+    """
+    from letta_client import NotFoundError
+
+    from band.adapters.letta import LettaAdapter, LettaAdapterConfig, LettaMCPConfig
+
+    loopback = LETTA_MCP_ADVERTISED_HOST in ("127.0.0.1", "localhost")
+    # A unique suffix per run guarantees each adapter lands in a genuinely
+    # fresh org (not an already-seeded one from a prior run), which is what
+    # makes the agents.create() calls below a real proof of the base-tool
+    # bootstrap in on_started.
+    suffix = uuid4().hex[:8]
+
+    def make_adapter() -> LettaAdapter:
+        return LettaAdapter(
+            config=LettaAdapterConfig(
+                base_url=LETTA_BASE_URL,
+                provider_key=LETTA_API_KEY or None,
+                model=LETTA_MODEL,
+                embedding=LETTA_EMBEDDING,
+                mcp=LettaMCPConfig(
+                    bind_host="127.0.0.1" if loopback else "0.0.0.0",
+                    advertised_host=LETTA_MCP_ADVERTISED_HOST,
+                ),
+            ),
+        )
+
+    async def send_message_tool_metadata(adapter: LettaAdapter) -> dict:
+        # tools.list() returns an async paginator, not a plain list -- must
+        # be async-iterated (or awaited for just the first page), never
+        # looped over directly.
+        tool_name = adapter._mcp.send_message_tool
+        matches = [t async for t in adapter._client.tools.list(name=tool_name)]
+        assert matches, f"tool {tool_name!r} not found"
+        tool = matches[0]
+        assert tool.metadata is not None
+        return tool.metadata
+
+    adapter_a = make_adapter()
+    adapter_b = make_adapter()
+    try:
+        await adapter_a.on_started(f"IsolationBotA-{suffix}", "Isolation test bot A")
+        meta_a_before = await send_message_tool_metadata(adapter_a)
+
+        await adapter_b.on_started(f"IsolationBotB-{suffix}", "Isolation test bot B")
+        meta_b = await send_message_tool_metadata(adapter_b)
+
+        user_id_a = adapter_a._client.default_headers["user_id"]
+        user_id_b = adapter_b._client.default_headers["user_id"]
+        assert user_id_a != user_id_b
+
+        # B registering its own MCP server must not repoint A's tool row —
+        # the exact collision this fix exists to prevent.
+        meta_a_after = await send_message_tool_metadata(adapter_a)
+        assert meta_a_before["mcp"]["server_id"] == meta_a_after["mcp"]["server_id"]
+        assert meta_a_after["mcp"]["server_id"] != meta_b["mcp"]["server_id"]
+
+        # Fresh-org agent creation succeeds for both — proves the tools.list()
+        # bootstrap in on_started actually seeded base tools; without it this
+        # raises before either agent exists.
+        agent_id_a = await adapter_a._create_agent()
+        agent_id_b = await adapter_b._create_agent()
+
+        # Cross-org visibility: neither instance's client can retrieve the
+        # other's agent, but each can retrieve its own.
+        with pytest.raises(NotFoundError):
+            await adapter_b._client.agents.retrieve(agent_id_a)
+        await adapter_a._client.agents.retrieve(agent_id_a)
+
+        with pytest.raises(NotFoundError):
+            await adapter_a._client.agents.retrieve(agent_id_b)
+        await adapter_b._client.agents.retrieve(agent_id_b)
+    finally:
+        await adapter_a.cleanup_all()
+        await adapter_b.cleanup_all()
+
+
+@pytest.mark.asyncio
 async def test_conversations_api() -> None:
     """Test the Conversations API for shared agent mode."""
-    client = _make_client()
+    client = await _make_client()
 
     # Create agent
     # The server rejects an agent create without a model; the Docker server

--- a/tests/integration/test_letta_live.py
+++ b/tests/integration/test_letta_live.py
@@ -158,7 +158,7 @@ async def test_adapter_self_hosted_mcp_registration() -> None:
 async def test_two_instances_stay_isolated_in_shared_org() -> None:
     """Two adapter instances on one shared self-hosted Letta stay isolated.
 
-    Regression test for the org+user scoping fix (INT-985): without it,
+    Regression test for the org+user scoping fix: without it,
     Letta dedupes MCP-discovered Tool rows by (name, organization_id), so a
     second instance's registration silently re-points the first instance's
     band_send_message tool row to its own MCP server — the first instance's

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -16,10 +16,12 @@ conftest when building oneshot/REST-side fixtures.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from band_rest import (
     AgentMe,
     ChatMessage,
@@ -32,6 +34,18 @@ from band_rest import (
 
 from band.core.types import PlatformConnection, PlatformMessage
 from band.runtime.presence import RoomPresence
+
+
+async def wait_for_condition(
+    predicate, *, timeout: float = 1.0, interval: float = 0.01
+) -> None:
+    """Wait until a predicate becomes true, failing fast on timeout."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(interval)
+    pytest.fail("Timed out waiting for condition")
 
 
 def admit_room(presence: RoomPresence, room_id: str) -> None:

--- a/tests/runtime/test_execution.py
+++ b/tests/runtime/test_execution.py
@@ -27,6 +27,7 @@ from tests.conftest import (
     make_participant_mock,
     make_participant_removed_event,
 )
+from tests.runtime.conftest import wait_for_condition
 
 
 @pytest.fixture
@@ -184,8 +185,7 @@ class TestExecutionContextEvents:
         event = make_message_event(room_id="room-123", msg_id="msg-1", content="Hello")
         await ctx.on_event(event)
 
-        # Wait for processing
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: mock_handler.call_count >= 1)
 
         mock_handler.assert_called()
         call_args = mock_handler.call_args[0]
@@ -204,9 +204,9 @@ class TestExecutionContextEvents:
 
         # Send same message twice
         await ctx.on_event(event)
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: mock_handler.call_count >= 1)
         await ctx.on_event(event)
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: ctx.queue.qsize() == 0)
 
         # Should only be called once
         assert mock_handler.call_count == 1
@@ -559,7 +559,7 @@ class TestExecutionContextParticipantEvents:
             type="User",
         )
         await ctx.on_event(event)
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: ctx.queue.qsize() == 0)
 
         assert any(p["id"] == "user-2" for p in ctx.participants)
 
@@ -579,7 +579,7 @@ class TestExecutionContextParticipantEvents:
             participant_id="user-1",
         )
         await ctx.on_event(event)
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: ctx.queue.qsize() == 0)
 
         assert not any(p["id"] == "user-1" for p in ctx.participants)
 
@@ -678,7 +678,7 @@ class TestCrashRecoverySync:
         ctx = ExecutionContext("room-123", mock_link_with_next, mock_handler)
 
         await ctx.start()
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: ctx._sync_complete)
 
         assert ctx._sync_complete is True
         mock_link_with_next.get_next_message.assert_called()
@@ -717,7 +717,7 @@ class TestCrashRecoverySync:
         )
 
         await ctx.start()
-        await asyncio.sleep(0.2)
+        await wait_for_condition(lambda: mock_handler.call_count >= 1)
 
         # Handler should be called for backlog message
         assert mock_handler.call_count >= 1
@@ -763,7 +763,7 @@ class TestCrashRecoverySync:
 
         # Start should sync and find sync point
         await ctx.start()
-        await asyncio.sleep(0.2)
+        await wait_for_condition(lambda: ctx._sync_complete)
 
         # Marker should be cleared
         assert ctx._first_ws_msg_id is None
@@ -818,7 +818,12 @@ class TestCrashRecoverySync:
 
         # Start triggers sync
         await ctx.start()
-        await asyncio.sleep(0.2)
+        # Two handler dispatches expected (sync message + participant event);
+        # queue must be fully drained so Phase 2's participant processing has
+        # also settled, not just the sync-point crash-recovery phase.
+        await wait_for_condition(
+            lambda: mock_handler.call_count >= 2 and ctx.queue.qsize() == 0
+        )
 
         # Sync point reached and duplicate removed from WS phase
         assert ctx._first_ws_msg_id is None
@@ -861,7 +866,7 @@ class TestCrashRecoverySync:
             config=SessionConfig(enable_context_hydration=False),
         )
         await ctx.start()
-        await asyncio.sleep(0.05)
+        await wait_for_condition(lambda: ctx._sync_complete)
 
         event = make_message_event(
             room_id="room-123",
@@ -872,7 +877,7 @@ class TestCrashRecoverySync:
             ),
         )
         await ctx.on_event(event)
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: ctx.queue.qsize() == 0)
 
         mock_handler.assert_not_called()
         mock_link_with_next.mark_processing.assert_not_called()
@@ -907,11 +912,11 @@ class TestCrashRecoverySync:
             config=SessionConfig(enable_context_hydration=True),
         )
         await ctx.start()
-        await asyncio.sleep(0.05)
+        await wait_for_condition(lambda: ctx._sync_complete)
 
         event = make_message_event(room_id="room-123", msg_id="msg-stale-replay")
         await ctx.on_event(event)
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: ctx.queue.qsize() == 0)
 
         mock_handler.assert_not_called()
         mock_link_with_next.mark_processing.assert_not_called()
@@ -964,7 +969,9 @@ class TestCrashRecoverySync:
         )
 
         await ctx.start()
-        await asyncio.sleep(0.2)
+        await wait_for_condition(
+            lambda: mock_link_with_next.mark_processed.call_count >= 1
+        )
 
         mock_link_with_next.mark_processing.assert_called_once_with(
             "room-123", "msg-pending-down"
@@ -1077,7 +1084,10 @@ class TestCrashRecoverySync:
         await ctx.on_event(make_message_event(room_id="room-123", msg_id="msg-first"))
 
         release_handler.set()
-        await asyncio.sleep(0.2)  # Let sync finish and Phase 2 drain the WS copy
+        # Let sync finish and Phase 2 drain the WS copy.
+        await wait_for_condition(
+            lambda: mock_link_with_next.mark_processed.await_count >= 1
+        )
 
         assert handled_message_ids == ["msg-first"]
         assert mock_link_with_next.mark_processing.await_count == 1
@@ -1399,10 +1409,12 @@ class TestCrashRecoverySync:
         )
 
         await ctx.start()
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: ctx._sync_complete)
         await ctx.on_event(make_message_event(room_id="room-123", msg_id="msg-old-ws"))
         await ctx.on_event(make_message_event(room_id="room-123", msg_id="msg-new-ws"))
-        await asyncio.sleep(0.3)
+        await wait_for_condition(
+            lambda: mock_link_with_next.mark_processed.await_count >= 3
+        )
 
         assert [call.args[1].payload.id for call in mock_handler.await_args_list] == [
             "msg-old-ws",
@@ -1491,7 +1503,9 @@ class TestCrashRecoverySync:
             make_message_event(room_id="room-123", msg_id="msg-sync-claim-fails")
         )
         await ctx.start()
-        await asyncio.sleep(0.2)
+        await wait_for_condition(
+            lambda: mock_link_with_next.mark_processing.await_count >= 1
+        )
 
         assert ctx._first_ws_msg_id == "msg-sync-claim-fails"
         mock_handler.assert_not_called()
@@ -1569,7 +1583,9 @@ class TestCrashRecoverySync:
             make_message_event(room_id="room-123", msg_id="msg-newer-ws")
         )
         await ctx.start()
-        await asyncio.sleep(0.2)
+        await wait_for_condition(
+            lambda: mock_link_with_next.mark_processing.await_count >= 1
+        )
 
         mock_link_with_next.mark_processing.assert_awaited_once_with(
             "room-123", "msg-older-claim-fails"
@@ -1646,12 +1662,14 @@ class TestCrashRecoverySync:
         )
 
         await ctx.start()
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: ctx._sync_complete)
         await ctx.request_resync()
         await ctx.on_event(
             make_message_event(room_id="room-123", msg_id="msg-resync-newer-ws")
         )
-        await asyncio.sleep(0.2)
+        await wait_for_condition(
+            lambda: mock_link_with_next.mark_processing.await_count >= 1
+        )
 
         mock_link_with_next.mark_processing.assert_awaited_once_with(
             "room-123", "msg-resync-older-claim-fails"
@@ -1693,7 +1711,7 @@ class TestCrashRecoverySync:
         ctx._retry_tracker.mark_permanently_failed("msg-failed-001")
 
         await ctx.start()
-        await asyncio.sleep(0.2)
+        await wait_for_condition(lambda: ctx._sync_complete)
 
         # Handler should NOT be called for failed message
         assert mock_handler.call_count == 0
@@ -1860,14 +1878,14 @@ class TestCancellationDuringProcessing:
         await ctx.start()
 
         # Wait for sync to complete
-        await asyncio.sleep(0.05)
+        await wait_for_condition(lambda: ctx._sync_complete)
 
         # Enqueue a message to trigger processing
         event = make_message_event(room_id="room-123", msg_id="msg-001", content="Test")
         await ctx.on_event(event)
 
-        # Give time to start processing
-        await asyncio.sleep(0.05)
+        # Wait for the slow handler to actually be in flight
+        await wait_for_condition(lambda: ctx.is_processing)
 
         # Stop should cancel processing
         start = asyncio.get_running_loop().time()
@@ -2093,11 +2111,11 @@ class TestContextCacheTTL:
         ctx._context_hydrated = True
 
         await ctx.start()
-        await asyncio.sleep(0.05)
+        await wait_for_condition(lambda: ctx._sync_complete)
 
         event = make_message_event(room_id="room-123", msg_id="msg-ttl")
         await ctx.on_event(event)
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: mock_handler.call_count >= 1)
 
         mock_handler.assert_called()
         assert mock_link.rest.agent_api_context.get_agent_chat_context.await_count == 1
@@ -2126,7 +2144,7 @@ class TestParticipantCallbacks:
             on_participant_added=on_participant_added,
         )
         await ctx.start()
-        await asyncio.sleep(0.05)
+        await wait_for_condition(lambda: ctx._sync_complete)
 
         event = make_participant_added_event(
             room_id="room-123",
@@ -2134,7 +2152,7 @@ class TestParticipantCallbacks:
             name="User Two",
         )
         await ctx.on_event(event)
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: mock_handler.await_count >= 1)
 
         on_participant_added.assert_awaited_once_with("room-123", event)
         mock_handler.assert_awaited_once()
@@ -2158,14 +2176,14 @@ class TestParticipantCallbacks:
             on_participant_removed=on_participant_removed,
         )
         await ctx.start()
-        await asyncio.sleep(0.05)
+        await wait_for_condition(lambda: ctx._sync_complete)
 
         event = make_participant_removed_event(
             room_id="room-123",
             participant_id="user-1",
         )
         await ctx.on_event(event)
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: mock_handler.await_count >= 1)
 
         on_participant_removed.assert_awaited_once_with("room-123", event)
         mock_handler.assert_awaited_once()
@@ -2185,7 +2203,7 @@ class TestParticipantCallbacks:
             on_participant_added=on_participant_added,
         )
         await ctx.start()
-        await asyncio.sleep(0.05)
+        await wait_for_condition(lambda: ctx._sync_complete)
 
         event = make_participant_added_event(
             room_id="room-123",
@@ -2193,7 +2211,7 @@ class TestParticipantCallbacks:
             name="User Two",
         )
         await ctx.on_event(event)
-        await asyncio.sleep(0.1)
+        await wait_for_condition(lambda: mock_handler.await_count >= 1)
 
         on_participant_added.assert_awaited_once()
         mock_handler.assert_awaited_once()
@@ -2272,14 +2290,14 @@ class TestGracefulStopWithTimeout:
             config=SessionConfig(enable_context_hydration=False),
         )
         await ctx.start()
-        await asyncio.sleep(0.05)
+        await wait_for_condition(lambda: ctx._sync_complete)
 
         # Enqueue a message
         event = make_message_event(room_id="room-123", msg_id="msg-001")
         await ctx.on_event(event)
 
-        # Give time to start processing
-        await asyncio.sleep(0.05)
+        # Wait for the handler to actually be in flight
+        await wait_for_condition(lambda: ctx.is_processing)
 
         # Stop with timeout - should wait for processing
         result = await ctx.stop(timeout=5.0)
@@ -2300,14 +2318,14 @@ class TestGracefulStopWithTimeout:
             config=SessionConfig(enable_context_hydration=False),
         )
         await ctx.start()
-        await asyncio.sleep(0.05)
+        await wait_for_condition(lambda: ctx._sync_complete)
 
         # Enqueue a message
         event = make_message_event(room_id="room-123", msg_id="msg-001")
         await ctx.on_event(event)
 
-        # Give time to start processing
-        await asyncio.sleep(0.05)
+        # Wait for the handler to actually be in flight
+        await wait_for_condition(lambda: ctx.is_processing)
 
         # Stop with short timeout
         start = asyncio.get_running_loop().time()

--- a/tests/runtime/test_resync.py
+++ b/tests/runtime/test_resync.py
@@ -24,19 +24,7 @@ from band.runtime.presence import RoomPresence
 from band.runtime.runtime import AgentRuntime
 from band.runtime.types import PlatformMessage, SessionConfig
 
-from tests.runtime.conftest import admit_room
-
-
-async def wait_for_condition(
-    predicate, *, timeout: float = 1.0, interval: float = 0.01
-) -> None:
-    """Wait until a predicate becomes true, failing fast on timeout."""
-    deadline = asyncio.get_running_loop().time() + timeout
-    while asyncio.get_running_loop().time() < deadline:
-        if predicate():
-            return
-        await asyncio.sleep(interval)
-    pytest.fail("Timed out waiting for condition")
+from tests.runtime.conftest import admit_room, wait_for_condition
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Self-hosted Letta dedupes MCP-discovered `Tool` rows by `(name, organization_id)`. With no `user_id` header set, every `LettaAdapter` instance on a shared self-hosted server resolves to the same default org/actor — so a second instance's MCP registration silently re-points the first instance's `band_send_message` tool row's `metadata_.mcp.server_id` to itself. When the first instance's agent later calls that tool, Letta routes the call into the second instance's in-process MCP server, posting the reply under the wrong Band agent's identity. Root-caused and verified live against `letta-ai/letta@0.16.8` (see INT-985's Investigation section).

- Provision a dedicated Letta organization + user per self-hosted `LettaAdapter` instance and send its `user_id` in every request (`AsyncLetta(default_headers={"user_id": ...})`), isolating MCP server + tool storage between instances. Default-on for self-hosted, no-op on Cloud (`org_scoped=True` against Cloud is rejected at config construction — Cloud doesn't expose the admin API this needs).
- New `src/band/integrations/letta/orgscope.py`: a small raw-`httpx` client for Letta's self-hosted-only admin API (`/v1/admin/orgs/`, `/v1/admin/users/` — not exposed by the `letta_client` SDK), following the `opencode/client.py` precedent.
- Force-seed base tools (`tools.list()`) for a freshly-provisioned org in `on_started`, since a fresh org otherwise has zero `Tool` rows and the first `agents.create(include_base_tools=True)` would raise.
- CI: set `LETTA_NO_DEFAULT_ACTOR=true` on the test Letta server so an unresolvable `user_id` fails loud instead of silently falling back to the default org (closing a residual gap that would otherwise mask a single-instance scoping bug).
- Removed the `Adapter.LETTA` exclusion from the rehydration E2E test — this fix is exactly what that exclusion was waiting on.

**Bug found and fixed while live-testing this against a real Letta server:** the org/user pagination helper's `after`-cursor walk stalled forever once it landed on Letta's own seeded default user, whose `created_at` is `null` — Letta's own pagination code silently drops the boundary filter for a null-`created_at` cursor, so the "next page" comes back as the same unfiltered list forever. Fixed with stall detection (treat a non-advancing cursor as exhaustion) plus a permanent regression test.

## Test plan

- [x] `uv run pytest tests/adapters/test_letta_orgscope.py tests/adapters/test_letta_mcp.py tests/adapters/test_letta_adapter.py tests/adapters/test_deprecation_shims.py -v` — all pass (including 6 new unit/wiring tests + 1 pagination-stall regression test)
- [x] Full unit suite: `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/` — 5402 passed, 0 failed
- [x] `uv run ruff check . && uv run ruff format --check . && uv run pyrefly check` — clean
- [x] Live integration tests against a real self-hosted Letta (Docker): `uv run pytest tests/integration/test_letta_live.py -v -s --no-cov` — 4/4 pass, including the new `test_two_instances_stay_isolated_in_shared_org` (org/user isolation, MCP tool metadata non-collision, cross-org 404 checks, fresh-org agent creation)
- [x] E2E baseline `letta` lane against the live Band platform + LLMs: `BAND_E2E_LANE=letta E2E_TESTS_ENABLED=true uv run pytest tests/e2e/baseline/ -v -s --no-cov` — 60 passed, 0 failed, including `test_partial_reboot_preserves_context_and_peer[letta]` (the test this fix was specifically meant to unblock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018j6NRbrMzkT4jTP6dBChsn