### PR TITLE
feat: Adopt AgentFailure/send_failure across Python adapters

### DIFF
--- a/docs/adapters/codex.md
+++ b/docs/adapters/codex.md
@@ -249,7 +249,6 @@ These `CodexAdapterConfig(...)` flags add more telemetry detail:
 | `emit_turn_lifecycle_events` | `bool` | `False` | Emit enriched turn lifecycle events at turn start and completion. |
 | `emit_diff_events` | `bool` | `False` | Include file diffs in event metadata, capped at 64 KB. |
 | `emit_token_usage_events` | `bool` | `False` | Track and emit token usage per session. |
-| `structured_errors` | `bool` | `True` | Emit structured error events instead of plain text errors. |
 
 Enabling both `emit_turn_task_markers` and `emit_turn_lifecycle_events` produces two task events per completed turn. Pick one; lifecycle events contain richer metadata.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "band-client-rest==0.0.27",
-    "band-sdk-core==2.0.0",
+    "band-sdk-core==2.3.0",
     "phoenix-channels-python-client>=0.2.4",
     "python-dotenv>=1.2.2",
     "pydantic>=2.0",

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from agno.media import Image
 from agno.tools.function import ToolResult
+from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
 from band.core.protocols import AgentToolsProtocol
@@ -333,14 +334,18 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
             is_session_bootstrap,
         )
 
-        messages = self._build_run_input(
-            msg,
-            history,
-            participants_msg,
-            contacts_msg,
-            is_session_bootstrap=is_session_bootstrap,
-            room_id=room_id,
-        )
+        try:
+            messages = self._build_run_input(
+                msg,
+                history,
+                participants_msg,
+                contacts_msg,
+                is_session_bootstrap=is_session_bootstrap,
+                room_id=room_id,
+            )
+        except Exception as e:
+            await tools.send_failure(AgentFailure("agno", str(e)))
+            raise
         response = await self._run_agent(
             messages, tools, room_id=room_id, msg_id=msg.id
         )
@@ -465,18 +470,18 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
         :meth:`_run_streamed`), matching the other adapters' live reporting.
         Otherwise it runs non-streaming, exactly as before.
         """
-        agent = self._agent
-        if agent is None:
-            raise RuntimeError("AgnoAdapter was used before on_started()")
-        session_id = self._session_id_factory(room_id)
-        logger.debug(
-            "Room %s msg %s: running Agno agent (%d input messages, session_id=%s)",
-            room_id,
-            msg_id,
-            len(messages),
-            session_id,
-        )
         try:
+            agent = self._agent
+            if agent is None:
+                raise RuntimeError("AgnoAdapter was used before on_started()")
+            session_id = self._session_id_factory(room_id)
+            logger.debug(
+                "Room %s msg %s: running Agno agent (%d input messages, session_id=%s)",
+                room_id,
+                msg_id,
+                len(messages),
+                session_id,
+            )
             with _bind_room_tools(tools):
                 if Emit.TOOL_CALLS in self.features.emit:
                     response = await self._run_streamed(
@@ -494,22 +499,23 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
             # the turn as failed rather than as a silent empty reply.
             if response is not None and response.status == RunStatus.error:
                 raise AgnoRunError(_error_summary(response.content))
-        except Exception:
+        except Exception as e:
             # Keep the user-facing payload generic; the full traceback is in the
             # agent log via logger.exception. Exception text can include DB
-            # strings, paths, and tokens that must not surface in chat.
+            # strings, paths, and tokens that must not surface in chat. Only
+            # the coarse RunStatus.error code -- never response.content -- is
+            # safe to attach.
             logger.exception(
                 "Room %s msg %s: error running Agno agent", room_id, msg_id
             )
-            try:
-                await tools.send_event(
-                    content="Internal error while processing message; see agent logs.",
-                    message_type="error",
+            code = RunStatus.error.value if isinstance(e, AgnoRunError) else None
+            await tools.send_failure(
+                AgentFailure(
+                    "agno",
+                    "Internal error while processing message; see agent logs.",
+                    code,
                 )
-            except Exception:
-                logger.exception(
-                    "Room %s msg %s: failed to report error event", room_id, msg_id
-                )
+            )
             raise
 
         if response is None:

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -15,7 +15,7 @@ from agno.tools.function import ToolResult
 from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE, AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.tool_filter import filter_tool_schemas
 from band.core.types import (
@@ -334,18 +334,14 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
             is_session_bootstrap,
         )
 
-        try:
-            messages = self._build_run_input(
-                msg,
-                history,
-                participants_msg,
-                contacts_msg,
-                is_session_bootstrap=is_session_bootstrap,
-                room_id=room_id,
-            )
-        except Exception as e:
-            await tools.send_failure(AgentFailure("agno", str(e)))
-            raise
+        messages = self._build_run_input(
+            msg,
+            history,
+            participants_msg,
+            contacts_msg,
+            is_session_bootstrap=is_session_bootstrap,
+            room_id=room_id,
+        )
         response = await self._run_agent(
             messages, tools, room_id=room_id, msg_id=msg.id
         )
@@ -510,11 +506,7 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
             )
             code = RunStatus.error.value if isinstance(e, AgnoRunError) else None
             await tools.send_failure(
-                AgentFailure(
-                    "agno",
-                    "Internal error while processing message; see agent logs.",
-                    code,
-                )
+                AgentFailure("agno", GENERIC_PROVIDER_FAILURE_MESSAGE, code)
             )
             raise
 

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -63,6 +63,17 @@ def _image_tool_result_content(result: dict[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
+def _to_agent_failure(e: Exception) -> AgentFailure:
+    """Parse a turn-ending exception into the shared provider-failure shape.
+
+    ``APIStatusError`` carries an HTTP status and response body that a plain
+    exception's message alone does not.
+    """
+    if isinstance(e, APIStatusError):
+        return AgentFailure("anthropic", str(e), str(e.status_code), e.body)
+    return AgentFailure("anthropic", str(e))
+
+
 class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
     """
     Anthropic SDK adapter using SimpleAdapter pattern.
@@ -280,13 +291,7 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
                     )
                 except Exception as e:
                     logger.error("Error calling Anthropic: %s", e, exc_info=True)
-                    if isinstance(e, APIStatusError):
-                        failure = AgentFailure(
-                            "anthropic", str(e), str(e.status_code), e.body
-                        )
-                    else:
-                        failure = AgentFailure("anthropic", str(e))
-                    await tools.send_failure(failure)
+                    await tools.send_failure(_to_agent_failure(e))
                     raise  # Re-raise so message is marked as failed
 
                 turn_usage = turn_usage + self._usage_from_response(response)

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -17,7 +17,7 @@ from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
 from band.core.exceptions import BandConfigError
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE, AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
     Capability,
@@ -71,7 +71,7 @@ def _to_agent_failure(e: Exception) -> AgentFailure:
     """
     if isinstance(e, APIStatusError):
         return AgentFailure("anthropic", str(e), str(e.status_code), e.body)
-    return AgentFailure("anthropic", str(e))
+    return AgentFailure("anthropic", GENERIC_PROVIDER_FAILURE_MESSAGE)
 
 
 class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -11,8 +11,9 @@ import logging
 import warnings
 from typing import Any, ClassVar, cast
 
-from anthropic import AsyncAnthropic
+from anthropic import APIStatusError, AsyncAnthropic
 from anthropic.types import Message, MessageParam, TextBlock, ToolParam, ToolUseBlock
+from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
 from band.core.exceptions import BandConfigError
@@ -279,7 +280,13 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
                     )
                 except Exception as e:
                     logger.error("Error calling Anthropic: %s", e, exc_info=True)
-                    await self._report_error(tools, str(e))
+                    if isinstance(e, APIStatusError):
+                        failure = AgentFailure(
+                            "anthropic", str(e), str(e.status_code), e.body
+                        )
+                    else:
+                        failure = AgentFailure("anthropic", str(e))
+                    await tools.send_failure(failure)
                     raise  # Re-raise so message is marked as failed
 
                 turn_usage = turn_usage + self._usage_from_response(response)
@@ -512,11 +519,3 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
             )
 
         return tool_results
-
-    # --- Copied from BaseFrameworkAgent._report_error ---
-    async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        """Send error event (best effort)."""
-        try:
-            await tools.send_event(content=f"Error: {error}", message_type="error")
-        except Exception as e:
-            logger.warning("Failed to send error event: %s", e)

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -52,7 +52,11 @@ except ImportError:
 from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import (
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    AgentToolsProtocol,
+    TurnResultAlreadyReported,
+)
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
     Capability,
@@ -99,12 +103,6 @@ from band.runtime.tools import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-class TurnResultAlreadyReported(Exception):
-    """A terminal `ResultMessage` failure `_on_turn_complete` already
-    reported via `send_failure`. `on_message`'s outer except re-raises this
-    without reporting the same failure a second time."""
 
 
 # Tool names as constants (MCP naming convention: mcp__{server}__{tool})
@@ -712,12 +710,16 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
             )
             await self._invalidate_session(room_id)
 
-            await tools.send_failure(AgentFailure("claude_sdk", str(e)))
+            await tools.send_failure(
+                AgentFailure("claude_sdk", GENERIC_PROVIDER_FAILURE_MESSAGE)
+            )
             raise
 
         except Exception as e:
             logger.exception("Error processing message: %s", e)
-            await tools.send_failure(AgentFailure("claude_sdk", str(e)))
+            await tools.send_failure(
+                AgentFailure("claude_sdk", GENERIC_PROVIDER_FAILURE_MESSAGE)
+            )
             raise
 
         logger.debug("Message %s processed successfully", msg.id)

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -133,6 +133,9 @@ _DEFAULT_MODEL = "claude-sonnet-4-6"
 # same constant instead of a second, driftable number.
 _CLAUDE_SDK_MAX_BUFFER_BYTES = MAX_INLINE_IMAGE_BYTES * 2
 
+# AgentFailure.provider tag for every failure this adapter reports.
+_PROVIDER = "claude_sdk"
+
 # Approval flow types (mirrors Codex adapter patterns)
 ApprovalMode = Literal["auto_accept", "auto_decline", "manual"]
 ApprovalDecision = Literal["accept", "decline"]
@@ -621,10 +624,22 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                         room_id, resume_session_id=None
                     )
                 except Exception as fresh_exc:
-                    await tools.send_failure(AgentFailure("claude_sdk", str(fresh_exc)))
+                    logger.exception(
+                        "Room %s: Fresh session creation also failed: %s",
+                        room_id,
+                        fresh_exc,
+                    )
+                    await tools.send_failure(
+                        AgentFailure(_PROVIDER, GENERIC_PROVIDER_FAILURE_MESSAGE)
+                    )
                     raise
             else:
-                await tools.send_failure(AgentFailure("claude_sdk", str(resume_exc)))
+                logger.exception(
+                    "Room %s: Session creation failed: %s", room_id, resume_exc
+                )
+                await tools.send_failure(
+                    AgentFailure(_PROVIDER, GENERIC_PROVIDER_FAILURE_MESSAGE)
+                )
                 raise
 
         # Add chat_id context (Claude needs this for tool calls) -- the label
@@ -711,14 +726,14 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
             await self._invalidate_session(room_id)
 
             await tools.send_failure(
-                AgentFailure("claude_sdk", GENERIC_PROVIDER_FAILURE_MESSAGE)
+                AgentFailure(_PROVIDER, GENERIC_PROVIDER_FAILURE_MESSAGE)
             )
             raise
 
         except Exception as e:
             logger.exception("Error processing message: %s", e)
             await tools.send_failure(
-                AgentFailure("claude_sdk", GENERIC_PROVIDER_FAILURE_MESSAGE)
+                AgentFailure(_PROVIDER, GENERIC_PROVIDER_FAILURE_MESSAGE)
             )
             raise
 
@@ -959,14 +974,14 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
             )
             detail = self._result_error_detail(sdk_message)
             await tools.send_failure(
-                AgentFailure("claude_sdk", detail, code, sdk_message.errors)
+                AgentFailure(_PROVIDER, detail, code, sdk_message.errors)
             )
             raise TurnResultAlreadyReported(detail)
         elif not replied_this_turn and not self._declined_the_reply(
             sdk_message.permission_denials, notified
         ):
             detail = missing_reply_error("Claude SDK")
-            await tools.send_failure(AgentFailure("claude_sdk", detail))
+            await tools.send_failure(AgentFailure(_PROVIDER, detail))
             raise TurnResultAlreadyReported(detail)
 
     def _declined_the_reply(

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -49,6 +49,7 @@ try:
 except ImportError:
     _CLAUDE_SDK_AVAILABLE = False
 
+from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
 from band.core.protocols import AgentToolsProtocol
@@ -611,10 +612,15 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                     stored_session_id,
                     resume_exc,
                 )
-                client = await self._session_manager.get_or_create_session(
-                    room_id, resume_session_id=None
-                )
+                try:
+                    client = await self._session_manager.get_or_create_session(
+                        room_id, resume_session_id=None
+                    )
+                except Exception as fresh_exc:
+                    await tools.send_failure(AgentFailure("claude_sdk", str(fresh_exc)))
+                    raise
             else:
+                await tools.send_failure(AgentFailure("claude_sdk", str(resume_exc)))
                 raise
 
         # Add chat_id context (Claude needs this for tool calls) -- the label
@@ -695,12 +701,12 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
             )
             await self._invalidate_session(room_id)
 
-            await self._report_error(tools, str(e))
+            await tools.send_failure(AgentFailure("claude_sdk", str(e)))
             raise
 
         except Exception as e:
             logger.exception("Error processing message: %s", e)
-            await self._report_error(tools, str(e))
+            await tools.send_failure(AgentFailure("claude_sdk", str(e)))
             raise
 
         logger.debug("Message %s processed successfully", msg.id)
@@ -933,11 +939,25 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
         # outright) doesn't linger and grow this room's entry unbounded.
         notified = self._notified_declines.pop(room_id, None)
         if sdk_message.is_error:
-            await self._report_error(tools, self._result_error_detail(sdk_message))
+            code = (
+                str(sdk_message.api_error_status)
+                if sdk_message.api_error_status is not None
+                else None
+            )
+            await tools.send_failure(
+                AgentFailure(
+                    "claude_sdk",
+                    self._result_error_detail(sdk_message),
+                    code,
+                    sdk_message.errors,
+                )
+            )
         elif not replied_this_turn and not self._declined_the_reply(
             sdk_message.permission_denials, notified
         ):
-            await self._report_error(tools, missing_reply_error("Claude SDK"))
+            await tools.send_failure(
+                AgentFailure("claude_sdk", missing_reply_error("Claude SDK"))
+            )
 
     def _declined_the_reply(
         self, permission_denials: list[Any] | None, notified: set[str] | None
@@ -1126,14 +1146,6 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
         self._notified_declines.pop(room_id, None)
         self._pending_tool_names.pop(room_id, None)
         logger.debug("Room %s: Cleaned up Claude SDK session", room_id)
-
-    # --- Copied from BaseFrameworkAgent._report_error ---
-    async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        """Send error event (best effort)."""
-        try:
-            await tools.send_event(content=f"Error: {error}", message_type="error")
-        except Exception:
-            logger.debug("Failed to send error event", exc_info=True)
 
     async def cleanup_all(self) -> None:
         """Cleanup all sessions (call on stop)."""

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -101,6 +101,12 @@ from band.runtime.tools import (
 logger = logging.getLogger(__name__)
 
 
+class TurnResultAlreadyReported(Exception):
+    """A terminal `ResultMessage` failure `_on_turn_complete` already
+    reported via `send_failure`. `on_message`'s outer except re-raises this
+    without reporting the same failure a second time."""
+
+
 # Tool names as constants (MCP naming convention: mcp__{server}__{tool})
 # Derived from TOOL_MODELS — single source of truth
 BAND_BASE_TOOLS: list[str] = mcp_tool_names(BASE_TOOL_NAMES)
@@ -691,6 +697,11 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
             # Process streaming response (MCP tools handle execution)
             await self._process_response(client, room_id, tools)
 
+        except TurnResultAlreadyReported:
+            # _on_turn_complete already reported this failure via
+            # send_failure; propagate without reporting it a second time.
+            raise
+
         except CLIConnectionError as e:
             # CLI process is dead — evict the cached session so the next
             # message creates a fresh one instead of reusing the corpse.
@@ -944,20 +955,17 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                 if sdk_message.api_error_status is not None
                 else None
             )
+            detail = self._result_error_detail(sdk_message)
             await tools.send_failure(
-                AgentFailure(
-                    "claude_sdk",
-                    self._result_error_detail(sdk_message),
-                    code,
-                    sdk_message.errors,
-                )
+                AgentFailure("claude_sdk", detail, code, sdk_message.errors)
             )
+            raise TurnResultAlreadyReported(detail)
         elif not replied_this_turn and not self._declined_the_reply(
             sdk_message.permission_denials, notified
         ):
-            await tools.send_failure(
-                AgentFailure("claude_sdk", missing_reply_error("Claude SDK"))
-            )
+            detail = missing_reply_error("Claude SDK")
+            await tools.send_failure(AgentFailure("claude_sdk", detail))
+            raise TurnResultAlreadyReported(detail)
 
     def _declined_the_reply(
         self, permission_denials: list[Any] | None, notified: set[str] | None

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -825,45 +825,42 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     if self.config.stream_reasoning_events:
                         delta = params.get("delta", "")
                         item_id = str(params.get("itemId") or "")
-                        try:
-                            await tools.send_event(
-                                content=str(delta),
-                                message_type="thought",
-                                metadata={
-                                    "streaming": True,
-                                    "codex_item_id": item_id,
-                                    "codex_event_type": event.method,
-                                    "codex_room_id": room_id,
-                                    "codex_thread_id": thread_id,
-                                    "codex_turn_id": turn_id,
-                                },
-                            )
-                        except Exception:
-                            logger.debug(
-                                "Failed to stream reasoning delta",
-                                exc_info=True,
-                            )
+                        await send_event_safe(
+                            tools,
+                            content=str(delta),
+                            message_type="thought",
+                            metadata={
+                                "streaming": True,
+                                "codex_item_id": item_id,
+                                "codex_event_type": event.method,
+                                "codex_room_id": room_id,
+                                "codex_thread_id": thread_id,
+                                "codex_turn_id": turn_id,
+                            },
+                            log_label="reasoning delta",
+                            log_level=logging.DEBUG,
+                        )
                     continue
 
                 if event.method == "item/plan/delta":
                     if self.config.stream_plan_events:
                         delta = params.get("delta", "")
                         item_id = str(params.get("itemId") or "")
-                        try:
-                            await tools.send_event(
-                                content=str(delta),
-                                message_type="thought",
-                                metadata={
-                                    "streaming": True,
-                                    "subtype": "plan",
-                                    "codex_item_id": item_id,
-                                    "codex_room_id": room_id,
-                                    "codex_thread_id": thread_id,
-                                    "codex_turn_id": turn_id,
-                                },
-                            )
-                        except Exception:
-                            logger.debug("Failed to stream plan delta", exc_info=True)
+                        await send_event_safe(
+                            tools,
+                            content=str(delta),
+                            message_type="thought",
+                            metadata={
+                                "streaming": True,
+                                "subtype": "plan",
+                                "codex_item_id": item_id,
+                                "codex_room_id": room_id,
+                                "codex_thread_id": thread_id,
+                                "codex_turn_id": turn_id,
+                            },
+                            log_label="plan delta",
+                            log_level=logging.DEBUG,
+                        )
                     continue
 
                 # --- Phase 2: Plan step tracking ---
@@ -897,27 +894,24 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     ):
                         compacted_thread = str(params.get("threadId") or thread_id)
                         compacted_turn = str(params.get("turnId") or turn_id or "")
-                        try:
-                            await tools.send_event(
-                                content=self._build_task_event_content(
-                                    task_id=compacted_turn or None,
-                                    task="Codex context compaction",
-                                    status="completed",
-                                    summary=f"Thread: {compacted_thread}",
-                                ),
-                                message_type="task",
-                                metadata={
-                                    "codex_event_type": "context_compaction",
-                                    "codex_room_id": room_id,
-                                    "codex_thread_id": compacted_thread,
-                                    "codex_turn_id": compacted_turn or None,
-                                },
-                            )
-                        except Exception:
-                            logger.debug(
-                                "Failed to emit context compaction event",
-                                exc_info=True,
-                            )
+                        await send_event_safe(
+                            tools,
+                            content=self._build_task_event_content(
+                                task_id=compacted_turn or None,
+                                task="Codex context compaction",
+                                status="completed",
+                                summary=f"Thread: {compacted_thread}",
+                            ),
+                            message_type="task",
+                            metadata={
+                                "codex_event_type": "context_compaction",
+                                "codex_room_id": room_id,
+                                "codex_thread_id": compacted_thread,
+                                "codex_turn_id": compacted_turn or None,
+                            },
+                            log_label="context compaction event",
+                            log_level=logging.DEBUG,
+                        )
                     continue
 
                 # --- Phase 4: Aggregated diffs ---
@@ -944,26 +938,21 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                             and self.config.stream_commentary_events
                         ):
                             # Stream as thought; exclude from final_text.
-                            try:
-                                await tools.send_event(
-                                    content=delta,
-                                    message_type="thought",
-                                    metadata={
-                                        "streaming": True,
-                                        "subtype": "commentary",
-                                        "codex_item_id": str(
-                                            params.get("itemId") or ""
-                                        ),
-                                        "codex_room_id": room_id,
-                                        "codex_thread_id": thread_id,
-                                        "codex_turn_id": turn_id,
-                                    },
-                                )
-                            except Exception:
-                                logger.debug(
-                                    "Failed to stream commentary delta",
-                                    exc_info=True,
-                                )
+                            await send_event_safe(
+                                tools,
+                                content=delta,
+                                message_type="thought",
+                                metadata={
+                                    "streaming": True,
+                                    "subtype": "commentary",
+                                    "codex_item_id": str(params.get("itemId") or ""),
+                                    "codex_room_id": room_id,
+                                    "codex_thread_id": thread_id,
+                                    "codex_turn_id": turn_id,
+                                },
+                                log_label="commentary delta",
+                                log_level=logging.DEBUG,
+                            )
                         else:
                             # When streaming is disabled, commentary accumulates
                             # into final_text for backward compatibility.
@@ -1638,29 +1627,24 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 logger.exception("Failed to send approval policy notification")
 
         if Emit.THOUGHTS in self.features.emit:
-            try:
-                await tools.send_event(
-                    content=(
-                        f"Codex approval request handled automatically ({decision})."
-                    ),
-                    message_type="thought",
-                    metadata={
-                        "codex_approval_method": event.method,
-                        "codex_approval_type": self._approval_type(event.method),
-                        "codex_approval_options": [
-                            "accept",
-                            "acceptForSession",
-                            "decline",
-                        ],
-                    },
-                )
-            except Exception:
-                # Best-effort telemetry — never fail the turn on thought
-                # emission failures.
-                logger.debug(
-                    "Failed to emit approval thought event",
-                    exc_info=True,
-                )
+            # Best-effort telemetry — never fail the turn on thought emission
+            # failures.
+            await send_event_safe(
+                tools,
+                content=(f"Codex approval request handled automatically ({decision})."),
+                message_type="thought",
+                metadata={
+                    "codex_approval_method": event.method,
+                    "codex_approval_type": self._approval_type(event.method),
+                    "codex_approval_options": [
+                        "accept",
+                        "acceptForSession",
+                        "decline",
+                    ],
+                },
+                log_label="approval thought event",
+                log_level=logging.DEBUG,
+            )
 
     @staticmethod
     def _turn_usage(usage: CodexTokenUsage | None) -> TurnUsage:
@@ -1762,19 +1746,19 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 lifecycle_metadata["codex_error"] = turn_error
             if has_usage:
                 lifecycle_metadata.update(usage.to_metadata())
-            try:
-                await tools.send_event(
-                    content=self._build_task_event_content(
-                        task_id=turn_id,
-                        task="Codex turn lifecycle",
-                        status=turn_status,
-                        summary=f"Duration: {duration_s:.1f}s | Thread: {thread_id}",
-                    ),
-                    message_type="task",
-                    metadata=lifecycle_metadata,
-                )
-            except Exception:
-                logger.debug("Failed to emit turn lifecycle event", exc_info=True)
+            await send_event_safe(
+                tools,
+                content=self._build_task_event_content(
+                    task_id=turn_id,
+                    task="Codex turn lifecycle",
+                    status=turn_status,
+                    summary=f"Duration: {duration_s:.1f}s | Thread: {thread_id}",
+                ),
+                message_type="task",
+                metadata=lifecycle_metadata,
+                log_label="turn lifecycle event",
+                log_level=logging.DEBUG,
+            )
 
         mention = [{"id": msg.sender_id, "name": msg.sender_name or msg.sender_type}]
 
@@ -2197,22 +2181,19 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 net_ctx = params.get("networkContext") or params.get("network_context")
                 if net_ctx:
                     approval_metadata["codex_network_context"] = net_ctx
-                try:
-                    await tools.send_event(
-                        content=self._build_task_event_content(
-                            task_id=token,
-                            task="Codex approval request",
-                            status="pending",
-                            summary=summary,
-                        ),
-                        message_type="task",
-                        metadata=approval_metadata,
-                    )
-                except Exception:
-                    logger.debug(
-                        "Failed to emit approval request task event",
-                        exc_info=True,
-                    )
+                await send_event_safe(
+                    tools,
+                    content=self._build_task_event_content(
+                        task_id=token,
+                        task="Codex approval request",
+                        status="pending",
+                        summary=summary,
+                    ),
+                    message_type="task",
+                    metadata=approval_metadata,
+                    log_label="approval request task event",
+                    log_level=logging.DEBUG,
+                )
             await tools.send_message(approval_msg, mentions=mention)
             decision_raw = await asyncio.wait_for(
                 pending.future,
@@ -2355,6 +2336,12 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             # carry; build_agent_failure's own fallback covers it uniformly
             # instead of shipping a degenerate literal string like "None".
             error = {"message": str(error)} if error else {}
+        logger.error(
+            "Codex turn failed (thread=%s, turn=%s): %s",
+            thread_id,
+            turn_id,
+            error.get("message", ""),
+        )
         await tools.send_failure(
             build_agent_failure(
                 error, thread_id=thread_id, turn_id=turn_id, room_id=room_id
@@ -2379,24 +2366,24 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         if not steps:
             return
         step_dicts = [{"step": s.step, "status": s.status} for s in steps]
-        try:
-            await tools.send_event(
-                content=self._build_task_event_content(
-                    task_id=turn_id,
-                    task="Codex plan",
-                    status="updated",
-                    summary=f"{len(steps)} steps",
-                ),
-                message_type="task",
-                metadata={
-                    "codex_plan_steps": step_dicts,
-                    "codex_room_id": room_id,
-                    "codex_thread_id": thread_id,
-                    "codex_turn_id": turn_id,
-                },
-            )
-        except Exception:
-            logger.debug("Failed to forward plan steps", exc_info=True)
+        await send_event_safe(
+            tools,
+            content=self._build_task_event_content(
+                task_id=turn_id,
+                task="Codex plan",
+                status="updated",
+                summary=f"{len(steps)} steps",
+            ),
+            message_type="task",
+            metadata={
+                "codex_plan_steps": step_dicts,
+                "codex_room_id": room_id,
+                "codex_thread_id": thread_id,
+                "codex_turn_id": turn_id,
+            },
+            log_label="plan steps",
+            log_level=logging.DEBUG,
+        )
 
     # ------------------------------------------------------------------
     # Phase 4: Token usage & diffs
@@ -2427,14 +2414,14 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         metadata = usage.to_metadata()
         metadata["codex_thread_id"] = thread_id
         metadata["codex_room_id"] = room_id
-        try:
-            await tools.send_event(
-                content=usage.format_summary(),
-                message_type="task",
-                metadata=metadata,
-            )
-        except Exception:
-            logger.debug("Failed to emit token usage event", exc_info=True)
+        await send_event_safe(
+            tools,
+            content=usage.format_summary(),
+            message_type="task",
+            metadata=metadata,
+            log_label="token usage event",
+            log_level=logging.DEBUG,
+        )
 
     async def _forward_diff_event(
         self,
@@ -2490,19 +2477,19 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             metadata["codex_diff_truncated"] = True
             metadata["codex_diff_original_length"] = original_length
             metadata["codex_diff_original_bytes"] = original_byte_length
-        try:
-            await tools.send_event(
-                content=self._build_task_event_content(
-                    task_id=turn_id,
-                    task="Codex diff",
-                    status="updated",
-                    summary=summary,
-                ),
-                message_type="task",
-                metadata=metadata,
-            )
-        except Exception:
-            logger.debug("Failed to forward diff event", exc_info=True)
+        await send_event_safe(
+            tools,
+            content=self._build_task_event_content(
+                task_id=turn_id,
+                task="Codex diff",
+                status="updated",
+                summary=summary,
+            ),
+            message_type="task",
+            metadata=metadata,
+            log_label="diff event",
+            log_level=logging.DEBUG,
+        )
 
     # ------------------------------------------------------------------
     # Phase 1: Approval audit trail
@@ -2563,27 +2550,27 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         """Emit a task event for an approval decision."""
         if Emit.TASK_EVENTS not in self.features.emit:
             return
-        try:
-            await tools.send_event(
-                content=self._build_task_event_content(
-                    task_id=str(entry.request_id),
-                    task="Codex approval",
-                    status=entry.decision,
-                    summary=entry.summary,
-                ),
-                message_type="task",
-                metadata={
-                    "codex_event_type": "approval_resolution",
-                    "codex_approval_method": entry.method,
-                    "codex_approval_decision": entry.decision,
-                    "codex_decided_by": entry.decided_by,
-                    "codex_session_level": entry.session_level,
-                    "codex_room_id": room_id,
-                    "codex_timestamp": entry.timestamp,
-                },
-            )
-        except Exception:
-            logger.debug("Failed to emit approval audit event", exc_info=True)
+        await send_event_safe(
+            tools,
+            content=self._build_task_event_content(
+                task_id=str(entry.request_id),
+                task="Codex approval",
+                status=entry.decision,
+                summary=entry.summary,
+            ),
+            message_type="task",
+            metadata={
+                "codex_event_type": "approval_resolution",
+                "codex_approval_method": entry.method,
+                "codex_approval_decision": entry.decision,
+                "codex_decided_by": entry.decided_by,
+                "codex_session_level": entry.session_level,
+                "codex_room_id": room_id,
+                "codex_timestamp": entry.timestamp,
+            },
+            log_label="approval audit event",
+            log_level=logging.DEBUG,
+        )
 
     async def _handle_local_command(
         self,

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -20,7 +20,7 @@ from typing_extensions import Unpack
 from band.converters.codex import CodexHistoryConverter
 from band.converters.helpers import build_replay_messages
 from band.core.delivery import DeliveryFailedError, deliver_reply
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import FAILURE_CODE_TIMEOUT, AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
     AgentInput,
@@ -570,13 +570,20 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             "decline",
             "approvals",
         }:
-            handled = await self._handle_approval_command(
-                tools=tools,
-                msg=msg,
-                room_id=room_id,
-                command=command[0],
-                args=command[1],
-            )
+            try:
+                handled = await self._handle_approval_command(
+                    tools=tools,
+                    msg=msg,
+                    room_id=room_id,
+                    command=command[0],
+                    args=command[1],
+                )
+            except DeliveryFailedError as e:
+                # Same Band-delivery-vs-provider-failure split as the
+                # turn-processing path below: re-raise the cause so
+                # mark_failed/retry bookkeeping keys off the real exception.
+                logger.exception("Codex reply delivery failed: %s", e.cause)
+                raise e.cause from None
             if handled:
                 return
 
@@ -719,11 +726,10 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     duration_s=_turn_duration_s,
                 )
             except DeliveryFailedError as e:
-                # The turn did its work; posting it to the room is what failed.
-                # Band-side delivery, never a Codex provider failure -- but
-                # this call path had no try/except before deliver_reply
-                # existed, so any exception here must keep propagating
-                # exactly as it always did (durable mark_failed/retry).
+                # The turn did its work; posting it to the room is what
+                # failed -- Band-side delivery, never a Codex provider
+                # failure. Re-raise the cause (not this wrapper) so
+                # mark_failed/retry bookkeeping keys off the real exception.
                 logger.exception("Codex reply delivery failed: %s", e.cause)
                 raise e.cause from None
             except Exception as e:
@@ -745,6 +751,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             raise RuntimeError("CodexAdapter client is None during turn event loop")
 
         result = TurnResult()
+        failure_reported = False
         try:
             while True:
                 _remaining = max(
@@ -781,13 +788,14 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     continue
 
                 if event.method == "error":
-                    await self._handle_error_event(
+                    reported = await self._handle_error_event(
                         tools=tools,
                         params=params,
                         room_id=room_id,
                         thread_id=thread_id,
                         turn_id=turn_id,
                     )
+                    failure_reported = failure_reported or reported
                     continue
 
                 # --- Phase 3: Real-time streaming ---
@@ -995,8 +1003,10 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                         continue
                     result.turn_status = str(turn_payload.get("status") or "failed")
                     result.turn_error = self._extract_turn_error(turn_payload)
-                    # Phase 1: structured error for failed turns
-                    if result.turn_status == "failed":
+                    # Phase 1: structured error for failed turns. Skipped when
+                    # an earlier "error" notification in this same turn
+                    # already reported one, so one incident isn't posted twice.
+                    if result.turn_status == "failed" and not failure_reported:
                         await self._emit_structured_turn_error(
                             tools=tools,
                             turn_payload=turn_payload,
@@ -1023,6 +1033,13 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                         "Failed to send turn/interrupt after timeout",
                         exc_info=True,
                     )
+            await tools.send_failure(
+                AgentFailure(
+                    "codex",
+                    f"Codex turn timed out after {self.config.turn_timeout_s}s",
+                    FAILURE_CODE_TIMEOUT,
+                )
+            )
             result.turn_status = "interrupted"
             result.turn_error = "Turn timed out"
         return result
@@ -2258,8 +2275,13 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         room_id: str,
         thread_id: str,
         turn_id: str | None,
-    ) -> None:
-        """Handle an ``error`` notification from Codex."""
+    ) -> bool:
+        """Handle an ``error`` notification from Codex.
+
+        Returns whether a failure was actually reported, so the turn loop can
+        skip a redundant second report if ``turn/completed`` also arrives with
+        a failed status for the same incident.
+        """
         error_obj = params.get("error") or {}
         if isinstance(error_obj, dict):
             error_msg = error_obj.get("message", "")
@@ -2281,7 +2303,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 turn_id,
                 error_msg,
             )
-            return
+            return False
 
         logger.error("Codex error: %s", error_msg)
         await tools.send_failure(
@@ -2289,6 +2311,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 error_obj, thread_id=thread_id, turn_id=turn_id, room_id=room_id
             )
         )
+        return True
 
     async def _emit_structured_turn_error(
         self,
@@ -2304,7 +2327,10 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         if error is None:
             return
         if not isinstance(error, dict):
-            error = {"message": str(error)}
+            # A falsy scalar (``""``, ``0``) has no useful message to carry;
+            # build_agent_failure's own fallback covers it uniformly instead
+            # of shipping a degenerate literal string like "False".
+            error = {"message": str(error)} if error else {}
         await tools.send_failure(
             build_agent_failure(
                 error, thread_id=thread_id, turn_id=turn_id, room_id=room_id

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -10,7 +10,7 @@ import time as _time
 from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import ClassVar, Any, Callable, Literal, NamedTuple, NoReturn, Protocol
+from typing import ClassVar, Any, Callable, Literal, NamedTuple, Protocol
 
 from band_sdk_core import AgentFailure
 from pydantic import AliasChoices, BaseModel, Field, ValidationError, field_validator
@@ -19,8 +19,17 @@ from typing_extensions import Unpack
 
 from band.converters.codex import CodexHistoryConverter
 from band.converters.helpers import build_replay_messages
-from band.core.delivery import DeliveryFailedError, deliver_reply
-from band.core.protocols import FAILURE_CODE_TIMEOUT, AgentToolsProtocol
+from band.core.delivery import (
+    DeliveryFailedError,
+    deliver_reply,
+    reraise_delivery_cause,
+)
+from band.core.protocols import (
+    FAILURE_CODE_TIMEOUT,
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    AgentToolsProtocol,
+    TurnResultAlreadyReported,
+)
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
     AgentInput,
@@ -79,16 +88,6 @@ def _image_content_items(result: dict[str, Any]) -> list[dict[str, Any]]:
         }
         for block in result["content"]
     ]
-
-
-def _reraise_delivery_cause(e: DeliveryFailedError) -> NoReturn:
-    """Band-side reply delivery failed, never a Codex provider failure.
-
-    Re-raises the cause (not this wrapper) so mark_failed/retry bookkeeping
-    keys off the real exception.
-    """
-    logger.exception("Codex reply delivery failed: %s", e.cause)
-    raise e.cause from None
 
 
 TransportKind = Literal["stdio", "ws"]
@@ -589,7 +588,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     args=command[1],
                 )
             except DeliveryFailedError as e:
-                _reraise_delivery_cause(e)
+                reraise_delivery_cause(e)
             if handled:
                 return
 
@@ -706,6 +705,12 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                         turn_id=turn_id or None,
                         turn_start=_turn_start,
                     )
+                except TurnResultAlreadyReported:
+                    # A nested handler (e.g. the turn-timeout branch) already
+                    # reported this failure via send_failure; propagate it
+                    # without emitting a friendly _emit_turn_outcome reply or
+                    # a generic "Internal error" fallback.
+                    raise
                 except Exception:
                     logger.exception(
                         "Unexpected error during Codex turn event processing "
@@ -732,9 +737,19 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     duration_s=_turn_duration_s,
                 )
             except DeliveryFailedError as e:
-                _reraise_delivery_cause(e)
-            except Exception as e:
+                reraise_delivery_cause(e)
+            except TurnResultAlreadyReported:
+                raise
+            except CodexJsonRpcError as e:
+                # A structured RPC error from the app-server (e.g. "model not
+                # available") is safe, curated text -- unlike an arbitrary
+                # caught exception, it's worth showing verbatim.
                 await tools.send_failure(AgentFailure("codex", str(e)))
+                raise
+            except Exception:
+                await tools.send_failure(
+                    AgentFailure("codex", GENERIC_PROVIDER_FAILURE_MESSAGE)
+                )
                 raise
 
     async def _process_turn_events(
@@ -991,7 +1006,10 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                         self._token_usage.pop(stale_thread, None)
                     for stale_room in stale_rooms:
                         self._clear_pending_approvals_for_room(stale_room)
-                    break
+                    await tools.send_failure(
+                        AgentFailure("codex", result.turn_error, "transport_closed")
+                    )
+                    raise TurnResultAlreadyReported(result.turn_error)
 
                 if event.method == "turn/completed":
                     turn_payload = (
@@ -1004,10 +1022,12 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                         continue
                     result.turn_status = str(turn_payload.get("status") or "failed")
                     result.turn_error = self._extract_turn_error(turn_payload)
-                    # Phase 1: structured error for failed turns. Skipped when
-                    # an earlier "error" notification in this same turn
-                    # already reported one, so one incident isn't posted twice.
-                    if result.turn_status == "failed" and not failure_reported:
+                    if result.turn_status != "failed":
+                        break
+                    # Skipped when an earlier "error" notification in this same
+                    # turn already reported one, so one incident isn't posted
+                    # twice -- but the turn still fails either way.
+                    if not failure_reported:
                         await self._emit_structured_turn_error(
                             tools=tools,
                             turn_payload=turn_payload,
@@ -1015,7 +1035,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                             thread_id=thread_id,
                             turn_id=turn_id,
                         )
-                    break
+                    raise TurnResultAlreadyReported(result.turn_error or "Turn failed")
         except asyncio.TimeoutError:
             logger.error(
                 "Codex turn timed out after %ss (thread=%s, turn=%s)",
@@ -1041,8 +1061,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     FAILURE_CODE_TIMEOUT,
                 )
             )
-            result.turn_status = "interrupted"
-            result.turn_error = "Turn timed out"
+            raise TurnResultAlreadyReported("Turn timed out")
         return result
 
     async def on_cleanup(self, room_id: str) -> None:

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -632,25 +632,22 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     Emit.TASK_EVENTS in self.features.emit
                     and self.config.emit_turn_task_markers
                 ):
-                    try:
-                        await tools.send_event(
-                            content=self._build_task_event_content(
-                                task_id=turn_id or None,
-                                task="Codex turn",
-                                status="started",
-                                summary=f"Thread: {thread_id}",
-                            ),
-                            message_type="task",
-                            metadata={
-                                "codex_thread_id": thread_id,
-                                "codex_turn_id": turn_id or None,
-                                "codex_room_id": room_id,
-                            },
-                        )
-                    except Exception:
-                        logger.debug(
-                            "Failed to emit turn started task event", exc_info=True
-                        )
+                    await self._emit_event_safe(
+                        tools,
+                        content=self._build_task_event_content(
+                            task_id=turn_id or None,
+                            task="Codex turn",
+                            status="started",
+                            summary=f"Thread: {thread_id}",
+                        ),
+                        message_type="task",
+                        metadata={
+                            "codex_thread_id": thread_id,
+                            "codex_turn_id": turn_id or None,
+                            "codex_room_id": room_id,
+                        },
+                        log_label="turn started task event",
+                    )
 
                 # Phase 2: Turn STARTED lifecycle event with input summary
                 if (
@@ -658,29 +655,25 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     and Emit.TASK_EVENTS in self.features.emit
                 ):
                     input_summary = (msg.content or "")[:200]
-                    try:
-                        await tools.send_event(
-                            content=self._build_task_event_content(
-                                task_id=turn_id or None,
-                                task="Codex turn lifecycle",
-                                status="started",
-                                summary=f"Thread: {thread_id}",
-                            ),
-                            message_type="task",
-                            metadata={
-                                "codex_event_type": "turn_lifecycle",
-                                "codex_room_id": room_id,
-                                "codex_thread_id": thread_id,
-                                "codex_turn_id": turn_id or None,
-                                "codex_turn_status": "started",
-                                "codex_input_summary": input_summary,
-                            },
-                        )
-                    except Exception:
-                        logger.debug(
-                            "Failed to emit turn started lifecycle event",
-                            exc_info=True,
-                        )
+                    await self._emit_event_safe(
+                        tools,
+                        content=self._build_task_event_content(
+                            task_id=turn_id or None,
+                            task="Codex turn lifecycle",
+                            status="started",
+                            summary=f"Thread: {thread_id}",
+                        ),
+                        message_type="task",
+                        metadata={
+                            "codex_event_type": "turn_lifecycle",
+                            "codex_room_id": room_id,
+                            "codex_thread_id": thread_id,
+                            "codex_turn_id": turn_id or None,
+                            "codex_turn_status": "started",
+                            "codex_input_summary": input_summary,
+                        },
+                        log_label="turn started lifecycle event",
+                    )
 
                 # Reset per-turn token deltas for the new turn.
                 usage_obj = self._token_usage.get(thread_id)
@@ -1162,26 +1155,22 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     self._room_threads[room_id] = thread_id
                     self._raw_history_by_room.pop(room_id, None)
                     if Emit.TASK_EVENTS in self.features.emit:
-                        try:
-                            await tools.send_event(
-                                content=self._build_task_event_content(
-                                    task_id=thread_id,
-                                    task="Codex thread",
-                                    status="resumed",
-                                    summary=f"Room: {room_id}",
-                                ),
-                                message_type="task",
-                                metadata={
-                                    "codex_thread_id": thread_id,
-                                    "codex_room_id": room_id,
-                                    "codex_resumed": True,
-                                },
-                            )
-                        except Exception:
-                            logger.debug(
-                                "Failed to emit thread resumed task event",
-                                exc_info=True,
-                            )
+                        await self._emit_event_safe(
+                            tools,
+                            content=self._build_task_event_content(
+                                task_id=thread_id,
+                                task="Codex thread",
+                                status="resumed",
+                                summary=f"Room: {room_id}",
+                            ),
+                            message_type="task",
+                            metadata={
+                                "codex_thread_id": thread_id,
+                                "codex_room_id": room_id,
+                                "codex_resumed": True,
+                            },
+                            log_label="thread resumed task event",
+                        )
                     return thread_id
             except CodexJsonRpcError as exc:
                 logger.warning(
@@ -1215,24 +1204,23 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         self._room_threads[room_id] = thread_id
 
         if Emit.TASK_EVENTS in self.features.emit:
-            try:
-                await tools.send_event(
-                    content=self._build_task_event_content(
-                        task_id=thread_id,
-                        task="Codex thread",
-                        status="mapped",
-                        summary=f"Transport: {self.config.transport}",
-                    ),
-                    message_type="task",
-                    metadata={
-                        "codex_thread_id": thread_id,
-                        "codex_room_id": room_id,
-                        "codex_created_at": datetime.now(timezone.utc).isoformat(),
-                        "codex_transport": self.config.transport,
-                    },
-                )
-            except Exception:
-                logger.debug("Failed to emit thread mapped task event", exc_info=True)
+            await self._emit_event_safe(
+                tools,
+                content=self._build_task_event_content(
+                    task_id=thread_id,
+                    task="Codex thread",
+                    status="mapped",
+                    summary=f"Transport: {self.config.transport}",
+                ),
+                message_type="task",
+                metadata={
+                    "codex_thread_id": thread_id,
+                    "codex_room_id": room_id,
+                    "codex_created_at": datetime.now(timezone.utc).isoformat(),
+                    "codex_transport": self.config.transport,
+                },
+                log_label="thread mapped task event",
+            )
 
         return thread_id
 
@@ -1696,19 +1684,18 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 metadata["codex_duration_s"] = round(duration_s, 2)
             if has_usage:
                 metadata.update(usage.to_metadata())
-            try:
-                await tools.send_event(
-                    content=self._build_task_event_content(
-                        task_id=turn_id,
-                        task="Codex turn",
-                        status=turn_status,
-                        summary=summary,
-                    ),
-                    message_type="task",
-                    metadata=metadata,
-                )
-            except Exception:
-                logger.debug("Failed to emit turn outcome task event", exc_info=True)
+            await self._emit_event_safe(
+                tools,
+                content=self._build_task_event_content(
+                    task_id=turn_id,
+                    task="Codex turn",
+                    status=turn_status,
+                    summary=summary,
+                ),
+                message_type="task",
+                metadata=metadata,
+                log_label="turn outcome task event",
+            )
 
         # Phase 2: Enriched turn lifecycle events
         if (
@@ -3272,6 +3259,23 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         if summary and summary != task:
             lines.append(f"Summary: {summary}")
         return "\n".join(lines)
+
+    async def _emit_event_safe(
+        self,
+        tools: AgentToolsProtocol,
+        *,
+        content: str,
+        message_type: str,
+        metadata: dict[str, Any],
+        log_label: str,
+    ) -> None:
+        """Send a best-effort platform event, downgrading a failure to a debug log."""
+        try:
+            await tools.send_event(
+                content=content, message_type=message_type, metadata=metadata
+            )
+        except Exception:
+            logger.debug("Failed to emit %s", log_label, exc_info=True)
 
     @staticmethod
     def _extract_local_command(content: str) -> tuple[str, str] | None:

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -29,6 +29,7 @@ from band.core.protocols import (
     GENERIC_PROVIDER_FAILURE_MESSAGE,
     AgentToolsProtocol,
     TurnResultAlreadyReported,
+    send_event_safe,
 )
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
@@ -644,7 +645,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     Emit.TASK_EVENTS in self.features.emit
                     and self.config.emit_turn_task_markers
                 ):
-                    await self._emit_event_safe(
+                    await send_event_safe(
                         tools,
                         content=self._build_task_event_content(
                             task_id=turn_id or None,
@@ -659,6 +660,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                             "codex_room_id": room_id,
                         },
                         log_label="turn started task event",
+                        log_level=logging.DEBUG,
                     )
 
                 # Phase 2: Turn STARTED lifecycle event with input summary
@@ -667,7 +669,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     and Emit.TASK_EVENTS in self.features.emit
                 ):
                     input_summary = (msg.content or "")[:200]
-                    await self._emit_event_safe(
+                    await send_event_safe(
                         tools,
                         content=self._build_task_event_content(
                             task_id=turn_id or None,
@@ -685,6 +687,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                             "codex_input_summary": input_summary,
                         },
                         log_label="turn started lifecycle event",
+                        log_level=logging.DEBUG,
                     )
 
                 # Reset per-turn token deltas for the new turn.
@@ -1192,7 +1195,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     self._room_threads[room_id] = thread_id
                     self._raw_history_by_room.pop(room_id, None)
                     if Emit.TASK_EVENTS in self.features.emit:
-                        await self._emit_event_safe(
+                        await send_event_safe(
                             tools,
                             content=self._build_task_event_content(
                                 task_id=thread_id,
@@ -1207,6 +1210,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                                 "codex_resumed": True,
                             },
                             log_label="thread resumed task event",
+                            log_level=logging.DEBUG,
                         )
                     return thread_id
             except CodexJsonRpcError as exc:
@@ -1241,7 +1245,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         self._room_threads[room_id] = thread_id
 
         if Emit.TASK_EVENTS in self.features.emit:
-            await self._emit_event_safe(
+            await send_event_safe(
                 tools,
                 content=self._build_task_event_content(
                     task_id=thread_id,
@@ -1257,6 +1261,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     "codex_transport": self.config.transport,
                 },
                 log_label="thread mapped task event",
+                log_level=logging.DEBUG,
             )
 
         return thread_id
@@ -1721,7 +1726,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 metadata["codex_duration_s"] = round(duration_s, 2)
             if has_usage:
                 metadata.update(usage.to_metadata())
-            await self._emit_event_safe(
+            await send_event_safe(
                 tools,
                 content=self._build_task_event_content(
                     task_id=turn_id,
@@ -1732,6 +1737,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 message_type="task",
                 metadata=metadata,
                 log_label="turn outcome task event",
+                log_level=logging.DEBUG,
             )
 
         # Phase 2: Enriched turn lifecycle events
@@ -2344,12 +2350,10 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
     ) -> None:
         """Emit a structured error event when turn/completed reports failure."""
         error = turn_payload.get("error")
-        if error is None:
-            return
         if not isinstance(error, dict):
-            # A falsy scalar (``""``, ``0``) has no useful message to carry;
-            # build_agent_failure's own fallback covers it uniformly instead
-            # of shipping a degenerate literal string like "False".
+            # A falsy scalar (``""``, ``0``, ``None``) has no useful message to
+            # carry; build_agent_failure's own fallback covers it uniformly
+            # instead of shipping a degenerate literal string like "None".
             error = {"message": str(error)} if error else {}
         await tools.send_failure(
             build_agent_failure(
@@ -3305,23 +3309,6 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         if summary and summary != task:
             lines.append(f"Summary: {summary}")
         return "\n".join(lines)
-
-    async def _emit_event_safe(
-        self,
-        tools: AgentToolsProtocol,
-        *,
-        content: str,
-        message_type: str,
-        metadata: dict[str, Any],
-        log_label: str,
-    ) -> None:
-        """Send a best-effort platform event, downgrading a failure to a debug log."""
-        try:
-            await tools.send_event(
-                content=content, message_type=message_type, metadata=metadata
-            )
-        except Exception:
-            logger.debug("Failed to emit %s", log_label, exc_info=True)
 
     @staticmethod
     def _extract_local_command(content: str) -> tuple[str, str] | None:

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -12,12 +12,14 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import ClassVar, Any, Callable, Literal, NamedTuple, Protocol
 
+from band_sdk_core import AgentFailure
 from pydantic import AliasChoices, BaseModel, Field, ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Unpack
 
 from band.converters.codex import CodexHistoryConverter
 from band.converters.helpers import build_replay_messages
+from band.core.delivery import DeliveryFailedError, deliver_reply
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
@@ -42,7 +44,7 @@ from band.integrations.codex.types import (
     CodexItemType,
     CodexSessionState,
     CodexTokenUsage,
-    build_structured_error_metadata,
+    build_agent_failure,
     parse_plan_steps,
 )
 from band.runtime.custom_tools import (
@@ -356,8 +358,6 @@ class CodexAdapterConfig(BaseSettings):
     # File-change approvals always key on the sorted set of paths being
     # modified, independent of this flag.
     session_approval_granularity: Literal["binary", "full_command"] = "full_command"
-    # --- Phase 1: Structured errors & enriched approvals ---
-    structured_errors: bool = True
     # --- Phase 2: Plan & task lifecycle ---
     stream_plan_events: bool = False
     emit_turn_lifecycle_events: bool = False
@@ -525,7 +525,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             "execution_reporting=%s, self_config_tools=%s, "
             "task_events=%s, turn_markers=%s, thought_events=%s, "
             "stream_reasoning=%s, stream_plan=%s, stream_commentary=%s, "
-            "diffs=%s, token_usage=%s, structured_errors=%s",
+            "diffs=%s, token_usage=%s",
             agent_name,
             self.config.transport,
             self._selected_model or self.config.model or "auto",
@@ -541,7 +541,6 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             self.config.stream_commentary_events,
             self.config.emit_diff_events,
             self.config.emit_token_usage_events,
-            self.config.structured_errors,
         )
 
     async def on_event(self, inp: AgentInput) -> None:
@@ -582,142 +581,157 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 return
 
         async with self._rpc_lock:
-            await self._ensure_client_ready()
-            if self._client is None:
-                raise RuntimeError(
-                    "Codex client not initialized after _ensure_client_ready"
-                )
+            try:
+                await self._ensure_client_ready()
+                if self._client is None:
+                    raise RuntimeError(
+                        "Codex client not initialized after _ensure_client_ready"
+                    )
 
-            if command is not None:
-                handled = await self._handle_local_command(
-                    tools=tools,
-                    msg=msg,
-                    history=history,
+                if command is not None:
+                    handled = await self._handle_local_command(
+                        tools=tools,
+                        msg=msg,
+                        history=history,
+                        room_id=room_id,
+                        command=command[0],
+                        args=command[1],
+                    )
+                    if handled:
+                        return
+
+                thread_id = await self._ensure_thread(
                     room_id=room_id,
-                    command=command[0],
-                    args=command[1],
-                )
-                if handled:
-                    return
-
-            thread_id = await self._ensure_thread(
-                room_id=room_id,
-                history=history,
-                tools=tools,
-                is_session_bootstrap=is_session_bootstrap,
-            )
-
-            turn_input, has_pending_prompt_injection = self._build_turn_input(
-                msg=msg,
-                participants_msg=participants_msg,
-                contacts_msg=contacts_msg,
-                room_id=room_id,
-            )
-
-            turn_params: dict[str, Any] = {
-                "threadId": thread_id,
-                "input": turn_input,
-            }
-            self._apply_turn_overrides(turn_params, room_id=room_id)
-
-            turn_started = await self._start_turn(turn_params)
-            if has_pending_prompt_injection:
-                self._prompt_injected_rooms.add(room_id)
-            turn = turn_started.get("turn") if isinstance(turn_started, dict) else {}
-            turn_id = str((turn or {}).get("id") or "")
-
-            if (
-                Emit.TASK_EVENTS in self.features.emit
-                and self.config.emit_turn_task_markers
-            ):
-                await tools.send_event(
-                    content=self._build_task_event_content(
-                        task_id=turn_id or None,
-                        task="Codex turn",
-                        status="started",
-                        summary=f"Thread: {thread_id}",
-                    ),
-                    message_type="task",
-                    metadata={
-                        "codex_thread_id": thread_id,
-                        "codex_turn_id": turn_id or None,
-                        "codex_room_id": room_id,
-                    },
+                    history=history,
+                    tools=tools,
+                    is_session_bootstrap=is_session_bootstrap,
                 )
 
-            # Phase 2: Turn STARTED lifecycle event with input summary
-            if (
-                self.config.emit_turn_lifecycle_events
-                and Emit.TASK_EVENTS in self.features.emit
-            ):
-                input_summary = (msg.content or "")[:200]
+                turn_input, has_pending_prompt_injection = self._build_turn_input(
+                    msg=msg,
+                    participants_msg=participants_msg,
+                    contacts_msg=contacts_msg,
+                    room_id=room_id,
+                )
+
+                turn_params: dict[str, Any] = {
+                    "threadId": thread_id,
+                    "input": turn_input,
+                }
+                self._apply_turn_overrides(turn_params, room_id=room_id)
+
+                turn_started = await self._start_turn(turn_params)
+                if has_pending_prompt_injection:
+                    self._prompt_injected_rooms.add(room_id)
+                turn = (
+                    turn_started.get("turn") if isinstance(turn_started, dict) else {}
+                )
+                turn_id = str((turn or {}).get("id") or "")
+
+                if (
+                    Emit.TASK_EVENTS in self.features.emit
+                    and self.config.emit_turn_task_markers
+                ):
+                    try:
+                        await tools.send_event(
+                            content=self._build_task_event_content(
+                                task_id=turn_id or None,
+                                task="Codex turn",
+                                status="started",
+                                summary=f"Thread: {thread_id}",
+                            ),
+                            message_type="task",
+                            metadata={
+                                "codex_thread_id": thread_id,
+                                "codex_turn_id": turn_id or None,
+                                "codex_room_id": room_id,
+                            },
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Failed to emit turn started task event", exc_info=True
+                        )
+
+                # Phase 2: Turn STARTED lifecycle event with input summary
+                if (
+                    self.config.emit_turn_lifecycle_events
+                    and Emit.TASK_EVENTS in self.features.emit
+                ):
+                    input_summary = (msg.content or "")[:200]
+                    try:
+                        await tools.send_event(
+                            content=self._build_task_event_content(
+                                task_id=turn_id or None,
+                                task="Codex turn lifecycle",
+                                status="started",
+                                summary=f"Thread: {thread_id}",
+                            ),
+                            message_type="task",
+                            metadata={
+                                "codex_event_type": "turn_lifecycle",
+                                "codex_room_id": room_id,
+                                "codex_thread_id": thread_id,
+                                "codex_turn_id": turn_id or None,
+                                "codex_turn_status": "started",
+                                "codex_input_summary": input_summary,
+                            },
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Failed to emit turn started lifecycle event",
+                            exc_info=True,
+                        )
+
+                # Reset per-turn token deltas for the new turn.
+                usage_obj = self._token_usage.get(thread_id)
+                if usage_obj is not None:
+                    usage_obj.reset_turn_deltas()
+
+                # perf_counter (not monotonic): highest-resolution clock, so a fast
+                # turn still measures a non-zero duration on Windows, where
+                # monotonic()'s coarse tick can round an instant turn to 0.0.
+                _turn_start = _time.perf_counter()
                 try:
-                    await tools.send_event(
-                        content=self._build_task_event_content(
-                            task_id=turn_id or None,
-                            task="Codex turn lifecycle",
-                            status="started",
-                            summary=f"Thread: {thread_id}",
-                        ),
-                        message_type="task",
-                        metadata={
-                            "codex_event_type": "turn_lifecycle",
-                            "codex_room_id": room_id,
-                            "codex_thread_id": thread_id,
-                            "codex_turn_id": turn_id or None,
-                            "codex_turn_status": "started",
-                            "codex_input_summary": input_summary,
-                        },
+                    result = await self._process_turn_events(
+                        tools=tools,
+                        msg=msg,
+                        room_id=room_id,
+                        thread_id=thread_id,
+                        turn_id=turn_id or None,
+                        turn_start=_turn_start,
                     )
                 except Exception:
-                    logger.debug(
-                        "Failed to emit turn started lifecycle event",
-                        exc_info=True,
+                    logger.exception(
+                        "Unexpected error during Codex turn event processing "
+                        "(thread=%s, turn=%s)",
+                        thread_id,
+                        turn_id,
+                    )
+                    result = TurnResult(
+                        turn_status="failed",
+                        turn_error="Internal error during turn processing",
                     )
 
-            # Reset per-turn token deltas for the new turn.
-            usage_obj = self._token_usage.get(thread_id)
-            if usage_obj is not None:
-                usage_obj.reset_turn_deltas()
-
-            # perf_counter (not monotonic): highest-resolution clock, so a fast
-            # turn still measures a non-zero duration on Windows, where
-            # monotonic()'s coarse tick can round an instant turn to 0.0.
-            _turn_start = _time.perf_counter()
-            try:
-                result = await self._process_turn_events(
+                _turn_duration_s = _time.perf_counter() - _turn_start
+                await self._emit_turn_outcome(
                     tools=tools,
                     msg=msg,
                     room_id=room_id,
                     thread_id=thread_id,
                     turn_id=turn_id or None,
-                    turn_start=_turn_start,
+                    turn_status=result.turn_status,
+                    turn_error=result.turn_error,
+                    final_text=result.final_text,
+                    saw_send_message_tool=result.saw_send_message_tool,
+                    duration_s=_turn_duration_s,
                 )
-            except Exception:
-                logger.exception(
-                    "Unexpected error during Codex turn event processing "
-                    "(thread=%s, turn=%s)",
-                    thread_id,
-                    turn_id,
-                )
-                result = TurnResult(
-                    turn_status="failed",
-                    turn_error="Internal error during turn processing",
-                )
-
-            _turn_duration_s = _time.perf_counter() - _turn_start
-            await self._emit_turn_outcome(
-                tools=tools,
-                msg=msg,
-                room_id=room_id,
-                thread_id=thread_id,
-                turn_id=turn_id or None,
-                turn_status=result.turn_status,
-                turn_error=result.turn_error,
-                final_text=result.final_text,
-                saw_send_message_tool=result.saw_send_message_tool,
-                duration_s=_turn_duration_s,
-            )
+            except DeliveryFailedError as e:
+                # The turn did its work; posting it to the room is what failed.
+                # Band-side delivery, never a Codex provider failure.
+                logger.exception("Codex reply delivery failed: %s", e.cause)
+            except Exception as e:
+                await tools.send_failure(AgentFailure("codex", str(e)))
+                raise
 
     async def _process_turn_events(
         self,
@@ -985,7 +999,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     result.turn_status = str(turn_payload.get("status") or "failed")
                     result.turn_error = self._extract_turn_error(turn_payload)
                     # Phase 1: structured error for failed turns
-                    if result.turn_status == "failed" and self.config.structured_errors:
+                    if result.turn_status == "failed":
                         await self._emit_structured_turn_error(
                             tools=tools,
                             turn_payload=turn_payload,
@@ -1144,20 +1158,26 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     self._room_threads[room_id] = thread_id
                     self._raw_history_by_room.pop(room_id, None)
                     if Emit.TASK_EVENTS in self.features.emit:
-                        await tools.send_event(
-                            content=self._build_task_event_content(
-                                task_id=thread_id,
-                                task="Codex thread",
-                                status="resumed",
-                                summary=f"Room: {room_id}",
-                            ),
-                            message_type="task",
-                            metadata={
-                                "codex_thread_id": thread_id,
-                                "codex_room_id": room_id,
-                                "codex_resumed": True,
-                            },
-                        )
+                        try:
+                            await tools.send_event(
+                                content=self._build_task_event_content(
+                                    task_id=thread_id,
+                                    task="Codex thread",
+                                    status="resumed",
+                                    summary=f"Room: {room_id}",
+                                ),
+                                message_type="task",
+                                metadata={
+                                    "codex_thread_id": thread_id,
+                                    "codex_room_id": room_id,
+                                    "codex_resumed": True,
+                                },
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Failed to emit thread resumed task event",
+                                exc_info=True,
+                            )
                     return thread_id
             except CodexJsonRpcError as exc:
                 logger.warning(
@@ -1191,21 +1211,24 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         self._room_threads[room_id] = thread_id
 
         if Emit.TASK_EVENTS in self.features.emit:
-            await tools.send_event(
-                content=self._build_task_event_content(
-                    task_id=thread_id,
-                    task="Codex thread",
-                    status="mapped",
-                    summary=f"Transport: {self.config.transport}",
-                ),
-                message_type="task",
-                metadata={
-                    "codex_thread_id": thread_id,
-                    "codex_room_id": room_id,
-                    "codex_created_at": datetime.now(timezone.utc).isoformat(),
-                    "codex_transport": self.config.transport,
-                },
-            )
+            try:
+                await tools.send_event(
+                    content=self._build_task_event_content(
+                        task_id=thread_id,
+                        task="Codex thread",
+                        status="mapped",
+                        summary=f"Transport: {self.config.transport}",
+                    ),
+                    message_type="task",
+                    metadata={
+                        "codex_thread_id": thread_id,
+                        "codex_room_id": room_id,
+                        "codex_created_at": datetime.now(timezone.utc).isoformat(),
+                        "codex_transport": self.config.transport,
+                    },
+                )
+            except Exception:
+                logger.debug("Failed to emit thread mapped task event", exc_info=True)
 
         return thread_id
 
@@ -1669,16 +1692,19 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 metadata["codex_duration_s"] = round(duration_s, 2)
             if has_usage:
                 metadata.update(usage.to_metadata())
-            await tools.send_event(
-                content=self._build_task_event_content(
-                    task_id=turn_id,
-                    task="Codex turn",
-                    status=turn_status,
-                    summary=summary,
-                ),
-                message_type="task",
-                metadata=metadata,
-            )
+            try:
+                await tools.send_event(
+                    content=self._build_task_event_content(
+                        task_id=turn_id,
+                        task="Codex turn",
+                        status=turn_status,
+                        summary=summary,
+                    ),
+                    message_type="task",
+                    metadata=metadata,
+                )
+            except Exception:
+                logger.debug("Failed to emit turn outcome task event", exc_info=True)
 
         # Phase 2: Enriched turn lifecycle events
         if (
@@ -1724,11 +1750,12 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 and final_text.strip()
                 and not saw_send_message_tool
             ):
-                await tools.send_message(final_text.strip(), mentions=mention)
+                await deliver_reply(tools, final_text.strip(), mentions=mention)
             return
 
         if turn_status == "interrupted":
-            await tools.send_message(
+            await deliver_reply(
+                tools,
                 "I stopped before completing this request.",
                 mentions=mention,
             )
@@ -1739,7 +1766,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             if not turn_error
             else f"I couldn't complete this request ({turn_status}): {turn_error}"
         )
-        await tools.send_message(error_text, mentions=mention)
+        await deliver_reply(tools, error_text, mentions=mention)
 
     async def _emit_item_completed_events(
         self,
@@ -2266,26 +2293,11 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             return
 
         logger.error("Codex error: %s", error_msg)
-        if self.config.structured_errors:
-            content, err_meta = build_structured_error_metadata(
-                error_obj, thread_id=thread_id, turn_id=turn_id
+        await tools.send_failure(
+            build_agent_failure(
+                error_obj, thread_id=thread_id, turn_id=turn_id, room_id=room_id
             )
-            err_meta["codex_room_id"] = room_id
-            await tools.send_event(
-                content=content or f"Codex error: {error_msg}",
-                message_type="error",
-                metadata=err_meta,
-            )
-        else:
-            await tools.send_event(
-                content=f"Codex error: {error_msg}",
-                message_type="error",
-                metadata={
-                    "codex_room_id": room_id,
-                    "codex_thread_id": thread_id,
-                    "codex_turn_id": turn_id,
-                },
-            )
+        )
 
     async def _emit_structured_turn_error(
         self,
@@ -2298,20 +2310,15 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
     ) -> None:
         """Emit a structured error event when turn/completed reports failure."""
         error = turn_payload.get("error")
-        if not isinstance(error, dict):
+        if error is None:
             return
-        content, err_meta = build_structured_error_metadata(
-            error, thread_id=thread_id, turn_id=turn_id
-        )
-        err_meta["codex_room_id"] = room_id
-        try:
-            await tools.send_event(
-                content=content,
-                message_type="error",
-                metadata=err_meta,
+        if not isinstance(error, dict):
+            error = {"message": str(error)}
+        await tools.send_failure(
+            build_agent_failure(
+                error, thread_id=thread_id, turn_id=turn_id, room_id=room_id
             )
-        except Exception:
-            logger.debug("Failed to emit structured turn error", exc_info=True)
+        )
 
     # ------------------------------------------------------------------
     # Phase 2: Plan step tracking
@@ -2550,7 +2557,8 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         mention = [{"id": msg.sender_id, "name": msg.sender_name or msg.sender_type}]
 
         if command == "help":
-            await tools.send_message(
+            await deliver_reply(
+                tools,
                 "Codex commands: "
                 "`/status`, `/model`, `/models`, `/model list`, `/models list`, `/model <id>`, "
                 "`/reasoning [none|minimal|low|medium|high|xhigh]`, "
@@ -2587,13 +2595,14 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 f"- token_usage: {usage_line}\n"
                 f"- turn_task_markers: {self.config.emit_turn_task_markers}"
             )
-            await tools.send_message(status_text, mentions=mention)
+            await deliver_reply(tools, status_text, mentions=mention)
             return True
 
         if command in {"model", "models"}:
             model_arg = args.strip()
             if not model_arg:
-                await tools.send_message(
+                await deliver_reply(
+                    tools,
                     "Current model: "
                     f"`{self._selected_model or 'unknown'}` "
                     f"(configured: `{self.config.model or 'auto'}`). "
@@ -2611,12 +2620,14 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     preview = ", ".join(models[:10])
                     if len(models) > 10:
                         preview += ", ..."
-                    await tools.send_message(
+                    await deliver_reply(
+                        tools,
                         f"Available models ({len(models)}): {preview}",
                         mentions=mention,
                     )
                 else:
-                    await tools.send_message(
+                    await deliver_reply(
+                        tools,
                         "No visible models returned by Codex app-server.",
                         mentions=mention,
                     )
@@ -2624,7 +2635,8 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
 
             self.config.model = model_arg
             self._selected_model = model_arg
-            await tools.send_message(
+            await deliver_reply(
+                tools,
                 f"Model override set to `{model_arg}` for subsequent turns.",
                 mentions=mention,
             )
@@ -2633,7 +2645,8 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         if command == "reasoning":
             effort_arg = args.strip().lower()
             if not effort_arg:
-                await tools.send_message(
+                await deliver_reply(
+                    tools,
                     f"Current reasoning effort: `{self.config.reasoning_effort or 'default'}`. "
                     f"Summary: `{self.config.reasoning_summary or 'default'}`. "
                     f"Use `/reasoning <{'|'.join(sorted(_REASONING_EFFORTS))}>` to override.",
@@ -2641,14 +2654,16 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 )
                 return True
             if effort_arg not in _REASONING_EFFORTS:
-                await tools.send_message(
+                await deliver_reply(
+                    tools,
                     f"Invalid reasoning effort `{effort_arg}`. "
                     f"Valid values: {', '.join(sorted(_REASONING_EFFORTS))}.",
                     mentions=mention,
                 )
                 return True
             self.config.reasoning_effort = effort_arg  # type: ignore[assignment]  # Literal narrowed by Pydantic validation
-            await tools.send_message(
+            await deliver_reply(
+                tools,
                 f"Reasoning effort set to `{effort_arg}` for subsequent turns.",
                 mentions=mention,
             )
@@ -2657,7 +2672,8 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         # --- Phase 1: /sandbox and /permissions commands ---
         if command == "sandbox":
             if self.config.sandbox_policy is not None:
-                await tools.send_message(
+                await deliver_reply(
+                    tools,
                     "Cannot override sandbox: a `sandbox_policy` is configured. "
                     "Remove `sandbox_policy` from config to use per-room `/sandbox` overrides.",
                     mentions=mention,
@@ -2666,7 +2682,8 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             mode_arg = args.strip()
             if not mode_arg:
                 effective = self._effective_sandbox(room_id) or "default"
-                await tools.send_message(
+                await deliver_reply(
+                    tools,
                     f"Current sandbox: `{effective}`. "
                     "Use `/sandbox <read-only|workspace-write|danger-full-access>` to change.",
                     mentions=mention,
@@ -2678,7 +2695,8 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             confirm_flag = "--confirm" in tokens
             mode_tokens = [tok for tok in tokens if tok != "--confirm"]
             if len(mode_tokens) != 1:
-                await tools.send_message(
+                await deliver_reply(
+                    tools,
                     "Usage: `/sandbox <read-only|workspace-write|danger-full-access> "
                     "[--confirm]`.",
                     mentions=mention,
@@ -2687,14 +2705,16 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             mode_token = mode_tokens[0]
             normalized = self._normalize_sandbox_mode(mode_token)
             if normalized is None:
-                await tools.send_message(
+                await deliver_reply(
+                    tools,
                     f"Invalid sandbox mode `{mode_token}`. "
                     "Valid: read-only, workspace-write, danger-full-access.",
                     mentions=mention,
                 )
                 return True
             if normalized == "danger-full-access" and not confirm_flag:
-                await tools.send_message(
+                await deliver_reply(
+                    tools,
                     "Escalating to `danger-full-access` removes all sandbox "
                     "restrictions. Re-run with `--confirm` to proceed:\n"
                     "`/sandbox danger-full-access --confirm`",
@@ -2709,7 +2729,8 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     msg.sender_name or msg.sender_type or "unknown",
                 )
             self._sandbox_overrides[room_id] = normalized
-            await tools.send_message(
+            await deliver_reply(
+                tools,
                 f"Sandbox mode set to `{normalized}` for subsequent turns in this room.",
                 mentions=mention,
             )
@@ -2733,7 +2754,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                         f"  - [{entry.timestamp}] {entry.method}: "
                         f"{entry.decision} by {entry.decided_by}"
                     )
-            await tools.send_message("\n".join(lines), mentions=mention)
+            await deliver_reply(tools, "\n".join(lines), mentions=mention)
             return True
 
         # --- Phase 2: /threads, /thread info, /thread archive ---
@@ -2742,22 +2763,22 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             if command == "threads" or not subcommand:
                 # List all room->thread mappings
                 if not self._room_threads:
-                    await tools.send_message(
-                        "No active thread mappings.", mentions=mention
+                    await deliver_reply(
+                        tools, "No active thread mappings.", mentions=mention
                     )
                     return True
                 lines = ["Active thread mappings:"]
                 for rid, tid in self._room_threads.items():
                     current = " (current)" if rid == room_id else ""
                     lines.append(f"- room `{rid}` → thread `{tid}`{current}")
-                await tools.send_message("\n".join(lines), mentions=mention)
+                await deliver_reply(tools, "\n".join(lines), mentions=mention)
                 return True
 
             if subcommand == "info":
                 mapped_thread = self._room_threads.get(room_id)
                 if not mapped_thread:
-                    await tools.send_message(
-                        "No thread mapped for this room.", mentions=mention
+                    await deliver_reply(
+                        tools, "No thread mapped for this room.", mentions=mention
                     )
                     return True
                 usage = self._token_usage.get(mapped_thread)
@@ -2772,7 +2793,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     f"- room_id: {room_id}\n"
                     f"- token_usage: {usage_line}"
                 )
-                await tools.send_message(info_text, mentions=mention)
+                await deliver_reply(tools, info_text, mentions=mention)
                 return True
 
             if subcommand == "archive":
@@ -2781,7 +2802,8 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 self._token_usage.pop(mapped_thread or "", None)
                 self._raw_history_by_room.pop(room_id, None)
                 self._needs_history_injection.discard(room_id)
-                await tools.send_message(
+                await deliver_reply(
+                    tools,
                     f"Thread `{mapped_thread or 'none'}` archived. "
                     "A new thread will be created on next message.",
                     mentions=mention,
@@ -2794,19 +2816,22 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         if command == "usage":
             mapped_thread = self._room_threads.get(room_id)
             if not mapped_thread:
-                await tools.send_message(
+                await deliver_reply(
+                    tools,
                     "No thread mapped for this room — no usage data.",
                     mentions=mention,
                 )
                 return True
             usage = self._token_usage.get(mapped_thread)
             if not usage or usage.total_tokens == 0:
-                await tools.send_message(
+                await deliver_reply(
+                    tools,
                     "No token usage recorded for this thread.",
                     mentions=mention,
                 )
                 return True
-            await tools.send_message(
+            await deliver_reply(
+                tools,
                 f"Thread `{mapped_thread}` — {usage.format_summary()}",
                 mentions=mention,
             )

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -727,8 +727,12 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 )
             except DeliveryFailedError as e:
                 # The turn did its work; posting it to the room is what failed.
-                # Band-side delivery, never a Codex provider failure.
+                # Band-side delivery, never a Codex provider failure -- but
+                # this call path had no try/except before deliver_reply
+                # existed, so any exception here must keep propagating
+                # exactly as it always did (durable mark_failed/retry).
                 logger.exception("Codex reply delivery failed: %s", e.cause)
+                raise e.cause from None
             except Exception as e:
                 await tools.send_failure(AgentFailure("codex", str(e)))
                 raise
@@ -2853,21 +2857,22 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
 
         if command == "approvals":
             if not pending:
-                await tools.send_message("No pending approvals.", mentions=mention)
+                await deliver_reply(tools, "No pending approvals.", mentions=mention)
                 return True
             lines = ["Pending approvals:"]
             now = datetime.now(timezone.utc)
             for token, item in list(pending.items()):
                 age_s = int((now - item.created_at).total_seconds())
                 lines.append(f"- {token}: {item.summary} ({age_s}s)")
-            await tools.send_message("\n".join(lines), mentions=mention)
+            await deliver_reply(tools, "\n".join(lines), mentions=mention)
             return True
 
         if command not in {"approve", "decline", "approve-session"}:
             return False
 
         if not pending:
-            await tools.send_message(
+            await deliver_reply(
+                tools,
                 "No pending approvals to resolve.",
                 mentions=mention,
             )
@@ -2878,7 +2883,8 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             selected = pending.get(token)
             if selected is None:
                 available = ", ".join(sorted(pending.keys()))
-                await tools.send_message(
+                await deliver_reply(
+                    tools,
                     f"Unknown approval id `{token}`. Pending: {available}",
                     mentions=mention,
                 )
@@ -2887,7 +2893,8 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             token, selected = next(iter(pending.items()))
         else:
             available = ", ".join(sorted(pending.keys()))
-            await tools.send_message(
+            await deliver_reply(
+                tools,
                 "Multiple approvals pending. "
                 f"Use `/{command} <id>`. Pending: {available}",
                 mentions=mention,
@@ -2903,7 +2910,8 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         # an empty string in _session_approved or report a misleading
         # "Future `` requests will be auto-approved" message to the user.
         if is_session and not selected.session_key:
-            await tools.send_message(
+            await deliver_reply(
+                tools,
                 f"Approval `{token}` cannot be resolved as session-level: "
                 "this request has no command signature to match against. "
                 f"Use `/approve {token}` for a one-shot approval instead.",
@@ -2924,13 +2932,15 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         # Session-level: register the session key for auto-approval
         if is_session:
             self._record_session_approval(room_id, selected.session_key)
-            await tools.send_message(
+            await deliver_reply(
+                tools,
                 f"Approval `{token}` resolved as `acceptForSession` (session-level). "
                 f"Future `{selected.session_key}` requests will be auto-approved.",
                 mentions=mention,
             )
         else:
-            await tools.send_message(
+            await deliver_reply(
+                tools,
                 f"Approval `{token}` resolved as `{decision_value}`.",
                 mentions=mention,
             )

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -10,7 +10,7 @@ import time as _time
 from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import ClassVar, Any, Callable, Literal, NamedTuple, Protocol
+from typing import ClassVar, Any, Callable, Literal, NamedTuple, NoReturn, Protocol
 
 from band_sdk_core import AgentFailure
 from pydantic import AliasChoices, BaseModel, Field, ValidationError, field_validator
@@ -79,6 +79,16 @@ def _image_content_items(result: dict[str, Any]) -> list[dict[str, Any]]:
         }
         for block in result["content"]
     ]
+
+
+def _reraise_delivery_cause(e: DeliveryFailedError) -> NoReturn:
+    """Band-side reply delivery failed, never a Codex provider failure.
+
+    Re-raises the cause (not this wrapper) so mark_failed/retry bookkeeping
+    keys off the real exception.
+    """
+    logger.exception("Codex reply delivery failed: %s", e.cause)
+    raise e.cause from None
 
 
 TransportKind = Literal["stdio", "ws"]
@@ -579,11 +589,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     args=command[1],
                 )
             except DeliveryFailedError as e:
-                # Same Band-delivery-vs-provider-failure split as the
-                # turn-processing path below: re-raise the cause so
-                # mark_failed/retry bookkeeping keys off the real exception.
-                logger.exception("Codex reply delivery failed: %s", e.cause)
-                raise e.cause from None
+                _reraise_delivery_cause(e)
             if handled:
                 return
 
@@ -726,12 +732,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     duration_s=_turn_duration_s,
                 )
             except DeliveryFailedError as e:
-                # The turn did its work; posting it to the room is what
-                # failed -- Band-side delivery, never a Codex provider
-                # failure. Re-raise the cause (not this wrapper) so
-                # mark_failed/retry bookkeeping keys off the real exception.
-                logger.exception("Codex reply delivery failed: %s", e.cause)
-                raise e.cause from None
+                _reraise_delivery_cause(e)
             except Exception as e:
                 await tools.send_failure(AgentFailure("codex", str(e)))
                 raise

--- a/src/band/adapters/copilot_sdk.py
+++ b/src/band/adapters/copilot_sdk.py
@@ -14,6 +14,7 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
+from band_sdk_core import AgentFailure
 from pydantic import ValidationError
 
 from band.converters.copilot_sdk import (
@@ -403,9 +404,14 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
 
         # Same-session calls must not interleave; other rooms run concurrently.
         async with self._session_manager.turn_lock(room_id):
-            session, inject_text = await self._obtain_session(
-                room_id, history, tools, is_session_bootstrap=is_session_bootstrap
-            )
+            try:
+                session, inject_text = await self._obtain_session(
+                    room_id, history, tools, is_session_bootstrap=is_session_bootstrap
+                )
+            except Exception as exc:
+                logger.exception("Room %s: Copilot session setup failed", room_id)
+                await tools.send_failure(AgentFailure("copilot_sdk", str(exc)))
+                raise
             prompt = self._compose_prompt(
                 msg,
                 participants_msg,
@@ -430,7 +436,7 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
                 # Abort any work the runtime is still doing for this turn and
                 # drop the session; the next message resumes it fresh by id.
                 await self._session_manager.evict_session(room_id)
-                await self._report_error(tools, str(exc))
+                await tools.send_failure(AgentFailure("copilot_sdk", str(exc)))
                 raise
             finally:
                 self._turn_state.pop(room_id, None)
@@ -444,7 +450,9 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
             # Session errors raise out of send_and_wait, so a None here
             # with no room output means the model genuinely said nothing.
             if final_text is None and not turn.replied_in_room:
-                await self._report_error(tools, "no assistant reply")
+                await tools.send_failure(
+                    AgentFailure("copilot_sdk", "no assistant reply")
+                )
                 raise RuntimeError("Copilot turn produced no reply")
 
             # The turn may already have replied into the room; sending its
@@ -962,6 +970,3 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
             logger.warning("Failed to send %s event: %s", message_type, exc)
             return False
         return True
-
-    async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        await self._send_event_safe(tools, f"Error: {error}", MessageType.ERROR)

--- a/src/band/adapters/copilot_sdk.py
+++ b/src/band/adapters/copilot_sdk.py
@@ -22,7 +22,13 @@ from band.converters.copilot_sdk import (
     CopilotSDKHistoryConverter,
     CopilotSDKSessionState,
 )
+from band.core.delivery import (
+    DeliveryFailedError,
+    deliver_reply,
+    reraise_delivery_cause,
+)
 from band.core.exceptions import BandConfigError
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE
 from band.core.simple_adapter import SimpleAdapter
 from band.core.tool_filter import filter_tool_schemas
 from band.core.types import Capability, Emit, MessageType, ToolEventKey, TurnUsage
@@ -408,9 +414,11 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
                 session, inject_text = await self._obtain_session(
                     room_id, history, tools, is_session_bootstrap=is_session_bootstrap
                 )
-            except Exception as exc:
+            except Exception:
                 logger.exception("Room %s: Copilot session setup failed", room_id)
-                await tools.send_failure(AgentFailure("copilot_sdk", str(exc)))
+                await tools.send_failure(
+                    AgentFailure("copilot_sdk", GENERIC_PROVIDER_FAILURE_MESSAGE)
+                )
                 raise
             prompt = self._compose_prompt(
                 msg,
@@ -431,12 +439,14 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
             self._turn_state[room_id] = turn
             try:
                 final_text = await self._run_turn(session, prompt, turn)
-            except Exception as exc:
+            except Exception:
                 logger.exception("Room %s: Copilot turn failed", room_id)
                 # Abort any work the runtime is still doing for this turn and
                 # drop the session; the next message resumes it fresh by id.
                 await self._session_manager.evict_session(room_id)
-                await tools.send_failure(AgentFailure("copilot_sdk", str(exc)))
+                await tools.send_failure(
+                    AgentFailure("copilot_sdk", GENERIC_PROVIDER_FAILURE_MESSAGE)
+                )
                 raise
             finally:
                 self._turn_state.pop(room_id, None)
@@ -458,7 +468,12 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
             # The turn may already have replied into the room; sending its
             # final text too would duplicate the reply.
             if final_text and not turn.replied_in_room:
-                await tools.send_message(final_text, mentions=[turn.sender_mention])
+                try:
+                    await deliver_reply(
+                        tools, final_text, mentions=[turn.sender_mention]
+                    )
+                except DeliveryFailedError as e:
+                    reraise_delivery_cause(e)
 
             await self._persist_session_id(room_id, tools)
 

--- a/src/band/adapters/copilot_sdk.py
+++ b/src/band/adapters/copilot_sdk.py
@@ -28,7 +28,7 @@ from band.core.delivery import (
     reraise_delivery_cause,
 )
 from band.core.exceptions import BandConfigError
-from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE, send_event_safe
 from band.core.simple_adapter import SimpleAdapter
 from band.core.tool_filter import filter_tool_schemas
 from band.core.types import Capability, Emit, MessageType, ToolEventKey, TurnUsage
@@ -460,6 +460,7 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
             # Session errors raise out of send_and_wait, so a None here
             # with no room output means the model genuinely said nothing.
             if final_text is None and not turn.replied_in_room:
+                logger.warning("Room %s: Copilot turn produced no reply", room_id)
                 await tools.send_failure(
                     AgentFailure("copilot_sdk", "no assistant reply")
                 )
@@ -831,7 +832,7 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
         invocation: ToolInvocation,
         arguments: dict[str, Any],
     ) -> None:
-        await self._send_event_safe(
+        await send_event_safe(
             room_tools,
             json.dumps(
                 {
@@ -851,7 +852,7 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
         invocation: ToolInvocation,
         output: str,
     ) -> None:
-        await self._send_event_safe(
+        await send_event_safe(
             room_tools,
             json.dumps(
                 {
@@ -943,7 +944,7 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
     async def _emit_thoughts(self, turn: TurnState, tools: AgentToolsProtocol) -> None:
         if Emit.THOUGHTS in self.features.emit:
             for reasoning in turn.reasonings.values():
-                await self._send_event_safe(tools, reasoning, MessageType.THOUGHT)
+                await send_event_safe(tools, reasoning, MessageType.THOUGHT)
 
     async def _persist_session_id(
         self, room_id: str, tools: AgentToolsProtocol
@@ -955,7 +956,7 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
         """
         ids = self._ids(room_id)
         if ids.current and ids.persisted != ids.current:
-            sent = await self._send_event_safe(
+            sent = await send_event_safe(
                 tools,
                 "Copilot SDK session",
                 MessageType.TASK,
@@ -965,23 +966,3 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
                 # Only mark persisted on success so a transient send failure
                 # is retried next turn instead of silently losing resume.
                 ids.persisted = ids.current
-
-    async def _send_event_safe(
-        self,
-        tools: AgentToolsProtocol,
-        content: str,
-        message_type: MessageType,
-        metadata: dict[str, Any] | None = None,
-    ) -> bool:
-        """Send a platform event, downgrading failures to a warning.
-
-        Returns True when the event was accepted by the platform.
-        """
-        try:
-            await tools.send_event(
-                content=content, message_type=message_type, metadata=metadata
-            )
-        except Exception as exc:
-            logger.warning("Failed to send %s event: %s", message_type, exc)
-            return False
-        return True

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -14,6 +14,7 @@ import warnings
 from contextvars import ContextVar
 from typing import ClassVar, TYPE_CHECKING, Any
 
+from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
 from band.core.protocols import AgentToolsProtocol
@@ -281,9 +282,11 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         logger.debug("Handling message %s in room %s", msg.id, room_id)
 
         if not self._crewai_agent:
-            raise RuntimeError(
+            error = RuntimeError(
                 "CrewAI agent not initialized - ensure on_started() was called"
             )
+            await tools.send_failure(AgentFailure("crewai", str(error)))
+            raise error
 
         # Set context variable for tool access (thread-safe room context).
         # Wrap in try/finally immediately to ensure cleanup even if code
@@ -406,15 +409,17 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
                 )
 
             if not (reply_tracker is not None and reply_tracker.replied):
-                await self._report_error(
-                    tools,
-                    missing_reply_error(
-                        "CrewAI",
-                        detail=(
-                            "Repeated tool failures may also have exhausted "
-                            f"max_iter={self.max_iter}."
+                await tools.send_failure(
+                    AgentFailure(
+                        "crewai",
+                        missing_reply_error(
+                            "CrewAI",
+                            detail=(
+                                "Repeated tool failures may also have exhausted "
+                                f"max_iter={self.max_iter}."
+                            ),
                         ),
-                    ),
+                    )
                 )
 
             logger.info(
@@ -448,7 +453,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
                 )
                 return
             logger.error("Error processing message: %s", e, exc_info=True)
-            await self._report_error(tools, str(e))
+            await tools.send_failure(AgentFailure("crewai", str(e)))
             raise
 
         logger.debug(
@@ -462,10 +467,3 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         if room_id in self._message_history:
             del self._message_history[room_id]
             logger.debug("Room %s: Cleaned up CrewAI session", room_id)
-
-    async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        """Send error event (best effort)."""
-        try:
-            await tools.send_event(content=f"Error: {error}", message_type="error")
-        except Exception as e:
-            logger.warning("Failed to send error event: %s", e)

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -282,11 +282,9 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         logger.debug("Handling message %s in room %s", msg.id, room_id)
 
         if not self._crewai_agent:
-            error = RuntimeError(
-                "CrewAI agent not initialized - ensure on_started() was called"
-            )
-            await tools.send_failure(AgentFailure("crewai", str(error)))
-            raise error
+            message = "CrewAI agent not initialized - ensure on_started() was called"
+            await tools.send_failure(AgentFailure("crewai", message))
+            raise RuntimeError(message)
 
         # Set context variable for tool access (thread-safe room context).
         # Wrap in try/finally immediately to ensure cleanup even if code

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -438,6 +438,9 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             )
 
         if not reply_tracker.did_productive_work:
+            logger.warning(
+                "Room %s: CrewAI turn produced nothing for the room", room_id
+            )
             detail = missing_reply_error(
                 "CrewAI",
                 detail=(

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -17,7 +17,11 @@ from typing import ClassVar, TYPE_CHECKING, Any
 from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import (
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    AgentToolsProtocol,
+    TurnResultAlreadyReported,
+)
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import Capability, Emit, FeatureKwargs, PlatformMessage
 from band.converters.crewai import CrewAIHistoryConverter, CrewAIMessages
@@ -407,18 +411,15 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
                 )
 
             if not (reply_tracker is not None and reply_tracker.replied):
-                await tools.send_failure(
-                    AgentFailure(
-                        "crewai",
-                        missing_reply_error(
-                            "CrewAI",
-                            detail=(
-                                "Repeated tool failures may also have exhausted "
-                                f"max_iter={self.max_iter}."
-                            ),
-                        ),
-                    )
+                detail = missing_reply_error(
+                    "CrewAI",
+                    detail=(
+                        "Repeated tool failures may also have exhausted "
+                        f"max_iter={self.max_iter}."
+                    ),
                 )
+                await tools.send_failure(AgentFailure("crewai", detail))
+                raise TurnResultAlreadyReported(detail)
 
             logger.info(
                 "Room %s: CrewAI agent completed (output_length=%s)",
@@ -426,6 +427,8 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
                 len(result.raw) if result and result.raw else 0,
             )
 
+        except TurnResultAlreadyReported:
+            raise
         except Exception as e:
             # CrewAI raises ValueError("Invalid response from LLM call - None or
             # empty.") when its ReAct loop yields an empty final answer. In this
@@ -451,7 +454,9 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
                 )
                 return
             logger.error("Error processing message: %s", e, exc_info=True)
-            await tools.send_failure(AgentFailure("crewai", str(e)))
+            await tools.send_failure(
+                AgentFailure("crewai", GENERIC_PROVIDER_FAILURE_MESSAGE)
+            )
             raise
 
         logger.debug(

--- a/src/band/adapters/crewai_flow.py
+++ b/src/band/adapters/crewai_flow.py
@@ -945,7 +945,7 @@ class SideEffectExecutor:
         # error) -- so the untruncated text is preserved in detail for
         # structured consumers reading the "error"-typed event.
         message = error.message[:500]
-        detail = error.message if len(error.message) > 500 else None
+        detail = error.message if message != error.message else None
         await self._tools.send_failure(
             AgentFailure("crewai_flow", message, error.code, detail)
         )

--- a/src/band/adapters/crewai_flow.py
+++ b/src/band/adapters/crewai_flow.py
@@ -942,9 +942,12 @@ class SideEffectExecutor:
         # room-visible message is capped like every other room post in this
         # file (e.g. record_waiting) -- error.message can embed an unbounded
         # value (e.g. a full participant-id list from an ambiguous-identity
-        # error).
+        # error) -- so the untruncated text is preserved in detail for
+        # structured consumers reading the "error"-typed event.
+        message = error.message[:500]
+        detail = error.message if len(error.message) > 500 else None
         await self._tools.send_failure(
-            AgentFailure("crewai_flow", error.message[:500], error.code)
+            AgentFailure("crewai_flow", message, error.code, detail)
         )
         await self._send_event(
             content=f"failed:{error.code}",

--- a/src/band/adapters/crewai_flow.py
+++ b/src/band/adapters/crewai_flow.py
@@ -938,9 +938,13 @@ class SideEffectExecutor:
         )
 
     async def record_failed(self, error: CrewAIFlowError) -> None:
-        # Best-effort failure event for visibility, then the task event.
+        # Best-effort failure event for visibility, then the task event. The
+        # room-visible message is capped like every other room post in this
+        # file (e.g. record_waiting) -- error.message can embed an unbounded
+        # value (e.g. a full participant-id list from an ambiguous-identity
+        # error).
         await self._tools.send_failure(
-            AgentFailure("crewai_flow", error.message, error.code)
+            AgentFailure("crewai_flow", error.message[:500], error.code)
         )
         await self._send_event(
             content=f"failed:{error.code}",

--- a/src/band/adapters/crewai_flow.py
+++ b/src/band/adapters/crewai_flow.py
@@ -26,6 +26,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Literal, Protocol, Union, runtime_checkable
 from uuid import UUID
 
+from band_sdk_core import AgentFailure
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 from typing_extensions import Unpack
 
@@ -937,15 +938,10 @@ class SideEffectExecutor:
         )
 
     async def record_failed(self, error: CrewAIFlowError) -> None:
-        # Best-effort error event for visibility, then the task event.
-        try:
-            await self._tools.send_event(
-                content=f"flow error: {error.code}: {error.message}"[:500],
-                message_type="error",
-                metadata={"error": error.model_dump()},
-            )
-        except Exception:  # noqa: BLE001
-            logger.warning("Failed to emit error event", exc_info=True)
+        # Best-effort failure event for visibility, then the task event.
+        await self._tools.send_failure(
+            AgentFailure("crewai_flow", error.message, error.code)
+        )
         await self._send_event(
             content=f"failed:{error.code}",
             message_type="task",

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -9,6 +9,7 @@ import warnings
 from typing import Any, ClassVar, cast
 
 import httpx
+from band_sdk_core import AgentFailure
 from pydantic import ValidationError
 from typing_extensions import Unpack
 
@@ -240,10 +241,14 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
         try:
             while True:
                 if tool_rounds >= self.max_tool_rounds:
-                    raise RuntimeError(
+                    max_rounds_error = RuntimeError(
                         f"Exceeded max tool rounds ({self.max_tool_rounds}) "
                         f"in room {room_id}"
                     )
+                    await tools.send_failure(
+                        AgentFailure("gemini", str(max_rounds_error))
+                    )
+                    raise max_rounds_error
 
                 try:
                     response = await self._call_gemini(
@@ -251,7 +256,11 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                     )
                 except Exception as e:
                     logger.exception("Error calling Gemini: %s", e)
-                    await self._report_error(tools, str(e))
+                    if isinstance(e, ServerError):
+                        failure = AgentFailure("gemini", str(e), e.status, e.message)
+                    else:
+                        failure = AgentFailure("gemini", str(e))
+                    await tools.send_failure(failure)
                     raise
 
                 turn_usage = turn_usage + self._usage_from_response(response)
@@ -591,10 +600,3 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
             )
 
         return tool_response_parts
-
-    async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        """Send error event (best effort)."""
-        try:
-            await tools.send_event(content=f"Error: {error}", message_type="error")
-        except Exception as e:
-            logger.warning("Failed to send error event: %s", e)

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -25,7 +25,7 @@ except ImportError as e:
     ) from e
 
 from band.core.exceptions import BandConfigError
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE, AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.tool_filter import sanitize_tool_schema
 from band.core.types import (
@@ -80,7 +80,7 @@ def _to_agent_failure(e: Exception) -> AgentFailure:
     """
     if isinstance(e, ServerError):
         return AgentFailure("gemini", str(e), e.status, e.message)
-    return AgentFailure("gemini", str(e))
+    return AgentFailure("gemini", GENERIC_PROVIDER_FAILURE_MESSAGE)
 
 
 class GeminiAdapter(SimpleAdapter[GeminiMessages]):

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -72,6 +72,17 @@ def _image_function_response_parts(
     return parts
 
 
+def _to_agent_failure(e: Exception) -> AgentFailure:
+    """Parse a turn-ending exception into the shared provider-failure shape.
+
+    ``ServerError`` carries an HTTP status and message that a plain
+    exception's text alone does not.
+    """
+    if isinstance(e, ServerError):
+        return AgentFailure("gemini", str(e), e.status, e.message)
+    return AgentFailure("gemini", str(e))
+
+
 class GeminiAdapter(SimpleAdapter[GeminiMessages]):
     """
     Gemini SDK adapter using SimpleAdapter pattern.
@@ -241,14 +252,12 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
         try:
             while True:
                 if tool_rounds >= self.max_tool_rounds:
-                    max_rounds_error = RuntimeError(
+                    message = (
                         f"Exceeded max tool rounds ({self.max_tool_rounds}) "
                         f"in room {room_id}"
                     )
-                    await tools.send_failure(
-                        AgentFailure("gemini", str(max_rounds_error))
-                    )
-                    raise max_rounds_error
+                    await tools.send_failure(AgentFailure("gemini", message))
+                    raise RuntimeError(message)
 
                 try:
                     response = await self._call_gemini(
@@ -256,11 +265,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                     )
                 except Exception as e:
                     logger.exception("Error calling Gemini: %s", e)
-                    if isinstance(e, ServerError):
-                        failure = AgentFailure("gemini", str(e), e.status, e.message)
-                    else:
-                        failure = AgentFailure("gemini", str(e))
-                    await tools.send_failure(failure)
+                    await tools.send_failure(_to_agent_failure(e))
                     raise
 
                 turn_usage = turn_usage + self._usage_from_response(response)

--- a/src/band/adapters/google_adk.py
+++ b/src/band/adapters/google_adk.py
@@ -19,7 +19,7 @@ from band_sdk_core import AgentFailure
 from pydantic import ValidationError
 from typing_extensions import Unpack
 
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE, AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.tool_filter import sanitize_tool_schema
 from band.core.types import (
@@ -581,9 +581,11 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
                         "Room %s: ADK agent completed with final response",
                         room_id,
                     )
-        except Exception as e:
+        except Exception:
             logger.exception("Error running ADK agent in room %s", room_id)
-            await tools.send_failure(AgentFailure("google_adk", str(e)))
+            await tools.send_failure(
+                AgentFailure("google_adk", GENERIC_PROVIDER_FAILURE_MESSAGE)
+            )
             raise
         finally:
             # Emit before close so a close() failure can't drop the usage, but

--- a/src/band/adapters/google_adk.py
+++ b/src/band/adapters/google_adk.py
@@ -15,6 +15,7 @@ import re
 import uuid
 from typing import ClassVar, TYPE_CHECKING, Any, cast
 
+from band_sdk_core import AgentFailure
 from pydantic import ValidationError
 from typing_extensions import Unpack
 
@@ -474,14 +475,18 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
             # Safety: ensure history exists even if not first message
             self._room_history[room_id] = []
 
-        # A fresh runner is created per message because InMemoryRunner
-        # accumulates session history internally and tool schemas may change
-        # between calls.  History is injected as a text transcript instead.
-        runner = self._create_runner(tools)
         # Per-turn usage, summed across the event stream below. Initialized
         # outside the try so the finally can emit whatever accumulated.
         turn_usage = TurnUsage()
+        # None until the try's construction succeeds, so the finally's close()
+        # has nothing to do if runner construction itself is what failed.
+        runner: InMemoryRunner | None = None
         try:
+            # A fresh runner is created per message because InMemoryRunner
+            # accumulates session history internally and tool schemas may change
+            # between calls.  History is injected as a text transcript instead.
+            runner = self._create_runner(tools)
+
             # Always create a new session ID — each runner is fresh, so there
             # is no in-memory state to resume.  The ID is stored for cleanup
             # tracking.  The session must be pre-created in the runner's
@@ -578,7 +583,7 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
                     )
         except Exception as e:
             logger.exception("Error running ADK agent in room %s", room_id)
-            await self._report_error(tools, str(e))
+            await tools.send_failure(AgentFailure("google_adk", str(e)))
             raise
         finally:
             # Emit before close so a close() failure can't drop the usage, but
@@ -587,7 +592,8 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
                 # No-op unless Emit.USAGE is on; best-effort, never raises.
                 await self.emit_usage(tools, turn_usage)
             finally:
-                await runner.close()
+                if runner is not None:
+                    await runner.close()
 
         # Accumulate message history for future transcript injection
         self._room_history[room_id].append(
@@ -724,10 +730,3 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
                     )
                 except Exception as e:
                     logger.warning("Failed to send tool_result event: %s", e)
-
-    async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        """Send error event (best effort)."""
-        try:
-            await tools.send_event(content=f"Error: {error}", message_type="error")
-        except Exception as e:
-            logger.warning("Failed to send error event: %s", e)

--- a/src/band/adapters/langgraph.py
+++ b/src/band/adapters/langgraph.py
@@ -13,7 +13,7 @@ from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.pregel import Pregel
 from typing_extensions import Unpack
 
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE, AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
     Capability,
@@ -387,10 +387,7 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
             # surface in chat -- code/detail stay unset, never populated from
             # the caught exception.
             await tools.send_failure(
-                AgentFailure(
-                    "langgraph",
-                    "Internal error while processing message; see agent logs.",
-                )
+                AgentFailure("langgraph", GENERIC_PROVIDER_FAILURE_MESSAGE)
             )
             raise
         finally:

--- a/src/band/adapters/langgraph.py
+++ b/src/band/adapters/langgraph.py
@@ -8,6 +8,7 @@ import logging
 from collections import OrderedDict
 from typing import ClassVar, TYPE_CHECKING, Any, Callable
 
+from band_sdk_core import AgentFailure
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.pregel import Pregel
 from typing_extensions import Unpack
@@ -284,62 +285,6 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
         """Handle message with LangGraph."""
         logger.info("[HANDLE] Message %s in room %s", msg.id, room_id)
 
-        # Get LangChain tools
-        lc_tools = (
-            langchain_tools.agent_tools_to_langchain(
-                tools,
-                features=self.features,
-            )
-            + self.additional_tools
-        )
-
-        # Build or get graph
-        if self.graph_factory:
-            graph = self.graph_factory(lc_tools)
-        else:
-            graph = self._static_graph
-
-        if not graph:
-            raise RuntimeError("No graph available")
-
-        checkpointer = getattr(graph, "checkpointer", None) or self._simple_checkpointer
-        if checkpointer is not None:
-            self._room_checkpointers[room_id] = checkpointer
-
-        # Build messages
-        messages: list[Any] = []
-
-        # Session bootstrap: prepend the rendered system prompt and hydrate
-        # platform history exactly once per room. After that, the LangGraph
-        # checkpointer carries the system message and prior turns forward and
-        # we just append the new user turn.
-        should_mark_bootstrapped = False
-        if is_session_bootstrap and room_id not in self._bootstrapped_rooms:
-            checkpointer_already_has_messages = (
-                checkpointer is not None
-                and await self._checkpointer_has_messages(checkpointer, room_id)
-            )
-            if not checkpointer_already_has_messages:
-                if self._inject_system_prompt and self._system_prompt:
-                    messages.append(("system", self._system_prompt))
-                if history:
-                    messages.extend(history)  # Already converted by history_converter
-            should_mark_bootstrapped = True
-
-        # Inject metadata updates as user messages with [System]: prefix.
-        # Many LLM providers (including Anthropic) require a single system
-        # message at the start; additional system messages scattered through
-        # the conversation cause errors and kill provider cache savings.
-        if participants_msg:
-            messages.append(("user", f"[System]: {participants_msg}"))
-
-        if contacts_msg:
-            messages.append(("user", f"[System]: {contacts_msg}"))
-
-        messages.append(("user", msg.format_for_llm()))
-
-        graph_input = {"messages": messages}
-
         # Usage is reported per model call on the stream; a turn may make several
         # (a tool loop), so sum across every on_chat_model_end into one TurnUsage,
         # emitted on every exit via the finally. Gated outside the loop: the
@@ -348,6 +293,66 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
         track_usage = Emit.USAGE in self.features.emit
         turn_usage = TurnUsage()
         try:
+            # Get LangChain tools
+            lc_tools = (
+                langchain_tools.agent_tools_to_langchain(
+                    tools,
+                    features=self.features,
+                )
+                + self.additional_tools
+            )
+
+            # Build or get graph
+            if self.graph_factory:
+                graph = self.graph_factory(lc_tools)
+            else:
+                graph = self._static_graph
+
+            if not graph:
+                raise RuntimeError("No graph available")
+
+            checkpointer = (
+                getattr(graph, "checkpointer", None) or self._simple_checkpointer
+            )
+            if checkpointer is not None:
+                self._room_checkpointers[room_id] = checkpointer
+
+            # Build messages
+            messages: list[Any] = []
+
+            # Session bootstrap: prepend the rendered system prompt and hydrate
+            # platform history exactly once per room. After that, the LangGraph
+            # checkpointer carries the system message and prior turns forward and
+            # we just append the new user turn.
+            should_mark_bootstrapped = False
+            if is_session_bootstrap and room_id not in self._bootstrapped_rooms:
+                checkpointer_already_has_messages = (
+                    checkpointer is not None
+                    and await self._checkpointer_has_messages(checkpointer, room_id)
+                )
+                if not checkpointer_already_has_messages:
+                    if self._inject_system_prompt and self._system_prompt:
+                        messages.append(("system", self._system_prompt))
+                    if history:
+                        messages.extend(
+                            history
+                        )  # Already converted by history_converter
+                should_mark_bootstrapped = True
+
+            # Inject metadata updates as user messages with [System]: prefix.
+            # Many LLM providers (including Anthropic) require a single system
+            # message at the start; additional system messages scattered through
+            # the conversation cause errors and kill provider cache savings.
+            if participants_msg:
+                messages.append(("user", f"[System]: {participants_msg}"))
+
+            if contacts_msg:
+                messages.append(("user", f"[System]: {contacts_msg}"))
+
+            messages.append(("user", msg.format_for_llm()))
+
+            graph_input = {"messages": messages}
+
             async for event in graph.astream_events(
                 graph_input,
                 config={
@@ -376,17 +381,17 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
 
         except Exception:
             logger.exception("Error processing message %s", msg.id)
-            try:
-                # Keep the user-facing payload generic; the full traceback is
-                # in the agent log via logger.exception above. Tool/error
-                # internals can include DB strings, paths, and tokens that
-                # should not surface in chat.
-                await tools.send_event(
-                    content="Internal error while processing message; see agent logs.",
-                    message_type="error",
+            # Keep the user-facing payload generic; the full traceback is in
+            # the agent log via logger.exception above. Tool/error internals
+            # can include DB strings, paths, and tokens that should not
+            # surface in chat -- code/detail stay unset, never populated from
+            # the caught exception.
+            await tools.send_failure(
+                AgentFailure(
+                    "langgraph",
+                    "Internal error while processing message; see agent logs.",
                 )
-            except Exception:
-                logger.exception("Failed to report error event for message %s", msg.id)
+            )
             raise
         finally:
             # No-op unless Emit.USAGE is on; best-effort, never raises.

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -59,6 +59,9 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
+# AgentFailure.provider tag for every failure this adapter reports.
+_PROVIDER = "letta"
+
 
 @dataclass
 class RoomContext:
@@ -279,7 +282,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         if not self._client:
             logger.error("Letta client not initialized, dropping message %s", msg.id)
             message = "Letta adapter not initialized"
-            await tools.send_failure(AgentFailure("letta", message))
+            await tools.send_failure(AgentFailure(_PROVIDER, message))
             raise RuntimeError(message)
 
         # Lock only protects MCP/agent setup, not the full message path.
@@ -297,7 +300,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         except Exception as e:
             logger.exception("Room %s: Failed to prepare Letta session: %s", room_id, e)
             await tools.send_failure(
-                AgentFailure("letta", GENERIC_PROVIDER_FAILURE_MESSAGE)
+                AgentFailure(_PROVIDER, GENERIC_PROVIDER_FAILURE_MESSAGE)
             )
             raise
 
@@ -326,7 +329,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         if (room_ctx := await self._room_context(room_id, history, tools)) is None:
             logger.error("Room %s: No Letta agent context, dropping message", room_id)
             message = "Letta agent context unavailable"
-            await tools.send_failure(AgentFailure("letta", message))
+            await tools.send_failure(AgentFailure(_PROVIDER, message))
             raise RuntimeError(message)
 
         # Point the MCP resolver at this room's current tools for the
@@ -445,7 +448,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
             )
             await tools.send_failure(
                 AgentFailure(
-                    "letta",
+                    _PROVIDER,
                     f"Letta agent response timed out after {self.config.turn_timeout_s}s",
                     FAILURE_CODE_TIMEOUT,
                 )
@@ -454,7 +457,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         except Exception as e:
             logger.exception("Room %s: Error during Letta turn: %s", room_id, e)
             await tools.send_failure(
-                AgentFailure("letta", GENERIC_PROVIDER_FAILURE_MESSAGE)
+                AgentFailure(_PROVIDER, GENERIC_PROVIDER_FAILURE_MESSAGE)
             )
             raise
         else:
@@ -606,7 +609,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                 f"Letta agent did not call {self._mcp.send_message_tool} "
                 "(auto-relay disabled); its reply was dropped"
             )
-            await tools.send_failure(AgentFailure("letta", detail))
+            await tools.send_failure(AgentFailure(_PROVIDER, detail))
             raise TurnResultAlreadyReported(detail)
         else:
             final_text = "\n\n".join(final_text_parts)

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -14,7 +14,7 @@ from typing_extensions import Unpack
 
 from band.converters.letta import LettaHistoryConverter, LettaSessionState
 from band.core.delivery import DeliveryFailedError, deliver_reply
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import FAILURE_CODE_TIMEOUT, AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
     AdapterFeatures,
@@ -442,7 +442,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                 AgentFailure(
                     "letta",
                     f"Letta agent response timed out after {self.config.turn_timeout_s}s",
-                    "timeout",
+                    FAILURE_CODE_TIMEOUT,
                 )
             )
         except Exception as e:

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -9,9 +9,11 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import ClassVar, Any
 
+from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
 from band.converters.letta import LettaHistoryConverter, LettaSessionState
+from band.core.delivery import DeliveryFailedError, deliver_reply
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
@@ -267,7 +269,9 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         """Handle incoming message via Letta API with MCP tools."""
         if not self._client:
             logger.error("Letta client not initialized, dropping message %s", msg.id)
-            await self._report_error(tools, "Letta adapter not initialized")
+            await tools.send_failure(
+                AgentFailure("letta", "Letta adapter not initialized")
+            )
             return
 
         # Lock only protects MCP/agent setup, not the full message path.
@@ -284,7 +288,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                     await self._ensure_agent(room_id, history, tools)
         except Exception as e:
             logger.exception("Room %s: Failed to prepare Letta session: %s", room_id, e)
-            await self._report_error(tools, str(e))
+            await tools.send_failure(AgentFailure("letta", str(e)))
             return
 
         await self._handle_message(
@@ -311,7 +315,9 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         """Run one Letta turn: resolve the room, compose the message, send."""
         if (room_ctx := await self._room_context(room_id, history, tools)) is None:
             logger.error("Room %s: No Letta agent context, dropping message", room_id)
-            await self._report_error(tools, "Letta agent context unavailable")
+            await tools.send_failure(
+                AgentFailure("letta", "Letta agent context unavailable")
+            )
             return
 
         # Point the MCP resolver at this room's current tools for the
@@ -418,19 +424,30 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                 ),
                 timeout=self.config.turn_timeout_s,
             )
+        except DeliveryFailedError as e:
+            # The agent answered; posting the reply to the room is what
+            # failed. Band-side delivery, never a Letta provider failure.
+            logger.exception(
+                "Room %s: Failed to deliver Letta agent's reply: %s",
+                room_id,
+                e.cause,
+            )
         except asyncio.TimeoutError:
             logger.error(
                 "Room %s: Letta turn timed out after %ss",
                 room_id,
                 self.config.turn_timeout_s,
             )
-            await self._report_error(
-                tools,
-                f"Letta agent response timed out after {self.config.turn_timeout_s}s",
+            await tools.send_failure(
+                AgentFailure(
+                    "letta",
+                    f"Letta agent response timed out after {self.config.turn_timeout_s}s",
+                    "timeout",
+                )
             )
         except Exception as e:
             logger.exception("Room %s: Error during Letta turn: %s", room_id, e)
-            await self._report_error(tools, str(e))
+            await tools.send_failure(AgentFailure("letta", str(e)))
         else:
             if room_ctx.pending_seed:
                 room_ctx.pending_seed = []
@@ -576,10 +593,12 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                 room_id,
                 self._mcp.send_message_tool,
             )
-            await self._report_error(
-                tools,
-                f"Letta agent did not call {self._mcp.send_message_tool} "
-                "(auto-relay disabled); its reply was dropped",
+            await tools.send_failure(
+                AgentFailure(
+                    "letta",
+                    f"Letta agent did not call {self._mcp.send_message_tool} "
+                    "(auto-relay disabled); its reply was dropped",
+                )
             )
         else:
             final_text = "\n\n".join(final_text_parts)
@@ -589,7 +608,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                 room_id,
                 self._mcp.send_message_tool,
             )
-            await tools.send_message(final_text, mentions=mentions)
+            await deliver_reply(tools, final_text, mentions=mentions)
 
         return final_text_parts
 
@@ -1174,10 +1193,3 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         if len(text) <= max_length:
             return text
         return text[:max_length].rsplit(" ", 1)[0] + "..."
-
-    async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        """Send error event (best effort)."""
-        try:
-            await tools.send_event(content=f"Error: {error}", message_type="error")
-        except Exception:
-            logger.debug("Failed to report error to platform: %s", error)

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -269,9 +269,9 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         """Handle incoming message via Letta API with MCP tools."""
         if not self._client:
             logger.error("Letta client not initialized, dropping message %s", msg.id)
-            error = RuntimeError("Letta adapter not initialized")
-            await tools.send_failure(AgentFailure("letta", str(error)))
-            raise error
+            message = "Letta adapter not initialized"
+            await tools.send_failure(AgentFailure("letta", message))
+            raise RuntimeError(message)
 
         # Lock only protects MCP/agent setup, not the full message path.
         # This allows concurrent rooms to process messages in parallel. Both
@@ -314,9 +314,9 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         """Run one Letta turn: resolve the room, compose the message, send."""
         if (room_ctx := await self._room_context(room_id, history, tools)) is None:
             logger.error("Room %s: No Letta agent context, dropping message", room_id)
-            error = RuntimeError("Letta agent context unavailable")
-            await tools.send_failure(AgentFailure("letta", str(error)))
-            raise error
+            message = "Letta agent context unavailable"
+            await tools.send_failure(AgentFailure("letta", message))
+            raise RuntimeError(message)
 
         # Point the MCP resolver at this room's current tools for the
         # server-side tool calls this turn will make.

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -269,10 +269,9 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         """Handle incoming message via Letta API with MCP tools."""
         if not self._client:
             logger.error("Letta client not initialized, dropping message %s", msg.id)
-            await tools.send_failure(
-                AgentFailure("letta", "Letta adapter not initialized")
-            )
-            return
+            error = RuntimeError("Letta adapter not initialized")
+            await tools.send_failure(AgentFailure("letta", str(error)))
+            raise error
 
         # Lock only protects MCP/agent setup, not the full message path.
         # This allows concurrent rooms to process messages in parallel. Both
@@ -289,7 +288,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         except Exception as e:
             logger.exception("Room %s: Failed to prepare Letta session: %s", room_id, e)
             await tools.send_failure(AgentFailure("letta", str(e)))
-            return
+            raise
 
         await self._handle_message(
             msg=msg,
@@ -315,10 +314,9 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         """Run one Letta turn: resolve the room, compose the message, send."""
         if (room_ctx := await self._room_context(room_id, history, tools)) is None:
             logger.error("Room %s: No Letta agent context, dropping message", room_id)
-            await tools.send_failure(
-                AgentFailure("letta", "Letta agent context unavailable")
-            )
-            return
+            error = RuntimeError("Letta agent context unavailable")
+            await tools.send_failure(AgentFailure("letta", str(error)))
+            raise error
 
         # Point the MCP resolver at this room's current tools for the
         # server-side tool calls this turn will make.
@@ -426,12 +424,15 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
             )
         except DeliveryFailedError as e:
             # The agent answered; posting the reply to the room is what
-            # failed. Band-side delivery, never a Letta provider failure.
+            # failed. Band-side delivery, never a Letta provider failure --
+            # re-raise the cause so mark_failed/retry bookkeeping keys off
+            # the real exception.
             logger.exception(
                 "Room %s: Failed to deliver Letta agent's reply: %s",
                 room_id,
                 e.cause,
             )
+            raise e.cause from None
         except asyncio.TimeoutError:
             logger.error(
                 "Room %s: Letta turn timed out after %ss",
@@ -445,9 +446,11 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                     FAILURE_CODE_TIMEOUT,
                 )
             )
+            raise
         except Exception as e:
             logger.exception("Room %s: Error during Letta turn: %s", room_id, e)
             await tools.send_failure(AgentFailure("letta", str(e)))
+            raise
         else:
             if room_ctx.pending_seed:
                 room_ctx.pending_seed = []

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -13,8 +13,17 @@ from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
 from band.converters.letta import LettaHistoryConverter, LettaSessionState
-from band.core.delivery import DeliveryFailedError, deliver_reply
-from band.core.protocols import FAILURE_CODE_TIMEOUT, AgentToolsProtocol
+from band.core.delivery import (
+    DeliveryFailedError,
+    deliver_reply,
+    reraise_delivery_cause,
+)
+from band.core.protocols import (
+    FAILURE_CODE_TIMEOUT,
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    AgentToolsProtocol,
+    TurnResultAlreadyReported,
+)
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
     AdapterFeatures,
@@ -287,7 +296,9 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                     await self._ensure_agent(room_id, history, tools)
         except Exception as e:
             logger.exception("Room %s: Failed to prepare Letta session: %s", room_id, e)
-            await tools.send_failure(AgentFailure("letta", str(e)))
+            await tools.send_failure(
+                AgentFailure("letta", GENERIC_PROVIDER_FAILURE_MESSAGE)
+            )
             raise
 
         await self._handle_message(
@@ -423,16 +434,9 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                 timeout=self.config.turn_timeout_s,
             )
         except DeliveryFailedError as e:
-            # The agent answered; posting the reply to the room is what
-            # failed. Band-side delivery, never a Letta provider failure --
-            # re-raise the cause so mark_failed/retry bookkeeping keys off
-            # the real exception.
-            logger.exception(
-                "Room %s: Failed to deliver Letta agent's reply: %s",
-                room_id,
-                e.cause,
-            )
-            raise e.cause from None
+            reraise_delivery_cause(e)
+        except TurnResultAlreadyReported:
+            raise
         except asyncio.TimeoutError:
             logger.error(
                 "Room %s: Letta turn timed out after %ss",
@@ -449,7 +453,9 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
             raise
         except Exception as e:
             logger.exception("Room %s: Error during Letta turn: %s", room_id, e)
-            await tools.send_failure(AgentFailure("letta", str(e)))
+            await tools.send_failure(
+                AgentFailure("letta", GENERIC_PROVIDER_FAILURE_MESSAGE)
+            )
             raise
         else:
             if room_ctx.pending_seed:
@@ -596,13 +602,12 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                 room_id,
                 self._mcp.send_message_tool,
             )
-            await tools.send_failure(
-                AgentFailure(
-                    "letta",
-                    f"Letta agent did not call {self._mcp.send_message_tool} "
-                    "(auto-relay disabled); its reply was dropped",
-                )
+            detail = (
+                f"Letta agent did not call {self._mcp.send_message_tool} "
+                "(auto-relay disabled); its reply was dropped"
             )
+            await tools.send_failure(AgentFailure("letta", detail))
+            raise TurnResultAlreadyReported(detail)
         else:
             final_text = "\n\n".join(final_text_parts)
             mentions = [reply_to_sender_id] if reply_to_sender_id else None

--- a/src/band/adapters/opencode/adapter.py
+++ b/src/band/adapters/opencode/adapter.py
@@ -20,7 +20,11 @@ from band.adapters.opencode.approvals import ApprovalPorts, RoomApprovals
 from band.adapters.opencode.config import OpencodeAdapterConfig
 from band.converters.opencode import OpencodeHistoryConverter
 from band.core.exceptions import BandConnectionError
-from band.core.protocols import FAILURE_CODE_TIMEOUT, AgentToolsProtocol
+from band.core.protocols import (
+    FAILURE_CODE_TIMEOUT,
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    AgentToolsProtocol,
+)
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
     AdapterFeatures,
@@ -505,9 +509,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         except Exception:
             logger.exception("Unexpected OpenCode adapter failure in room %s", room_id)
             await tools.send_failure(
-                AgentFailure(
-                    "opencode", "OpenCode failed while processing the message."
-                )
+                AgentFailure("opencode", GENERIC_PROVIDER_FAILURE_MESSAGE)
             )
             raise
 

--- a/src/band/adapters/opencode/adapter.py
+++ b/src/band/adapters/opencode/adapter.py
@@ -501,6 +501,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
                     str(exc.response.status_code),
                 )
             )
+            raise
         except Exception:
             logger.exception("Unexpected OpenCode adapter failure in room %s", room_id)
             await tools.send_failure(
@@ -508,6 +509,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
                     "opencode", "OpenCode failed while processing the message."
                 )
             )
+            raise
 
     async def on_cleanup(self, room_id: str) -> None:
         room_state: RoomState | None = None

--- a/src/band/adapters/opencode/adapter.py
+++ b/src/band/adapters/opencode/adapter.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from typing import ClassVar, Any
 
 import httpx
+from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
 from band.adapters.opencode.approvals import ApprovalPorts, RoomApprovals
@@ -493,15 +494,19 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
             raise
         except httpx.HTTPStatusError as exc:
             logger.exception("OpenCode request failed for room %s", room_id)
-            await tools.send_event(
-                self._format_http_error(exc),
-                "error",
+            await tools.send_failure(
+                AgentFailure(
+                    "opencode",
+                    self._format_http_error(exc),
+                    str(exc.response.status_code),
+                )
             )
         except Exception:
             logger.exception("Unexpected OpenCode adapter failure in room %s", room_id)
-            await tools.send_event(
-                "OpenCode failed while processing the message.",
-                "error",
+            await tools.send_failure(
+                AgentFailure(
+                    "opencode", "OpenCode failed while processing the message."
+                )
             )
 
     async def on_cleanup(self, room_id: str) -> None:
@@ -921,9 +926,12 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
             )
             await self._abort_session(room_state, "timed-out")
             if room_state.tools:
-                await room_state.tools.send_event(
-                    "OpenCode timed out before completing the turn.",
-                    "error",
+                await room_state.tools.send_failure(
+                    AgentFailure(
+                        "opencode",
+                        "OpenCode timed out before completing the turn.",
+                        "timeout",
+                    )
                 )
             # Tokens spent before the timeout were still spent — emit them, same
             # as the success path (best-effort; no-op if none captured).
@@ -1117,8 +1125,8 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
                     text, mentions=room_state.pending_mentions
                 )
             elif room_state.last_error_message:
-                await room_state.tools.send_event(
-                    room_state.last_error_message, "error"
+                await room_state.tools.send_failure(
+                    AgentFailure("opencode", room_state.last_error_message)
                 )
             elif not replied:
                 await room_state.tools.send_message(

--- a/src/band/adapters/opencode/adapter.py
+++ b/src/band/adapters/opencode/adapter.py
@@ -20,7 +20,7 @@ from band.adapters.opencode.approvals import ApprovalPorts, RoomApprovals
 from band.adapters.opencode.config import OpencodeAdapterConfig
 from band.converters.opencode import OpencodeHistoryConverter
 from band.core.exceptions import BandConnectionError
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import FAILURE_CODE_TIMEOUT, AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
     AdapterFeatures,
@@ -930,7 +930,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
                     AgentFailure(
                         "opencode",
                         "OpenCode timed out before completing the turn.",
-                        "timeout",
+                        FAILURE_CODE_TIMEOUT,
                     )
                 )
             # Tokens spent before the timeout were still spent — emit them, same

--- a/src/band/adapters/parlant.py
+++ b/src/band/adapters/parlant.py
@@ -377,10 +377,10 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
         logger.debug("Handling message %s in room %s", msg.id, room_id)
 
         if not self._app:
-            logger.error("Parlant Application not initialized")
-            error = RuntimeError("Parlant Application not initialized")
-            await tools.send_failure(AgentFailure("parlant", str(error)))
-            raise error
+            message = "Parlant Application not initialized"
+            logger.error(message)
+            await tools.send_failure(AgentFailure("parlant", message))
+            raise RuntimeError(message)
 
         app = self._app
         sender_name = msg.sender_name or msg.sender_id or "User"

--- a/src/band/adapters/parlant.py
+++ b/src/band/adapters/parlant.py
@@ -378,10 +378,9 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
 
         if not self._app:
             logger.error("Parlant Application not initialized")
-            await tools.send_failure(
-                AgentFailure("parlant", "Parlant Application not initialized")
-            )
-            return
+            error = RuntimeError("Parlant Application not initialized")
+            await tools.send_failure(AgentFailure("parlant", str(error)))
+            raise error
 
         app = self._app
         sender_name = msg.sender_name or msg.sender_id or "User"
@@ -394,7 +393,7 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
             await tools.send_failure(
                 AgentFailure("parlant", f"Session initialization failed: {e}")
             )
-            return
+            raise
         session_id_str = str(session_id)
 
         # Set tools for this session (keyed by session_id for cross-task access)

--- a/src/band/adapters/parlant.py
+++ b/src/band/adapters/parlant.py
@@ -14,6 +14,7 @@ from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
 from typing import ClassVar, TYPE_CHECKING, Any
 
+from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
 from band.core.protocols import AgentToolsProtocol
@@ -377,6 +378,9 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
 
         if not self._app:
             logger.error("Parlant Application not initialized")
+            await tools.send_failure(
+                AgentFailure("parlant", "Parlant Application not initialized")
+            )
             return
 
         app = self._app
@@ -387,7 +391,9 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
             session_id = await self._get_or_create_session(room_id, sender_name)
         except Exception as e:
             logger.error("Failed to get/create session for room %s: %s", room_id, e)
-            await self._report_error(tools, f"Session initialization failed: {e}")
+            await tools.send_failure(
+                AgentFailure("parlant", f"Session initialization failed: {e}")
+            )
             return
         session_id_str = str(session_id)
 
@@ -445,7 +451,7 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
 
         except Exception as e:
             logger.error("Error processing message: %s", e, exc_info=True)
-            await self._report_error(tools, str(e))
+            await tools.send_failure(AgentFailure("parlant", str(e)))
             raise
         finally:
             # Clear tools after message processing
@@ -853,13 +859,6 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
             del self._room_customers[room_id]
 
         logger.debug("Room %s: Cleaned up Parlant session", room_id)
-
-    async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        """Send error event (best effort)."""
-        try:
-            await tools.send_event(content=f"Error: {error}", message_type="error")
-        except Exception:
-            logger.exception("Failed to send error event")
 
     async def cleanup_all(self) -> None:
         """Release all sessions and the owned Parlant server (call on stop)."""

--- a/src/band/adapters/parlant.py
+++ b/src/band/adapters/parlant.py
@@ -17,7 +17,12 @@ from typing import ClassVar, TYPE_CHECKING, Any
 from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
-from band.core.protocols import AgentToolsProtocol
+from band.core.delivery import (
+    DeliveryFailedError,
+    deliver_reply,
+    reraise_delivery_cause,
+)
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE, AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import Capability, Emit, FeatureKwargs, PlatformMessage
 from band.integrations.parlant.server import running_parlant_server
@@ -391,7 +396,7 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
         except Exception as e:
             logger.error("Failed to get/create session for room %s: %s", room_id, e)
             await tools.send_failure(
-                AgentFailure("parlant", f"Session initialization failed: {e}")
+                AgentFailure("parlant", GENERIC_PROVIDER_FAILURE_MESSAGE)
             )
             raise
         session_id_str = str(session_id)
@@ -448,9 +453,13 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
                 sender_name=sender_name,
             )
 
+        except DeliveryFailedError as e:
+            reraise_delivery_cause(e)
         except Exception as e:
             logger.error("Error processing message: %s", e, exc_info=True)
-            await tools.send_failure(AgentFailure("parlant", str(e)))
+            await tools.send_failure(
+                AgentFailure("parlant", GENERIC_PROVIDER_FAILURE_MESSAGE)
+            )
             raise
         finally:
             # Clear tools after message processing
@@ -796,18 +805,10 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
                             room_id,
                             message_content[:100],
                         )
-                        try:
-                            await tools.send_message(
-                                message_content, mentions=[sender_name]
-                            )
-                            logger.info("Room %s: Message sent successfully", room_id)
-                        except Exception as e:
-                            logger.error(
-                                "Room %s: Error sending message: %s",
-                                room_id,
-                                e,
-                                exc_info=True,
-                            )
+                        await deliver_reply(
+                            tools, message_content, mentions=[sender_name]
+                        )
+                        logger.info("Room %s: Message sent successfully", room_id)
                     else:
                         logger.warning(
                             "Room %s: Empty message content in event",

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -37,7 +37,11 @@ from pydantic_ai.models import ModelRequestContext
 
 from typing_extensions import Unpack
 
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import (
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    AgentToolsProtocol,
+    TurnResultAlreadyReported,
+)
 from band.core.simple_adapter import SimpleAdapter
 from band.core.task_types import TaskAssignmentStatus, TaskLifecycleState, TaskListState
 from band.core.types import (
@@ -1058,7 +1062,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                     ModelRequest(parts=[UserPromptPart(content=user_message)]),
                 ]
                 return
-            await tools.send_failure(AgentFailure("pydantic_ai", str(e)))
+            await tools.send_failure(
+                AgentFailure("pydantic_ai", GENERIC_PROVIDER_FAILURE_MESSAGE)
+            )
             raise
         finally:
             capture_cm.__exit__(None, None, None)
@@ -1078,9 +1084,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # either answered in plain text or said nothing at all. Surface it as an
         # error (mirrors the crewai adapter) instead of letting it vanish.
         if not tool_executed:
-            await tools.send_failure(
-                AgentFailure("pydantic_ai", missing_reply_error("Pydantic AI"))
-            )
+            detail = missing_reply_error("Pydantic AI")
+            await tools.send_failure(AgentFailure("pydantic_ai", detail))
+            raise TurnResultAlreadyReported(detail)
 
         logger.debug(
             "Room %s: Pydantic AI agent completed (history now has %s messages)",

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -12,7 +12,7 @@ import logging
 from collections.abc import Callable
 from typing import Any, ClassVar, Literal, cast, get_origin, get_type_hints
 
-import httpx
+from band_sdk_core import AgentFailure
 from pydantic_ai import (
     Agent,
     AgentRunResultEvent,
@@ -35,7 +35,6 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models import ModelRequestContext
 
-from band_rest.core.api_error import ApiError
 from typing_extensions import Unpack
 
 from band.core.protocols import AgentToolsProtocol
@@ -1025,7 +1024,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                                 room_id,
                                 dropped,
                             )
-        except UnexpectedModelBehavior as e:
+        except Exception as e:
             # A turn that already did its work must not fail over the reply the model
             # owes pydantic-ai. Allowing `None` — and normalizing blank text into it
             # — ends the ordinary nothing-left-to-say response cleanly, but some
@@ -1034,8 +1033,12 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             # band_send_message reply, a band_store_memory, ...) the work already went
             # out, so that exhaustion is benign — mirror the crewai adapter and
             # swallow it. Genuine no-response failures (no terminal tool ran — only
-            # read-only lookups or failed tools) still propagate.
-            if tool_executed and _is_output_retries_exhausted(e):
+            # read-only lookups or failed tools) still surface and propagate.
+            if (
+                tool_executed
+                and isinstance(e, UnexpectedModelBehavior)
+                and _is_output_retries_exhausted(e)
+            ):
                 logger.warning(
                     "Room %s: Pydantic AI exhausted its output retries after "
                     "the agent already did productive work this turn; treating as "
@@ -1055,6 +1058,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                     ModelRequest(parts=[UserPromptPart(content=user_message)]),
                 ]
                 return
+            await tools.send_failure(AgentFailure("pydantic_ai", str(e)))
             raise
         finally:
             capture_cm.__exit__(None, None, None)
@@ -1074,7 +1078,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # either answered in plain text or said nothing at all. Surface it as an
         # error (mirrors the crewai adapter) instead of letting it vanish.
         if not tool_executed:
-            await self._report_error(tools, missing_reply_error("Pydantic AI"))
+            await tools.send_failure(
+                AgentFailure("pydantic_ai", missing_reply_error("Pydantic AI"))
+            )
 
         logger.debug(
             "Room %s: Pydantic AI agent completed (history now has %s messages)",
@@ -1149,18 +1155,6 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             if isinstance(message, ModelResponse):
                 total = total + PydanticAIAdapter._usage_from_usage_obj(message.usage)
         return total
-
-    async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        """Send an error event to the room (best effort).
-
-        Structurally mirrors the crewai adapter, but narrows the catch to the REST
-        call's real failure modes (ApiError = HTTP status, httpx = transport) so a
-        failed error-report never crashes the turn — while a real bug still raises.
-        """
-        try:
-            await tools.send_event(content=f"Error: {error}", message_type="error")
-        except (ApiError, httpx.HTTPError) as e:
-            logger.warning("Failed to send error event: %s", e)
 
     # --- Copied from BandPydanticAgent._cleanup_session ---
     async def on_cleanup(self, room_id: str) -> None:

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -1088,6 +1088,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # either answered in plain text or said nothing at all. Surface it as an
         # error (mirrors the crewai adapter) instead of letting it vanish.
         if not tool_executed:
+            logger.warning(
+                "Room %s: Pydantic AI turn produced nothing for the room", room_id
+            )
             detail = missing_reply_error("Pydantic AI")
             await tools.send_failure(AgentFailure("pydantic_ai", detail))
             raise TurnResultAlreadyReported(detail)

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, ClassVar, cast
 
-import httpx
+from band_sdk_core import AgentFailure
 from pydantic import BaseModel
 
 try:
@@ -31,7 +31,6 @@ except ImportError as error:
         "Install with: uv add band-sdk[strands]"
     ) from error
 
-from band_rest.core.api_error import ApiError
 from typing_extensions import Unpack
 
 from band.core.protocols import AgentToolsProtocol
@@ -525,12 +524,17 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         hooks: BandTurnHooks,
     ) -> None:
         """Run the framework loop while preserving transcript and usage on failure."""
-        agent = self._build_agent(history, tools, hooks)
+        agent: Agent | None = None
         try:
+            agent = self._build_agent(history, tools, hooks)
             await agent.invoke_async(message)
+        except Exception as e:
+            await tools.send_failure(AgentFailure("strands", str(e)))
+            raise
         finally:
-            self._message_history[room_id] = agent.messages
-            await self.emit_usage(tools, self._usage_from_agent(agent))
+            if agent is not None:
+                self._message_history[room_id] = agent.messages
+                await self.emit_usage(tools, self._usage_from_agent(agent))
 
     async def on_message(
         self,
@@ -570,7 +574,9 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             hooks=hooks,
         )
         if not hooks.terminal_fired:
-            await self._report_error(tools, missing_reply_error("Strands"))
+            await tools.send_failure(
+                AgentFailure("strands", missing_reply_error("Strands"))
+            )
         logger.debug(
             "Room %s: Strands agent completed (history now has %s messages)",
             room_id,
@@ -591,16 +597,6 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             cache_read="cacheReadInputTokens",
             cache_write="cacheWriteInputTokens",
         )
-
-    async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        """Post a best-effort room-visible adapter error."""
-        try:
-            await tools.send_event(
-                content=f"Error: {error}",
-                message_type=MessageType.ERROR,
-            )
-        except (ApiError, httpx.HTTPError) as report_error:
-            logger.warning("Failed to send error event: %s", report_error)
 
     async def on_cleanup(self, room_id: str) -> None:
         """Discard the transcript when Band removes the adapter from a room."""

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -33,7 +33,11 @@ except ImportError as error:
 
 from typing_extensions import Unpack
 
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import (
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    AgentToolsProtocol,
+    TurnResultAlreadyReported,
+)
 from band.core.simple_adapter import SimpleAdapter
 from band.core.tool_filter import filter_tool_schemas
 from band.core.types import (
@@ -528,8 +532,10 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         try:
             agent = self._build_agent(history, tools, hooks)
             await agent.invoke_async(message)
-        except Exception as e:
-            await tools.send_failure(AgentFailure("strands", str(e)))
+        except Exception:
+            await tools.send_failure(
+                AgentFailure("strands", GENERIC_PROVIDER_FAILURE_MESSAGE)
+            )
             raise
         finally:
             if agent is not None:
@@ -574,9 +580,9 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             hooks=hooks,
         )
         if not hooks.terminal_fired:
-            await tools.send_failure(
-                AgentFailure("strands", missing_reply_error("Strands"))
-            )
+            detail = missing_reply_error("Strands")
+            await tools.send_failure(AgentFailure("strands", detail))
+            raise TurnResultAlreadyReported(detail)
         logger.debug(
             "Room %s: Strands agent completed (history now has %s messages)",
             room_id,

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -580,6 +580,9 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             hooks=hooks,
         )
         if not hooks.terminal_fired:
+            logger.warning(
+                "Room %s: Strands turn produced nothing for the room", room_id
+            )
             detail = missing_reply_error("Strands")
             await tools.send_failure(AgentFailure("strands", detail))
             raise TurnResultAlreadyReported(detail)

--- a/src/band/core/delivery.py
+++ b/src/band/core/delivery.py
@@ -9,10 +9,13 @@ the two apart and re-raise the original cause before its provider branch.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import logging
+from typing import TYPE_CHECKING, Any, NoReturn
 
 if TYPE_CHECKING:
     from band.core.protocols import AgentToolsProtocol
+
+logger = logging.getLogger(__name__)
 
 
 class DeliveryFailedError(Exception):
@@ -22,6 +25,17 @@ class DeliveryFailedError(Exception):
     def __init__(self, cause: BaseException) -> None:
         super().__init__(str(cause))
         self.cause = cause
+
+
+def reraise_delivery_cause(e: DeliveryFailedError) -> NoReturn:
+    """Log then re-raise a ``DeliveryFailedError``'s cause.
+
+    Band-side reply delivery failed, never a provider failure -- re-raises
+    the cause (not this wrapper) so mark_failed/retry bookkeeping keys off
+    the real exception.
+    """
+    logger.exception("Reply delivery failed: %s", e.cause)
+    raise e.cause from None
 
 
 async def deliver_reply(

--- a/src/band/core/delivery.py
+++ b/src/band/core/delivery.py
@@ -1,0 +1,38 @@
+"""Delivery-vs-provider-failure misclassification guard.
+
+An adapter's reply/bookkeeping post to the room (``send_message``) is Band-side
+delivery, never a provider failure -- even when the ``send_message`` call sits
+inside a try/except that also handles real provider errors. ``deliver_reply``
+wraps the cause in ``DeliveryFailedError`` so that shared except block can tell
+the two apart and re-raise the original cause before its provider branch.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from band.core.protocols import AgentToolsProtocol
+
+
+class DeliveryFailedError(Exception):
+    """Wraps a ``send_message`` failure so it is never mistaken for a
+    provider failure by a shared except block."""
+
+    def __init__(self, cause: BaseException) -> None:
+        super().__init__(str(cause))
+        self.cause = cause
+
+
+async def deliver_reply(
+    tools: "AgentToolsProtocol",
+    content: str,
+    mentions: list[str] | list[dict[str, str]] | None = None,
+) -> Any:
+    """Send a reply, raising ``DeliveryFailedError`` on failure instead of
+    the raw exception, so the caller's except can distinguish a delivery
+    failure from a provider failure."""
+    try:
+        return await tools.send_message(content, mentions=mentions)
+    except Exception as exc:
+        raise DeliveryFailedError(exc) from exc

--- a/src/band/core/protocols.py
+++ b/src/band/core/protocols.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, runtime_check
 
 from band_sdk_core import AgentFailure
 
+from band.core.content import has_visible_content
+
 if TYPE_CHECKING:
     from anthropic.types import ToolParam
 
@@ -29,6 +31,11 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
+# Shared ``AgentFailure.code`` value for a stalled/unresponsive provider turn,
+# so every adapter's timeout branch reports the same code instead of each
+# retyping the literal.
+FAILURE_CODE_TIMEOUT = "timeout"
+
 
 def to_failure_event(failure: AgentFailure) -> tuple[str, dict[str, Any]]:
     """Shared shape every ``send_failure`` implementation posts as an `error` event.
@@ -41,7 +48,8 @@ def to_failure_event(failure: AgentFailure) -> tuple[str, dict[str, Any]]:
     """
     content = (
         failure.message.strip()
-        or f"{failure.provider} failed without an error message."
+        if has_visible_content(failure.message)
+        else f"{failure.provider} failed without an error message."
     )
     return content, {"failure": failure.to_dict()}
 

--- a/src/band/core/protocols.py
+++ b/src/band/core/protocols.py
@@ -82,10 +82,10 @@ async def send_event_safe(
     """Send a best-effort platform event, logging instead of raising on failure.
 
     For events whose loss is tolerable (a thought, a lifecycle/task marker),
-    unlike ``send_message``/``send_failure`` calls a caller depends on as a
-    control signal. Returns whether the event was actually accepted, so a
-    caller that only wants to update its own bookkeeping once delivery is
-    confirmed (e.g. marking a session id persisted) can act on it.
+    unlike a ``send_message`` call a caller depends on as a control signal.
+    Returns whether the event was actually accepted, so a caller that only
+    wants to update its own bookkeeping once delivery is confirmed (e.g.
+    marking a session id persisted) can act on it.
     """
     try:
         await tools.send_event(

--- a/src/band/core/protocols.py
+++ b/src/band/core/protocols.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, runtime_checkable
 
+from band_sdk_core import AgentFailure
+
 if TYPE_CHECKING:
     from anthropic.types import ToolParam
 
@@ -26,6 +28,22 @@ if TYPE_CHECKING:
     from band.runtime.tools import ToolCallOutcome
 
 T = TypeVar("T")
+
+
+def to_failure_event(failure: AgentFailure) -> tuple[str, dict[str, Any]]:
+    """Shared shape every ``send_failure`` implementation posts as an `error` event.
+
+    A provider message can arrive blank (``Exception()`` and ``str("")`` both
+    reach here empty). The platform rejects a blank chat event, so an
+    unguarded blank message would make the failure vanish from the room
+    entirely. The fallback string is part of the TS/Python parity contract —
+    it must match ``toFailureEvent``'s exactly.
+    """
+    content = (
+        failure.message.strip()
+        or f"{failure.provider} failed without an error message."
+    )
+    return content, {"failure": failure.to_dict()}
 
 
 @runtime_checkable
@@ -77,6 +95,16 @@ class AgentToolsProtocol(Protocol):
         metadata: dict[str, Any] | None = None,
     ) -> Any:
         """Send an event (tool_call, tool_result, thought, error, task)."""
+        ...
+
+    async def send_failure(self, failure: AgentFailure) -> Any:
+        """Report a provider-originated failure as a structured `error` event.
+
+        Best-effort: swallows its own reporting failure rather than raising,
+        so a caller reporting a failure never has that report replaced by an
+        unrelated exception. Unlike ``send_event``, whose raising callers
+        depend on it as a control signal.
+        """
         ...
 
     async def add_participant(self, identifier: str, role: str = "member") -> Any:

--- a/src/band/core/protocols.py
+++ b/src/band/core/protocols.py
@@ -44,6 +44,12 @@ GENERIC_PROVIDER_FAILURE_MESSAGE = (
 )
 
 
+class TurnResultAlreadyReported(Exception):
+    """A terminal turn failure that a nested handler already reported via
+    ``send_failure``. An adapter's outer ``except`` re-raises this without
+    reporting the same failure a second time."""
+
+
 def to_failure_event(failure: AgentFailure) -> tuple[str, dict[str, Any]]:
     """Shared shape every ``send_failure`` implementation posts as an `error` event.
 

--- a/src/band/core/protocols.py
+++ b/src/band/core/protocols.py
@@ -36,6 +36,13 @@ T = TypeVar("T")
 # retyping the literal.
 FAILURE_CODE_TIMEOUT = "timeout"
 
+# Shared generic message for a caught provider exception whose text must not
+# reach the room (it can embed DB strings, paths, or tokens) -- the full
+# detail goes to the agent log via logger.exception instead.
+GENERIC_PROVIDER_FAILURE_MESSAGE = (
+    "Internal error while processing message; see agent logs."
+)
+
 
 def to_failure_event(failure: AgentFailure) -> tuple[str, dict[str, Any]]:
     """Shared shape every ``send_failure`` implementation posts as an `error` event.

--- a/src/band/core/protocols.py
+++ b/src/band/core/protocols.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, runtime_checkable
 
 from band_sdk_core import AgentFailure
 
 from band.core.content import has_visible_content
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from anthropic.types import ToolParam
@@ -65,6 +68,38 @@ def to_failure_event(failure: AgentFailure) -> tuple[str, dict[str, Any]]:
         else f"{failure.provider} failed without an error message."
     )
     return content, {"failure": failure.to_dict()}
+
+
+async def send_event_safe(
+    tools: "AgentToolsProtocol",
+    content: str,
+    message_type: str,
+    metadata: dict[str, Any] | None = None,
+    *,
+    log_label: str | None = None,
+    log_level: int = logging.WARNING,
+) -> bool:
+    """Send a best-effort platform event, logging instead of raising on failure.
+
+    For events whose loss is tolerable (a thought, a lifecycle/task marker),
+    unlike ``send_message``/``send_failure`` calls a caller depends on as a
+    control signal. Returns whether the event was actually accepted, so a
+    caller that only wants to update its own bookkeeping once delivery is
+    confirmed (e.g. marking a session id persisted) can act on it.
+    """
+    try:
+        await tools.send_event(
+            content=content, message_type=message_type, metadata=metadata
+        )
+    except Exception:
+        logger.log(
+            log_level,
+            "Failed to send %s event",
+            log_label or message_type,
+            exc_info=True,
+        )
+        return False
+    return True
 
 
 @runtime_checkable

--- a/src/band/integrations/a2a/adapter.py
+++ b/src/band/integrations/a2a/adapter.py
@@ -19,9 +19,11 @@ from a2a.types import (
     Task,
     TaskState,
 )
+from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
 from band.converters.a2a import A2AHistoryConverter
+from band.core.delivery import DeliveryFailedError, deliver_reply
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import Capability, Emit, FeatureKwargs, PlatformMessage
@@ -172,13 +174,13 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
                     event, tools, room_id, msg.sender_id, msg.sender_name
                 )
 
+        except DeliveryFailedError as e:
+            # The A2A agent answered; posting its reply to the room is what
+            # failed. Band-side delivery, never an A2A provider failure.
+            logger.exception("A2A reply delivery failed: %s", e.cause)
         except Exception as e:
             logger.exception("A2A agent error: %s", e)
-            await tools.send_event(
-                content=f"A2A agent error: {e}",
-                message_type="error",
-                metadata={"a2a_error": str(e)},
-            )
+            await tools.send_failure(AgentFailure("a2a", str(e)))
 
     async def _handle_event(
         self,
@@ -222,8 +224,9 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
         """Forward a direct A2A message to its Band sender."""
         text = get_message_text(message)
         if text:
-            await tools.send_message(
-                content=text,
+            await deliver_reply(
+                tools,
+                text,
                 mentions=[{"id": sender_id, "name": sender_name or ""}],
             )
 
@@ -259,22 +262,18 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
 
         if state == TaskState.TASK_STATE_INPUT_REQUIRED:
             text = self._get_status_text(task) or "Please provide more information."
-            await tools.send_message(content=text, mentions=[sender])
+            await deliver_reply(tools, text, mentions=[sender])
             return
 
         if state == TaskState.TASK_STATE_COMPLETED:
             response = self._extract_response(task)
             if response:
-                await tools.send_message(content=response, mentions=[sender])
+                await deliver_reply(tools, response, mentions=[sender])
             return
 
         if state in TERMINAL_TASK_STATES:
             error_text = self._get_status_text(task) or f"Task {state_name(state)}"
-            await tools.send_event(
-                content=error_text,
-                message_type="error",
-                metadata={"a2a_state": state_name(state)},
-            )
+            await tools.send_failure(AgentFailure("a2a", error_text, state_name(state)))
 
     def _finalize_task(self, room_id: str, task_id: str) -> None:
         """Release a terminal task after its Band output and state are persisted."""

--- a/src/band/integrations/a2a/adapter.py
+++ b/src/band/integrations/a2a/adapter.py
@@ -294,11 +294,12 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
             return
 
         if state in TERMINAL_TASK_STATES:
-            error_text = self._get_status_text(task) or f"Task {state_name(state)}"
+            state_str = state_name(state)
+            error_text = self._get_status_text(task) or f"Task {state_str}"
             logger.warning(
-                "Task %s: peer A2A task ended in state %s", task.id, state_name(state)
+                "Task %s: peer A2A task ended in state %s", task.id, state_str
             )
-            await tools.send_failure(AgentFailure("a2a", error_text, state_name(state)))
+            await tools.send_failure(AgentFailure("a2a", error_text, state_str))
             raise TurnResultAlreadyReported(error_text)
 
     def _finalize_task(self, room_id: str, task_id: str) -> None:

--- a/src/band/integrations/a2a/adapter.py
+++ b/src/band/integrations/a2a/adapter.py
@@ -295,6 +295,9 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
 
         if state in TERMINAL_TASK_STATES:
             error_text = self._get_status_text(task) or f"Task {state_name(state)}"
+            logger.warning(
+                "Task %s: peer A2A task ended in state %s", task.id, state_name(state)
+            )
             await tools.send_failure(AgentFailure("a2a", error_text, state_name(state)))
             raise TurnResultAlreadyReported(error_text)
 

--- a/src/band/integrations/a2a/adapter.py
+++ b/src/band/integrations/a2a/adapter.py
@@ -23,8 +23,16 @@ from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
 from band.converters.a2a import A2AHistoryConverter
-from band.core.delivery import DeliveryFailedError, deliver_reply
-from band.core.protocols import AgentToolsProtocol
+from band.core.delivery import (
+    DeliveryFailedError,
+    deliver_reply,
+    reraise_delivery_cause,
+)
+from band.core.protocols import (
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    AgentToolsProtocol,
+    TurnResultAlreadyReported,
+)
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import Capability, Emit, FeatureKwargs, PlatformMessage
 from band.integrations.a2a.protocol import (
@@ -175,15 +183,14 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
                 )
 
         except DeliveryFailedError as e:
-            # The A2A agent answered; posting its reply to the room is what
-            # failed. Band-side delivery, never an A2A provider failure --
-            # re-raise the cause so mark_failed/retry bookkeeping keys off
-            # the real exception.
-            logger.exception("A2A reply delivery failed: %s", e.cause)
-            raise e.cause from None
+            reraise_delivery_cause(e)
+        except TurnResultAlreadyReported:
+            raise
         except Exception as e:
             logger.exception("A2A agent error: %s", e)
-            await tools.send_failure(AgentFailure("a2a", str(e)))
+            await tools.send_failure(
+                AgentFailure("a2a", GENERIC_PROVIDER_FAILURE_MESSAGE)
+            )
             raise
 
     async def _handle_event(
@@ -289,6 +296,7 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
         if state in TERMINAL_TASK_STATES:
             error_text = self._get_status_text(task) or f"Task {state_name(state)}"
             await tools.send_failure(AgentFailure("a2a", error_text, state_name(state)))
+            raise TurnResultAlreadyReported(error_text)
 
     def _finalize_task(self, room_id: str, task_id: str) -> None:
         """Release a terminal task after its Band output and state are persisted."""

--- a/src/band/integrations/a2a/adapter.py
+++ b/src/band/integrations/a2a/adapter.py
@@ -176,11 +176,15 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
 
         except DeliveryFailedError as e:
             # The A2A agent answered; posting its reply to the room is what
-            # failed. Band-side delivery, never an A2A provider failure.
+            # failed. Band-side delivery, never an A2A provider failure --
+            # re-raise the cause so mark_failed/retry bookkeeping keys off
+            # the real exception.
             logger.exception("A2A reply delivery failed: %s", e.cause)
+            raise e.cause from None
         except Exception as e:
             logger.exception("A2A agent error: %s", e)
             await tools.send_failure(AgentFailure("a2a", str(e)))
+            raise
 
     async def _handle_event(
         self,

--- a/src/band/integrations/a2a/adapter.py
+++ b/src/band/integrations/a2a/adapter.py
@@ -210,8 +210,19 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
         finally:
             # A terminal task must be persisted and released even when Band
             # delivery fails, or the room keeps addressing a finished task.
+            # Best-effort: a failure here must never replace an exception
+            # already propagating from the try block above, or a Band
+            # delivery outage gets misreported as a fabricated provider
+            # failure once it reaches on_message's except clauses.
             if state in TERMINAL_TASK_STATES:
-                await self._emit_task_event(tools, task, state)
+                try:
+                    await self._emit_task_event(tools, task, state)
+                except Exception:
+                    logger.exception(
+                        "Failed to emit terminal task event (room=%s, task=%s)",
+                        room_id,
+                        task.id,
+                    )
                 self._finalize_task(room_id, task.id)
 
     async def _deliver_message(

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.types import Task, TaskState, TaskStatus
+from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
 from band.client.rest import (
@@ -77,6 +78,29 @@ def slugify(name: str) -> str:
     slug = name.lower()
     slug = re.sub(r"[^a-z0-9]+", "-", slug)  # Replace non-alphanumeric with -
     return slug.strip("-")  # Remove leading/trailing dashes
+
+
+_GATEWAY_ERROR_MAX_CHARS = 240
+_BEARER_TOKEN_RE = re.compile(r"Bearer\s+[^\s,;]+", re.IGNORECASE)
+_CREDENTIAL_KV_RE = re.compile(
+    r"(token|authorization|api[_-]?key)\s*[:=]\s*[^\s,;]+", re.IGNORECASE
+)
+
+
+def _sanitize_gateway_error_message(exc: BaseException) -> str:
+    """Redact bearer tokens/API keys before an internal exception message
+    reaches an external A2A client, and cap its length.
+
+    Mirrors the TS SDK's ``sanitizeGatewayErrorMessage``.
+    """
+    trimmed = str(exc).strip()
+    if not trimmed:
+        return "Unknown error"
+    redacted = _BEARER_TOKEN_RE.sub("Bearer [REDACTED]", trimmed)
+    redacted = _CREDENTIAL_KV_RE.sub(r"\1=[REDACTED]", redacted)
+    if len(redacted) <= _GATEWAY_ERROR_MAX_CHARS:
+        return redacted
+    return f"{redacted[: _GATEWAY_ERROR_MAX_CHARS - 3]}..."
 
 
 class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
@@ -339,14 +363,19 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
                 request.pending.task.id,
             )
             raise
-        except Exception:
+        except Exception as exc:
             logger.exception(
                 "A2A request failed: room=%s context=%s task=%s",
                 request.room_id,
                 request.context_id,
                 request.pending.task.id,
             )
-            await request.pending.fail("A2A request failed")
+            failure = AgentFailure(
+                "a2a-gateway",
+                _sanitize_gateway_error_message(exc),
+                type(exc).__name__,
+            )
+            await request.pending.fail("A2A request failed", failure=failure.to_dict())
             raise
         else:
             if completed:
@@ -427,7 +456,12 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
                 request.pending.task.id,
                 self.config.response_timeout_s,
             )
-            await request.pending.fail("Timed out waiting for a Band response")
+            failure = AgentFailure(
+                "a2a-gateway", "Timed out waiting for a Band response", "Timeout"
+            )
+            await request.pending.fail(
+                "Timed out waiting for a Band response", failure=failure.to_dict()
+            )
             return False
         return True
 
@@ -554,7 +588,13 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
     ) -> None:
         """Translate Band's message category into an A2A task intent."""
         if msg.message_type == "error":
-            await pending.fail(msg.content)
+            # The peer's own adapter already built this AgentFailure (see
+            # to_failure_event) -- relay it as-is rather than re-tagging its
+            # provider as "a2a-gateway".
+            failure = (
+                msg.metadata.get("failure") if isinstance(msg.metadata, dict) else None
+            )
+            await pending.fail(msg.content, failure=failure)
         elif msg.message_type in ("thought", "tool_call", "tool_result"):
             await pending.report_progress(msg.content)
         else:

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -457,7 +457,7 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
                 self.config.response_timeout_s,
             )
             failure = AgentFailure(
-                "a2a-gateway", "Timed out waiting for a Band response", "Timeout"
+                "a2a-gateway", "Timed out waiting for a Band response", "timeout"
             )
             await request.pending.fail(
                 "Timed out waiting for a Band response", failure=failure.to_dict()

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -9,7 +9,7 @@ import logging
 import re
 from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
-from typing import ClassVar
+from typing import Any, ClassVar
 from uuid import uuid4
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
@@ -94,6 +94,23 @@ def _redact_credentials(text: str) -> str:
     """Redact bearer tokens/API keys a message may embed."""
     redacted = _BEARER_TOKEN_RE.sub("Bearer [REDACTED]", text)
     return _CREDENTIAL_KV_RE.sub(r"\1=[REDACTED]", redacted)
+
+
+def _redact_credentials_deep(value: Any) -> Any:
+    """Recursively redact credentials from a peer's ``AgentFailure.detail``.
+
+    ``detail`` is untrusted, adapter-defined structure (e.g. Codex's own
+    ``codex_additional_details`` echoes upstream error text) that can nest
+    a credential-bearing string at any depth before it reaches an external
+    A2A client.
+    """
+    if isinstance(value, str):
+        return _redact_credentials(value)
+    if isinstance(value, dict):
+        return {key: _redact_credentials_deep(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_credentials_deep(item) for item in value]
+    return value
 
 
 def _sanitize_gateway_error_message(exc: BaseException) -> str:
@@ -604,11 +621,8 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
             failure = (
                 msg.metadata.get("failure") if isinstance(msg.metadata, dict) else None
             )
-            if isinstance(failure, dict) and isinstance(failure.get("message"), str):
-                failure = {
-                    **failure,
-                    "message": _redact_credentials(failure["message"]),
-                }
+            if isinstance(failure, dict):
+                failure = _redact_credentials_deep(failure)
             await pending.fail(_redact_credentials(msg.content), failure=failure)
         elif msg.message_type in ("thought", "tool_call", "tool_result"):
             await pending.report_progress(msg.content)

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -29,7 +29,7 @@ from band.client.rest import (
 )
 from band.converters.a2a_gateway import GatewayHistoryConverter
 from band.core.content import BLANK_CONTENT_ERROR
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import FAILURE_CODE_TIMEOUT, AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import Capability, Emit, FeatureKwargs, PlatformMessage
 from band.platform.posting import post_event, post_message
@@ -457,11 +457,11 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
                 self.config.response_timeout_s,
             )
             failure = AgentFailure(
-                "a2a-gateway", "Timed out waiting for a Band response", "timeout"
+                "a2a-gateway",
+                "Timed out waiting for a Band response",
+                FAILURE_CODE_TIMEOUT,
             )
-            await request.pending.fail(
-                "Timed out waiting for a Band response", failure=failure.to_dict()
-            )
+            await request.pending.fail(failure.message, failure=failure.to_dict())
             return False
         return True
 

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -82,9 +82,18 @@ def slugify(name: str) -> str:
 
 _GATEWAY_ERROR_MAX_CHARS = 240
 _BEARER_TOKEN_RE = re.compile(r"Bearer\s+[^\s,;]+", re.IGNORECASE)
+# The value group excludes only "," and ";" (not whitespace) so a
+# scheme-prefixed credential (e.g. "Authorization: ApiKey sk-...") gets
+# redacted in full instead of leaking everything past the first space.
 _CREDENTIAL_KV_RE = re.compile(
-    r"(token|authorization|api[_-]?key)\s*[:=]\s*[^\s,;]+", re.IGNORECASE
+    r"(token|authorization|api[_-]?key)\s*[:=]\s*[^,;]+", re.IGNORECASE
 )
+
+
+def _redact_credentials(text: str) -> str:
+    """Redact bearer tokens/API keys a message may embed."""
+    redacted = _BEARER_TOKEN_RE.sub("Bearer [REDACTED]", text)
+    return _CREDENTIAL_KV_RE.sub(r"\1=[REDACTED]", redacted)
 
 
 def _sanitize_gateway_error_message(exc: BaseException) -> str:
@@ -96,8 +105,7 @@ def _sanitize_gateway_error_message(exc: BaseException) -> str:
     trimmed = str(exc).strip()
     if not trimmed:
         return "Unknown error"
-    redacted = _BEARER_TOKEN_RE.sub("Bearer [REDACTED]", trimmed)
-    redacted = _CREDENTIAL_KV_RE.sub(r"\1=[REDACTED]", redacted)
+    redacted = _redact_credentials(trimmed)
     if len(redacted) <= _GATEWAY_ERROR_MAX_CHARS:
         return redacted
     return f"{redacted[: _GATEWAY_ERROR_MAX_CHARS - 3]}..."
@@ -589,12 +597,19 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
         """Translate Band's message category into an A2A task intent."""
         if msg.message_type == "error":
             # The peer's own adapter already built this AgentFailure (see
-            # to_failure_event) -- relay it as-is rather than re-tagging its
-            # provider as "a2a-gateway".
+            # to_failure_event) -- relay it rather than re-tagging its
+            # provider as "a2a-gateway", but still redact credentials the
+            # peer's own message may embed before it reaches an external
+            # A2A client, same as this gateway's own exception path.
             failure = (
                 msg.metadata.get("failure") if isinstance(msg.metadata, dict) else None
             )
-            await pending.fail(msg.content, failure=failure)
+            if isinstance(failure, dict) and isinstance(failure.get("message"), str):
+                failure = {
+                    **failure,
+                    "message": _redact_credentials(failure["message"]),
+                }
+            await pending.fail(_redact_credentials(msg.content), failure=failure)
         elif msg.message_type in ("thought", "tool_call", "tool_result"):
             await pending.report_progress(msg.content)
         else:

--- a/src/band/integrations/a2a/gateway/types.py
+++ b/src/band/integrations/a2a/gateway/types.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
+from typing import Any
 
 from a2a.server.events import EventQueue
 from a2a.server.tasks import TaskUpdater
 from a2a.helpers import new_text_message
-from a2a.types import Message, Task
+from a2a.types import Message, Task, TaskState
 
 
 @dataclass
@@ -67,12 +68,22 @@ class PendingA2ATask:
             await self._updater.complete(self._message(content))
             self.done.set()
 
-    async def fail(self, reason: str) -> None:
-        """Publish a terminal failure and release the request."""
+    async def fail(self, reason: str, *, failure: dict[str, Any] | None = None) -> None:
+        """Publish a terminal failure and release the request.
+
+        ``failure`` is the wire-shape ``AgentFailure`` dict (see
+        ``to_failure_event``), attached as task status metadata alongside
+        ``reason``'s freeform text so an A2A client can recover structured
+        provider-failure detail.
+        """
         async with self._lock:
             if self.done.is_set():
                 return
-            await self._updater.failed(self._message(reason))
+            await self._updater.update_status(
+                TaskState.TASK_STATE_FAILED,
+                message=self._message(reason),
+                metadata={"failure": failure} if failure else None,
+            )
             self.done.set()
 
     async def cancel(self) -> None:

--- a/src/band/integrations/acp/client_adapter.py
+++ b/src/band/integrations/acp/client_adapter.py
@@ -19,7 +19,7 @@ from typing_extensions import Unpack
 from band.converters.acp_client import ACPClientHistoryConverter
 from band.converters.helpers import build_replay_messages
 from band.core.delivery import DeliveryFailedError
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import FAILURE_CODE_TIMEOUT, AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
     AdapterFeatures,
@@ -396,7 +396,7 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
                 AgentFailure(
                     "acp",
                     f"ACP agent response timed out after {self._turn_timeout_s}s",
-                    "timeout",
+                    FAILURE_CODE_TIMEOUT,
                 )
             )
         except Exception as e:

--- a/src/band/integrations/acp/client_adapter.py
+++ b/src/band/integrations/acp/client_adapter.py
@@ -172,6 +172,7 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
         port: int | None = None,
         custom_section: str = "",
         spawn_process: SpawnProcess | None = None,
+        turn_timeout_s: float = 300.0,
         **features: Unpack[FeatureKwargs],
     ) -> None:
         super().__init__(
@@ -189,6 +190,7 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
         self._auth_method = auth_method
         self._profile = profile
         self._custom_section = custom_section
+        self._turn_timeout_s = turn_timeout_s
         self._runtime = self._build_runtime(spawn_process)
 
         self._room_to_session: dict[str, str] = {}
@@ -367,15 +369,36 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
                     session_id,
                     self._make_permission_handler(emitter, room_id),
                 )
-                await self._runtime.prompt(
-                    session_id=session_id,
-                    prompt_text=prompt_text,
-                    on_chunk=emitter.emit,
+                await asyncio.wait_for(
+                    self._runtime.prompt(
+                        session_id=session_id,
+                        prompt_text=prompt_text,
+                        on_chunk=emitter.emit,
+                    ),
+                    timeout=self._turn_timeout_s,
                 )
         except DeliveryFailedError as e:
             # The turn's reply is what failed to post -- Band-side delivery,
             # never an ACP provider failure, so the connection stays up.
             logger.exception("ACP reply delivery failed: %s", e.cause)
+        except asyncio.TimeoutError:
+            # A silent/stuck agent must become an observable failure instead
+            # of hanging the turn indefinitely -- the connection is presumed
+            # wedged, so it's torn down for the next turn to respawn.
+            logger.error(
+                "ACP turn timed out after %ss (room=%s, session=%s)",
+                self._turn_timeout_s,
+                room_id,
+                session_id,
+            )
+            await self.stop()
+            await tools.send_failure(
+                AgentFailure(
+                    "acp",
+                    f"ACP agent response timed out after {self._turn_timeout_s}s",
+                    "timeout",
+                )
+            )
         except Exception as e:
             logger.exception("ACP agent error: %s", e)
             await self.stop()

--- a/src/band/integrations/acp/client_adapter.py
+++ b/src/band/integrations/acp/client_adapter.py
@@ -11,11 +11,14 @@ from typing import Any, ClassVar
 from uuid import uuid4
 
 from acp import spawn_agent_process
+from acp.exceptions import RequestError
 from acp.schema import HttpMcpServer, SseMcpServer
+from band_sdk_core import AgentFailure
 from typing_extensions import Unpack
 
 from band.converters.acp_client import ACPClientHistoryConverter
 from band.converters.helpers import build_replay_messages
+from band.core.delivery import DeliveryFailedError
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
@@ -123,6 +126,18 @@ def _resolve_launcher(command: list[str]) -> list[str]:
         return command
     resolved = shutil.which(command[0])
     return [resolved, *command[1:]] if resolved else list(command)
+
+
+def _to_agent_failure(exc: Exception) -> AgentFailure:
+    """Parse a turn-ending exception into the shared provider-failure shape.
+
+    ``RequestError`` is raised for a JSON-RPC error the remote agent
+    returned; its numeric ``code``/``data`` carry more than the generic
+    message alone.
+    """
+    if isinstance(exc, RequestError):
+        return AgentFailure("acp", str(exc), str(exc.code), exc.data)
+    return AgentFailure("acp", str(exc))
 
 
 class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
@@ -357,14 +372,14 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
                     prompt_text=prompt_text,
                     on_chunk=emitter.emit,
                 )
+        except DeliveryFailedError as e:
+            # The turn's reply is what failed to post -- Band-side delivery,
+            # never an ACP provider failure, so the connection stays up.
+            logger.exception("ACP reply delivery failed: %s", e.cause)
         except Exception as e:
             logger.exception("ACP agent error: %s", e)
             await self.stop()
-            await tools.send_event(
-                content=f"ACP agent error: {e}",
-                message_type="error",
-                metadata={"acp_error": str(e)},
-            )
+            await tools.send_failure(_to_agent_failure(e))
 
     def _make_permission_handler(
         self,

--- a/src/band/integrations/acp/client_adapter.py
+++ b/src/band/integrations/acp/client_adapter.py
@@ -18,8 +18,12 @@ from typing_extensions import Unpack
 
 from band.converters.acp_client import ACPClientHistoryConverter
 from band.converters.helpers import build_replay_messages
-from band.core.delivery import DeliveryFailedError
-from band.core.protocols import FAILURE_CODE_TIMEOUT, AgentToolsProtocol
+from band.core.delivery import DeliveryFailedError, reraise_delivery_cause
+from band.core.protocols import (
+    FAILURE_CODE_TIMEOUT,
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    AgentToolsProtocol,
+)
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import (
     AdapterFeatures,
@@ -137,7 +141,7 @@ def _to_agent_failure(exc: Exception) -> AgentFailure:
     """
     if isinstance(exc, RequestError):
         return AgentFailure("acp", str(exc), str(exc.code), exc.data)
-    return AgentFailure("acp", str(exc))
+    return AgentFailure("acp", GENERIC_PROVIDER_FAILURE_MESSAGE)
 
 
 class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
@@ -380,7 +384,7 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
         except DeliveryFailedError as e:
             # The turn's reply is what failed to post -- Band-side delivery,
             # never an ACP provider failure, so the connection stays up.
-            logger.exception("ACP reply delivery failed: %s", e.cause)
+            reraise_delivery_cause(e)
         except asyncio.TimeoutError:
             # A silent/stuck agent must become an observable failure instead
             # of hanging the turn indefinitely -- the connection is presumed
@@ -401,9 +405,11 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
                     )
                 ),
             )
+            raise
         except Exception as e:
             logger.exception("ACP agent error: %s", e)
             await asyncio.gather(self.stop(), tools.send_failure(_to_agent_failure(e)))
+            raise
 
     def _make_permission_handler(
         self,

--- a/src/band/integrations/acp/client_adapter.py
+++ b/src/band/integrations/acp/client_adapter.py
@@ -391,18 +391,19 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
                 room_id,
                 session_id,
             )
-            await self.stop()
-            await tools.send_failure(
-                AgentFailure(
-                    "acp",
-                    f"ACP agent response timed out after {self._turn_timeout_s}s",
-                    FAILURE_CODE_TIMEOUT,
-                )
+            await asyncio.gather(
+                self.stop(),
+                tools.send_failure(
+                    AgentFailure(
+                        "acp",
+                        f"ACP agent response timed out after {self._turn_timeout_s}s",
+                        FAILURE_CODE_TIMEOUT,
+                    )
+                ),
             )
         except Exception as e:
             logger.exception("ACP agent error: %s", e)
-            await self.stop()
-            await tools.send_failure(_to_agent_failure(e))
+            await asyncio.gather(self.stop(), tools.send_failure(_to_agent_failure(e)))
 
     def _make_permission_handler(
         self,

--- a/src/band/integrations/acp/room_emitter.py
+++ b/src/band/integrations/acp/room_emitter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 
+from band.core.delivery import deliver_reply
 from band.core.protocols import AgentToolsProtocol
 from band.integrations.acp.types import (
     ACPToolCall,
@@ -173,7 +174,7 @@ class RoomTurnEmitter:
         # reply (and leak the agent's narration of the call).
         if not turn_replied_in_room(self._chunks):
             for text in self._pending_text:
-                await self._tools.send_message(content=text, mentions=self._mentions)
+                await deliver_reply(self._tools, text, mentions=self._mentions)
         await self._tools.send_event(
             content="ACP client session",
             message_type="task",

--- a/src/band/integrations/codex/__init__.py
+++ b/src/band/integrations/codex/__init__.py
@@ -10,21 +10,19 @@ from .rpc_base import (
 from .stdio_client import CodexStdioClient
 from .types import (
     CODEX_APPROVAL_METHODS,
-    CODEX_ERROR_REMEDIATION,
     ApprovalAuditEntry,
     CodexApprovalMethod,
     CodexItemType,
     CodexPlanStep,
     CodexSessionState,
     CodexTokenUsage,
-    build_structured_error_metadata,
+    build_agent_failure,
     parse_plan_steps,
 )
 from .websocket_client import CodexWebSocketClient
 
 __all__ = [
     "CODEX_APPROVAL_METHODS",
-    "CODEX_ERROR_REMEDIATION",
     "ApprovalAuditEntry",
     "CodexApprovalMethod",
     "CodexItemType",
@@ -36,6 +34,6 @@ __all__ = [
     "CodexWebSocketClient",
     "OverloadRetryPolicy",
     "RpcEvent",
-    "build_structured_error_metadata",
+    "build_agent_failure",
     "parse_plan_steps",
 ]

--- a/src/band/integrations/codex/types.py
+++ b/src/band/integrations/codex/types.py
@@ -103,7 +103,8 @@ def build_agent_failure(
     codex_info = error_obj.get("codexErrorInfo") or {}
     if not isinstance(codex_info, dict):
         codex_info = {}
-    error_type = codex_info.get("type") or None
+    raw_error_type = codex_info.get("type")
+    error_type = str(raw_error_type) if raw_error_type else None
     error_code = codex_info.get("code") or None
     http_status = codex_info.get("httpStatus")
     # A genuine passthrough of codexErrorInfo.retryable: absent means unknown,

--- a/src/band/integrations/codex/types.py
+++ b/src/band/integrations/codex/types.py
@@ -9,6 +9,8 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any
 
+from band_sdk_core import AgentFailure
+
 logger = logging.getLogger(__name__)
 
 
@@ -77,46 +79,15 @@ class CodexSessionState:
 # Structured error types
 # ---------------------------------------------------------------------------
 
-# Mapping from Codex error type to (human description, suggested action).
-CODEX_ERROR_REMEDIATION: dict[str, tuple[str, str]] = {
-    "ContextWindowExceeded": (
-        "Context window exceeded — the conversation is too long for the model.",
-        "compact_context",
-    ),
-    "UsageLimitExceeded": (
-        "Usage limit exceeded — you have hit your API quota.",
-        "wait_or_upgrade",
-    ),
-    "HttpConnectionFailed": (
-        "HTTP connection failed — could not reach the API.",
-        "check_connectivity",
-    ),
-    "SandboxError": (
-        "Sandbox error — a sandbox policy violation occurred.",
-        "review_sandbox_policy",
-    ),
-    "Unauthorized": (
-        "Unauthorized — authentication failed or expired.",
-        "re_authenticate",
-    ),
-    "BadRequest": (
-        "Bad request — the input format is invalid.",
-        "check_input_format",
-    ),
-    "ResponseTooManyFailedAttempts": (
-        "Too many failed attempts — the model could not produce a valid response.",
-        "retry_different_approach",
-    ),
-}
 
-
-def build_structured_error_metadata(
+def build_agent_failure(
     error_obj: dict[str, Any],
     *,
     thread_id: str | None = None,
     turn_id: str | None = None,
-) -> tuple[str, dict[str, Any]]:
-    """Parse a Codex error dict and return (content, metadata) for a structured error event.
+    room_id: str | None = None,
+) -> AgentFailure:
+    """Parse a Codex error dict into the shared provider-failure shape.
 
     The ``error_obj`` is typically the ``error`` field from a turn payload or an
     ``error`` notification.  It may contain a nested ``codexErrorInfo`` dict with
@@ -124,51 +95,46 @@ def build_structured_error_metadata(
 
     ``additionalDetails`` echoes upstream strings that may be attacker-controlled
     (e.g. error messages from a downstream HTTP target) and will be rendered by
-    downstream UIs.  Consumers MUST treat the resulting
-    ``codex_additional_details`` metadata field as untrusted — escape it before
-    rendering as HTML/Markdown.  This helper caps the length at
-    ``_MAX_ERROR_DETAIL_CHARS`` (2 KiB) so a hostile payload can't blow up
-    WebSocket frames or downstream storage.
+    downstream UIs.  Consumers MUST treat the resulting ``codex_additional_details``
+    detail field as untrusted — escape it before rendering as HTML/Markdown. This
+    helper caps the length at ``_MAX_ERROR_DETAIL_CHARS`` (2 KiB) so a hostile
+    payload can't blow up WebSocket frames or downstream storage.
     """
     codex_info = error_obj.get("codexErrorInfo") or {}
     if not isinstance(codex_info, dict):
         codex_info = {}
-    error_type = codex_info.get("type") or ""
-    error_code = codex_info.get("code") or ""
+    error_type = codex_info.get("type") or None
+    error_code = codex_info.get("code") or None
     http_status = codex_info.get("httpStatus")
-    is_retryable = bool(codex_info.get("retryable", False))
+    # A genuine passthrough of codexErrorInfo.retryable: absent means unknown,
+    # never defaulted to False.
+    is_retryable = codex_info.get("retryable")
     additional = error_obj.get("additionalDetails")
 
-    # Look up remediation
-    remediation = CODEX_ERROR_REMEDIATION.get(str(error_type))
-    if remediation:
-        content, suggested_action = remediation
-    else:
-        raw_message = error_obj.get("message", "")
-        content = (
-            str(raw_message)
-            if raw_message
-            else f"Codex error: {error_type or 'unknown'}"
-        )
-        suggested_action = ""
+    raw_message = error_obj.get("message", "")
+    message = (
+        str(raw_message) if raw_message else f"Codex error: {error_type or 'unknown'}"
+    )
 
-    metadata: dict[str, Any] = {
-        "codex_error_type": error_type or None,
-        "codex_error_code": error_code or None,
-        "codex_http_status": http_status,
-        "codex_is_retryable": is_retryable,
-        "codex_suggested_action": suggested_action or None,
-    }
+    detail: dict[str, Any] = {}
+    if error_code:
+        detail["codex_error_code"] = error_code
+    if http_status is not None:
+        detail["codex_http_status"] = http_status
+    if is_retryable is not None:
+        detail["codex_is_retryable"] = bool(is_retryable)
     if thread_id:
-        metadata["codex_thread_id"] = thread_id
+        detail["codex_thread_id"] = thread_id
     if turn_id:
-        metadata["codex_turn_id"] = turn_id
+        detail["codex_turn_id"] = turn_id
+    if room_id:
+        detail["codex_room_id"] = room_id
     if additional is not None:
         capped = _cap_error_detail(additional)
         if capped is not None:
-            metadata["codex_additional_details"] = capped
+            detail["codex_additional_details"] = capped
 
-    return content, metadata
+    return AgentFailure("codex", message, error_type, detail or None)
 
 
 def _cap_error_detail(value: Any) -> Any:

--- a/src/band/runtime/tools/agent.py
+++ b/src/band/runtime/tools/agent.py
@@ -45,7 +45,7 @@ from band.core.memory_types import (
     organization_scope_rejected_message,
     validate_subject_scope,
 )
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import AgentToolsProtocol, to_failure_event
 from band.core.task_types import (
     TaskAssignmentStatus,
     TaskIncludeOption,
@@ -441,6 +441,21 @@ class AgentTools(AgentToolsProtocol):
                 content=content, message_type=message_type, metadata=metadata
             ),
         )
+
+    async def send_failure(self, failure: band_sdk_core.AgentFailure) -> Any:
+        """
+        Report a provider-originated failure as a structured error event.
+
+        Best-effort, unlike ``send_event``: this runs inside a caller's own
+        except block, where raising would replace the provider failure the
+        room is being told about with an unrelated reporting failure.
+        """
+        content, metadata = to_failure_event(failure)
+        try:
+            return await self.send_event(content, "error", metadata)
+        except Exception as exc:
+            logger.exception("send_failure could not post the failure event")
+            return {"ok": False, "error": str(exc)}
 
     async def create_chatroom(self, task_id: str | None = None) -> str:
         """

--- a/src/band/runtime/tools/agent.py
+++ b/src/band/runtime/tools/agent.py
@@ -54,7 +54,7 @@ from band.core.task_types import (
     validate_include,
 )
 from band.core.tool_filter import sanitize_tool_schema
-from band.core.types import Capability
+from band.core.types import Capability, MessageType
 from band.core.validation import at_least_one_of
 from band.runtime.tools.registry import (
     TOOL_DEFINITIONS,
@@ -452,7 +452,7 @@ class AgentTools(AgentToolsProtocol):
         """
         content, metadata = to_failure_event(failure)
         try:
-            return await self.send_event(content, "error", metadata)
+            return await self.send_event(content, MessageType.ERROR, metadata)
         except Exception as exc:
             logger.exception("send_failure could not post the failure event")
             return {"ok": False, "error": str(exc)}

--- a/src/band/testing/__init__.py
+++ b/src/band/testing/__init__.py
@@ -12,7 +12,10 @@ from band.exports import lazy_exports
 
 # Type-only imports for static analysis (pyrefly, mypy, etc.)
 if TYPE_CHECKING:
-    from band.testing.fake_tools import FakeAgentTools as FakeAgentTools
+    from band.testing.fake_tools import (
+        FakeAgentTools as FakeAgentTools,
+        reported_failures as reported_failures,
+    )
     from band.testing.features import feature_kwargs as feature_kwargs
     from band.testing.phoenix_server import (
         FakePhoenixServer as FakePhoenixServer,
@@ -35,7 +38,7 @@ if TYPE_CHECKING:
 
 __all__, __getattr__ = lazy_exports(
     __name__,
-    fake_tools=["FakeAgentTools"],
+    fake_tools=["FakeAgentTools", "reported_failures"],
     features=["feature_kwargs"],
     phoenix_server=["FakePhoenixServer", "JoinOutcome", "fake_phoenix_server"],
     platform=["platform_connection_stub"],

--- a/src/band/testing/__init__.py
+++ b/src/band/testing/__init__.py
@@ -14,6 +14,7 @@ from band.exports import lazy_exports
 if TYPE_CHECKING:
     from band.testing.fake_tools import (
         FakeAgentTools as FakeAgentTools,
+        events_of_type as events_of_type,
         reported_failures as reported_failures,
     )
     from band.testing.features import feature_kwargs as feature_kwargs
@@ -38,7 +39,7 @@ if TYPE_CHECKING:
 
 __all__, __getattr__ = lazy_exports(
     __name__,
-    fake_tools=["FakeAgentTools", "reported_failures"],
+    fake_tools=["FakeAgentTools", "events_of_type", "reported_failures"],
     features=["feature_kwargs"],
     phoenix_server=["FakePhoenixServer", "JoinOutcome", "fake_phoenix_server"],
     platform=["platform_connection_stub"],

--- a/src/band/testing/fake_tools.py
+++ b/src/band/testing/fake_tools.py
@@ -8,6 +8,8 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any, Literal
 
+import band_sdk_core
+
 from band.client.rest import (
     AgentContact,
     AgentMemory,
@@ -34,6 +36,7 @@ from band.client.rest import (
 )
 from band.core.content import has_visible_content
 from band.core.exceptions import BandToolError
+from band.core.protocols import to_failure_event
 from band.core.task_types import TaskAssignmentStatus, TaskLifecycleState, TaskListState
 from band.core.types import Capability
 from band.runtime.tools import (
@@ -101,6 +104,9 @@ class FakeAgentTools:
         self._hub_room_id = hub_room_id
         self.messages_sent: list[dict[str, Any]] = []
         self.events_sent: list[dict[str, Any]] = []
+        # Set to simulate a send_event REST rejection (e.g. proving
+        # send_failure swallows it while send_event itself still raises).
+        self.send_event_error: Exception | None = None
         self._participants: list[dict[str, Any]] = participants or []
         self._room_context: list[dict[str, Any]] = list(room_context or [])
         # Seeds are validated and canonicalized at seed time (not list time),
@@ -198,6 +204,8 @@ class FakeAgentTools:
         Same fidelity rationale as ``send_message``: the real send returns
         ``None`` without a request rather than letting the platform 422.
         """
+        if self.send_event_error is not None:
+            raise self.send_event_error
         if not has_visible_content(content):
             return None
         event = {
@@ -208,6 +216,16 @@ class FakeAgentTools:
         }
         self.events_sent.append(event)
         return event
+
+    async def send_failure(
+        self, failure: band_sdk_core.AgentFailure
+    ) -> dict[str, Any] | None:
+        """Same best-effort delegation as ``AgentTools.send_failure``."""
+        content, metadata = to_failure_event(failure)
+        try:
+            return await self.send_event(content, "error", metadata)
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
 
     async def add_participant(
         self, identifier: str, role: str = "member"

--- a/src/band/testing/fake_tools.py
+++ b/src/band/testing/fake_tools.py
@@ -38,7 +38,7 @@ from band.core.content import has_visible_content
 from band.core.exceptions import BandToolError
 from band.core.protocols import to_failure_event
 from band.core.task_types import TaskAssignmentStatus, TaskLifecycleState, TaskListState
-from band.core.types import Capability
+from band.core.types import Capability, MessageType
 from band.runtime.tools import (
     DEFAULT_FILE_CAPTION,
     FILE_UNAVAILABLE_MESSAGE,
@@ -223,7 +223,7 @@ class FakeAgentTools:
         """Same best-effort delegation as ``AgentTools.send_failure``."""
         content, metadata = to_failure_event(failure)
         try:
-            return await self.send_event(content, "error", metadata)
+            return await self.send_event(content, MessageType.ERROR, metadata)
         except Exception as exc:
             return {"ok": False, "error": str(exc)}
 
@@ -729,3 +729,12 @@ class FakeAgentTools:
         assert not self.messages_sent, (
             f"Expected no messages, but {len(self.messages_sent)} were sent"
         )
+
+
+def reported_failures(tools: FakeAgentTools) -> list[dict[str, Any]]:
+    """Every ``AgentFailure`` reported via ``send_failure``, as its wire dict."""
+    return [
+        e["metadata"]["failure"]
+        for e in tools.events_sent
+        if e["message_type"] == MessageType.ERROR
+    ]

--- a/src/band/testing/fake_tools.py
+++ b/src/band/testing/fake_tools.py
@@ -731,10 +731,20 @@ class FakeAgentTools:
         )
 
 
+def events_of_type(tools: FakeAgentTools, message_type: str) -> list[dict[str, Any]]:
+    """Events of ``message_type`` captured on ``tools.events_sent``."""
+    return [e for e in tools.events_sent if e["message_type"] == message_type]
+
+
 def reported_failures(tools: FakeAgentTools) -> list[dict[str, Any]]:
-    """Every ``AgentFailure`` reported via ``send_failure``, as its wire dict."""
+    """Every ``AgentFailure`` reported via ``send_failure``, as its wire dict.
+
+    Ignores an "error" event with no ``failure`` metadata -- a pre-existing,
+    not-yet-migrated ``send_event(..., "error")`` call site posts one without
+    the ``send_failure`` shape, and that isn't what this helper reports on.
+    """
     return [
         e["metadata"]["failure"]
-        for e in tools.events_sent
-        if e["message_type"] == MessageType.ERROR
+        for e in events_of_type(tools, MessageType.ERROR)
+        if "failure" in e["metadata"]
     ]

--- a/tests/adapters/agno/test_adapter.py
+++ b/tests/adapters/agno/test_adapter.py
@@ -889,18 +889,17 @@ class TestRunFailureReporting:
                 room_id="room-A",
             )
 
-        errors = [e for e in tools.events_sent if e["message_type"] == "error"]
-        assert len(errors) == 1
+        failures = reported_failures(tools)
+        assert len(failures) == 1
         assert (
-            errors[0]["content"]
+            failures[0]["message"]
             == "Internal error while processing message; see agent logs."
         )
         # The exception text (which can carry secrets) must not leak to the room.
-        assert "secret-token" not in errors[0]["content"]
-        failure = reported_failures(tools)[0]
-        assert failure["provider"] == "agno"
+        assert "secret-token" not in failures[0]["message"]
+        assert failures[0]["provider"] == "agno"
         # A plain RuntimeError isn't a swallowed Agno run status -- no code.
-        assert failure["code"] is None
+        assert failures[0]["code"] is None
 
     async def test_error_status_run_is_raised_and_reported(
         self, make_started_adapter, tools
@@ -926,10 +925,10 @@ class TestRunFailureReporting:
                 room_id="room-A",
             )
 
-        errors = [e for e in tools.events_sent if e["message_type"] == "error"]
-        assert len(errors) == 1
-        assert "secret-token" not in errors[0]["content"]
-        assert errors[0]["metadata"]["failure"]["code"] == RunStatus.error.value
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert "secret-token" not in failures[0]["message"]
+        assert failures[0]["code"] == RunStatus.error.value
         # A failed turn must not be committed to the room transcript.
         assert not adapter._message_history.get("room-A")
 
@@ -956,10 +955,10 @@ class TestRunFailureReporting:
                 room_id="room-A",
             )
 
-        errors = [e for e in tools.events_sent if e["message_type"] == "error"]
-        assert len(errors) == 1
-        assert "secret-token" not in errors[0]["content"]
-        assert reported_failures(tools)[0]["code"] == RunStatus.error.value
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert "secret-token" not in failures[0]["message"]
+        assert failures[0]["code"] == RunStatus.error.value
         assert not adapter._message_history.get("room-A")
 
     async def test_error_event_failure_does_not_mask_original(

--- a/tests/adapters/agno/test_adapter.py
+++ b/tests/adapters/agno/test_adapter.py
@@ -897,6 +897,10 @@ class TestRunFailureReporting:
         )
         # The exception text (which can carry secrets) must not leak to the room.
         assert "secret-token" not in errors[0]["content"]
+        failure = errors[0]["metadata"]["failure"]
+        assert failure["provider"] == "agno"
+        # A plain RuntimeError isn't a swallowed Agno run status -- no code.
+        assert failure["code"] is None
 
     async def test_error_status_run_is_raised_and_reported(
         self, make_started_adapter, tools
@@ -925,6 +929,7 @@ class TestRunFailureReporting:
         errors = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert len(errors) == 1
         assert "secret-token" not in errors[0]["content"]
+        assert errors[0]["metadata"]["failure"]["code"] == RunStatus.error.value
         # A failed turn must not be committed to the room transcript.
         assert not adapter._message_history.get("room-A")
 
@@ -954,6 +959,7 @@ class TestRunFailureReporting:
         errors = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert len(errors) == 1
         assert "secret-token" not in errors[0]["content"]
+        assert errors[0]["metadata"]["failure"]["code"] == RunStatus.error.value
         assert not adapter._message_history.get("room-A")
 
     async def test_error_event_failure_does_not_mask_original(

--- a/tests/adapters/agno/test_adapter.py
+++ b/tests/adapters/agno/test_adapter.py
@@ -30,7 +30,7 @@ from band.adapters.agno import (
     _make_band_entrypoint,
 )
 from band.core.types import Capability, Emit, PlatformMessage
-from band.testing import FakeAgentTools
+from band.testing import FakeAgentTools, reported_failures
 
 from tests.adapters.agno.helpers import (
     CapturingModel,
@@ -897,7 +897,7 @@ class TestRunFailureReporting:
         )
         # The exception text (which can carry secrets) must not leak to the room.
         assert "secret-token" not in errors[0]["content"]
-        failure = errors[0]["metadata"]["failure"]
+        failure = reported_failures(tools)[0]
         assert failure["provider"] == "agno"
         # A plain RuntimeError isn't a swallowed Agno run status -- no code.
         assert failure["code"] is None
@@ -959,7 +959,7 @@ class TestRunFailureReporting:
         errors = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert len(errors) == 1
         assert "secret-token" not in errors[0]["content"]
-        assert errors[0]["metadata"]["failure"]["code"] == RunStatus.error.value
+        assert reported_failures(tools)[0]["code"] == RunStatus.error.value
         assert not adapter._message_history.get("room-A")
 
     async def test_error_event_failure_does_not_mask_original(

--- a/tests/adapters/copilot_sdk/fakes.py
+++ b/tests/adapters/copilot_sdk/fakes.py
@@ -147,10 +147,12 @@ class FakeCopilotClient:
         self,
         *,
         resume_error: Exception | None = None,
+        create_error: Exception | None = None,
         reply_content: str | None = "Hello from Copilot",
         turn_events: list[Any] | None = None,
     ):
         self.resume_error = resume_error
+        self.create_error = create_error
         self.reply_content = reply_content
         self.turn_events = turn_events or []
         self.started = False
@@ -168,6 +170,8 @@ class FakeCopilotClient:
     async def create_session(
         self, *, session_id: str | None = None, **kwargs: Any
     ) -> Any:
+        if self.create_error:
+            raise self.create_error
         session = FakeCopilotSession(
             session_id,
             kwargs,

--- a/tests/adapters/copilot_sdk/test_reply.py
+++ b/tests/adapters/copilot_sdk/test_reply.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from band.adapters.copilot_sdk import _COPILOT_SDK_AVAILABLE
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE
 from band.runtime.tools import CHAT_ID_FIELD_NAME, ToolCallOutcome
 from tests.adapters.copilot_sdk.fakes import (
     FakeCopilotClient,
@@ -78,7 +79,9 @@ class TestReply:
         session = client.sessions[0]
         assert session.aborted and session.disconnected
         error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
-        assert error_events and "boom" in error_events[0]["content"]
+        assert error_events and error_events[0]["content"] == (
+            GENERIC_PROVIDER_FAILURE_MESSAGE
+        )
 
     @pytest.mark.asyncio
     async def test_fallback_send_suppressed_when_band_send_message_fired(self):

--- a/tests/adapters/copilot_sdk/test_turn_failure.py
+++ b/tests/adapters/copilot_sdk/test_turn_failure.py
@@ -34,6 +34,7 @@ class TestTurnFailure:
         assert dead.disconnected
         error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert error_events
+        assert error_events[0]["metadata"]["failure"]["provider"] == "copilot_sdk"
 
         # ...so the next message starts clean, resuming by the stored id.
         await run_message(adapter, tools, is_session_bootstrap=False)
@@ -70,3 +71,18 @@ class TestTurnFailure:
             await run_message(adapter, tools)
 
         assert not tools.messages_sent
+
+    @pytest.mark.asyncio
+    async def test_session_creation_failure_is_reported(self):
+        """Previously fully uncaught: session setup ran outside on_message's
+        try entirely, so a create_session failure escaped with zero report."""
+        client = FakeCopilotClient(create_error=RuntimeError("Copilot CLI unreachable"))
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        with pytest.raises(RuntimeError, match="Copilot CLI unreachable"):
+            await run_message(adapter, tools)
+
+        error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
+        assert error_events
+        assert error_events[0]["metadata"]["failure"]["provider"] == "copilot_sdk"

--- a/tests/adapters/copilot_sdk/test_turn_failure.py
+++ b/tests/adapters/copilot_sdk/test_turn_failure.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from band.testing import reported_failures
 from tests.adapters.copilot_sdk.fakes import (
     FakeCopilotClient,
     ToolSchemaFakeTools,
@@ -32,9 +33,9 @@ class TestTurnFailure:
         # The stale turn is aborted on the runtime and the session dropped...
         assert dead.aborted
         assert dead.disconnected
-        error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
-        assert error_events
-        assert error_events[0]["metadata"]["failure"]["provider"] == "copilot_sdk"
+        failures = reported_failures(tools)
+        assert failures
+        assert failures[0]["provider"] == "copilot_sdk"
 
         # ...so the next message starts clean, resuming by the stored id.
         await run_message(adapter, tools, is_session_bootstrap=False)
@@ -74,8 +75,8 @@ class TestTurnFailure:
 
     @pytest.mark.asyncio
     async def test_session_creation_failure_is_reported(self):
-        """Previously fully uncaught: session setup ran outside on_message's
-        try entirely, so a create_session failure escaped with zero report."""
+        """A create_session failure, raised before on_message's own turn
+        processing begins, must still be reported."""
         client = FakeCopilotClient(create_error=RuntimeError("Copilot CLI unreachable"))
         adapter = await make_started_adapter(client)
         tools = ToolSchemaFakeTools()
@@ -83,6 +84,6 @@ class TestTurnFailure:
         with pytest.raises(RuntimeError, match="Copilot CLI unreachable"):
             await run_message(adapter, tools)
 
-        error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
-        assert error_events
-        assert error_events[0]["metadata"]["failure"]["provider"] == "copilot_sdk"
+        failures = reported_failures(tools)
+        assert failures
+        assert failures[0]["provider"] == "copilot_sdk"

--- a/tests/adapters/langgraph/conftest.py
+++ b/tests/adapters/langgraph/conftest.py
@@ -30,6 +30,7 @@ def mock_tools():
     tools = MagicMock()
     tools.send_message = AsyncMock(return_value={"status": "sent"})
     tools.send_event = AsyncMock(return_value={"status": "sent"})
+    tools.send_failure = AsyncMock(return_value={"status": "sent"})
     tools.add_participant = AsyncMock(return_value={"id": "user-1"})
     tools.remove_participant = AsyncMock(return_value={"status": "removed"})
     tools.lookup_peers = AsyncMock(return_value={"peers": []})

--- a/tests/adapters/langgraph/test_lifecycle.py
+++ b/tests/adapters/langgraph/test_lifecycle.py
@@ -342,8 +342,7 @@ class TestErrorHandling:
     async def test_reports_error_when_graph_factory_yields_no_graph(
         self, sample_message, mock_tools, mock_llm, mock_checkpointer
     ):
-        """Previously uncaught entirely: graph-factory construction ran
-        outside the try, so a bad factory's RuntimeError escaped unreported."""
+        """A bad graph factory's RuntimeError must be reported, not escape unreported."""
         adapter = LangGraphAdapter(
             llm=mock_llm,
             checkpointer=mock_checkpointer,

--- a/tests/adapters/langgraph/test_lifecycle.py
+++ b/tests/adapters/langgraph/test_lifecycle.py
@@ -327,11 +327,46 @@ class TestErrorHandling:
                     room_id="room-123",
                 )
 
-            # Should have tried to report an error event, AND that event
-            # must NOT include the raw exception text (it can carry DB
-            # strings, paths, tokens, etc.). The full traceback only goes
-            # to the agent log via logger.exception.
-            mock_tools.send_event.assert_awaited()
-            call_kwargs = mock_tools.send_event.call_args.kwargs
-            assert call_kwargs["message_type"] == "error"
-            assert "Graph error!" not in call_kwargs["content"]
+            # Should have tried to report a failure, AND that failure must
+            # NOT include the raw exception text anywhere -- message, code,
+            # or detail (it can carry DB strings, paths, tokens, etc.). The
+            # full traceback only goes to the agent log via logger.exception.
+            mock_tools.send_failure.assert_awaited_once()
+            failure = mock_tools.send_failure.call_args.args[0]
+            assert failure.provider == "langgraph"
+            assert "Graph error!" not in failure.message
+            assert failure.code is None
+            assert failure.detail is None
+
+    @pytest.mark.asyncio
+    async def test_reports_error_when_graph_factory_yields_no_graph(
+        self, sample_message, mock_tools, mock_llm, mock_checkpointer
+    ):
+        """Previously uncaught entirely: graph-factory construction ran
+        outside the try, so a bad factory's RuntimeError escaped unreported."""
+        adapter = LangGraphAdapter(
+            llm=mock_llm,
+            checkpointer=mock_checkpointer,
+        )
+        await adapter.on_started("TestBot", "Test bot")
+        adapter.graph_factory = MagicMock(return_value=None)
+
+        with patch(
+            "band.integrations.langgraph.langchain_tools.agent_tools_to_langchain"
+        ) as mock_convert:
+            mock_convert.return_value = []
+
+            with pytest.raises(RuntimeError, match="No graph available"):
+                await adapter.on_message(
+                    msg=sample_message,
+                    tools=mock_tools,
+                    history=[],
+                    participants_msg=None,
+                    contacts_msg=None,
+                    is_session_bootstrap=True,
+                    room_id="room-123",
+                )
+
+        mock_tools.send_failure.assert_awaited_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "langgraph"

--- a/tests/adapters/opencode/helpers.py
+++ b/tests/adapters/opencode/helpers.py
@@ -212,6 +212,16 @@ def tools_protocol(tools: FakeAgentTools) -> AgentToolsProtocol:
     return cast(AgentToolsProtocol, tools)
 
 
+def events_of_type(tools: FakeAgentTools, message_type: str) -> list[dict[str, Any]]:
+    """Events of ``message_type`` captured on ``tools.events_sent``."""
+    return [e for e in tools.events_sent if e["message_type"] == message_type]
+
+
+def reported_failures(tools: FakeAgentTools) -> list[dict[str, Any]]:
+    """Every ``AgentFailure`` reported via ``send_failure``, as its wire dict."""
+    return [e["metadata"]["failure"] for e in events_of_type(tools, "error")]
+
+
 class RaisingSendTools(FakeAgentTools):
     """FakeAgentTools whose send_message always fails, to exercise the
     best-effort ``_notify_room`` path: a room post that raises must be

--- a/tests/adapters/opencode/helpers.py
+++ b/tests/adapters/opencode/helpers.py
@@ -19,7 +19,7 @@ from band.core.types import (
     PlatformMessage,
 )
 from band.integrations.opencode.types import OpencodeSessionState
-from band.testing import FakeAgentTools
+from band.testing import FakeAgentTools, events_of_type as events_of_type
 
 RawOpencodeEvent: TypeAlias = dict[str, Any]
 
@@ -210,11 +210,6 @@ def event_session_error(session_id: str, message: str) -> RawOpencodeEvent:
 
 def tools_protocol(tools: FakeAgentTools) -> AgentToolsProtocol:
     return cast(AgentToolsProtocol, tools)
-
-
-def events_of_type(tools: FakeAgentTools, message_type: str) -> list[dict[str, Any]]:
-    """Events of ``message_type`` captured on ``tools.events_sent``."""
-    return [e for e in tools.events_sent if e["message_type"] == message_type]
 
 
 class RaisingSendTools(FakeAgentTools):

--- a/tests/adapters/opencode/helpers.py
+++ b/tests/adapters/opencode/helpers.py
@@ -217,11 +217,6 @@ def events_of_type(tools: FakeAgentTools, message_type: str) -> list[dict[str, A
     return [e for e in tools.events_sent if e["message_type"] == message_type]
 
 
-def reported_failures(tools: FakeAgentTools) -> list[dict[str, Any]]:
-    """Every ``AgentFailure`` reported via ``send_failure``, as its wire dict."""
-    return [e["metadata"]["failure"] for e in events_of_type(tools, "error")]
-
-
 class RaisingSendTools(FakeAgentTools):
     """FakeAgentTools whose send_message always fails, to exercise the
     best-effort ``_notify_room`` path: a room post that raises must be

--- a/tests/adapters/opencode/test_approvals.py
+++ b/tests/adapters/opencode/test_approvals.py
@@ -32,6 +32,7 @@ from tests.adapters.opencode.helpers import (
     event_question,
     event_session_idle,
     event_text_part,
+    events_of_type,
     make_platform_message,
     tools_protocol,
     wait_for,
@@ -626,7 +627,7 @@ async def test_permission_timeout_expiry() -> None:
 
     await wait_for(lambda: len(fake_client.permission_replies) > 0, timeout_s=3.0)
     assert fake_client.permission_replies[0]["response"] == "reject"
-    error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
+    error_events = events_of_type(tools, "error")
     assert any("timed out" in e["content"].lower() for e in error_events)
     # A human-approval timeout is a Band-side procedural notice, never an
     # AgentFailure -- it must not carry the shared failure metadata shape.
@@ -685,7 +686,7 @@ async def test_question_timeout_expiry() -> None:
 
     await wait_for(lambda: len(fake_client.question_rejections) > 0, timeout_s=3.0)
     assert fake_client.question_rejections == ["q-timeout"]
-    error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
+    error_events = events_of_type(tools, "error")
     assert any("timed out" in e["content"].lower() for e in error_events)
     # A human-approval timeout is a Band-side procedural notice, never an
     # AgentFailure -- it must not carry the shared failure metadata shape.

--- a/tests/adapters/opencode/test_approvals.py
+++ b/tests/adapters/opencode/test_approvals.py
@@ -628,6 +628,9 @@ async def test_permission_timeout_expiry() -> None:
     assert fake_client.permission_replies[0]["response"] == "reject"
     error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
     assert any("timed out" in e["content"].lower() for e in error_events)
+    # A human-approval timeout is a Band-side procedural notice, never an
+    # AgentFailure -- it must not carry the shared failure metadata shape.
+    assert "failure" not in error_events[0]["metadata"]
 
     await adapter.on_cleanup("room-1")
 
@@ -684,6 +687,9 @@ async def test_question_timeout_expiry() -> None:
     assert fake_client.question_rejections == ["q-timeout"]
     error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
     assert any("timed out" in e["content"].lower() for e in error_events)
+    # A human-approval timeout is a Band-side procedural notice, never an
+    # AgentFailure -- it must not carry the shared failure metadata shape.
+    assert "failure" not in error_events[0]["metadata"]
 
     await adapter.on_cleanup("room-1")
 

--- a/tests/adapters/opencode/test_lifecycle.py
+++ b/tests/adapters/opencode/test_lifecycle.py
@@ -25,6 +25,7 @@ from tests.adapters.opencode.helpers import (
     event_message_updated,
     event_session_idle,
     event_text_part,
+    events_of_type,
     make_platform_message,
     run_single_turn,
     tools_protocol,
@@ -259,7 +260,7 @@ async def test_concurrent_message_rejected(make_adapter, tools) -> None:
     )
 
     # Second message should get rejected with "still processing" error
-    error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
+    error_events = events_of_type(tools, "error")
     assert any("still processing" in e["content"].lower() for e in error_events)
     assert len(fake_client.prompt_calls) == 1
 

--- a/tests/adapters/opencode/test_setup.py
+++ b/tests/adapters/opencode/test_setup.py
@@ -24,6 +24,7 @@ from tests.adapters.opencode.helpers import (
     event_message_updated,
     event_session_idle,
     event_text_part,
+    events_of_type,
     make_platform_message,
     tools_protocol,
 )
@@ -249,7 +250,7 @@ async def test_bootstrap_creates_session_relays_text_and_persists_task(
     assert fake_client.created_sessions[0]["id"] == "sess-1"
     assert tools.messages_sent[0]["content"] == "OpenCode says hi"
     assert tools.messages_sent[0]["mentions"] == [{"id": "user-1"}]
-    task_events = [e for e in tools.events_sent if e["message_type"] == "task"]
+    task_events = events_of_type(tools, "task")
     assert task_events
     assert task_events[0]["metadata"]["opencode_session_id"] == "sess-1"
     assert (

--- a/tests/adapters/opencode/test_turns.py
+++ b/tests/adapters/opencode/test_turns.py
@@ -32,6 +32,7 @@ from tests.adapters.opencode.helpers import (
     event_tool_part,
     event_user_message_updated,
     make_platform_message,
+    reported_failures,
     tools_protocol,
     wait_for,
 )
@@ -82,6 +83,25 @@ async def test_prompt_submission_failure_does_not_leave_room_stuck(
         message["content"] == "Recovered after failure"
         for message in tools.messages_sent
     )
+
+
+async def test_http_error_reports_status_code_as_failure_code(
+    make_adapter, tools
+) -> None:
+    """An HTTP error talking to the OpenCode server preserves its status code
+    as the failure's ``code``, so a caller can branch on it without parsing
+    the message text."""
+    fake_client = FakeOpencodeClient(
+        prompt_exceptions=[AnyHTTPStatusError(503, "sess-1")]
+    )
+    adapter = make_adapter(fake_client)
+
+    await run_single_turn(adapter, tools)
+
+    failures = reported_failures(tools)
+    assert failures
+    assert failures[0]["provider"] == "opencode"
+    assert failures[0]["code"] == "503"
 
 
 async def test_reports_tool_events_when_enabled() -> None:
@@ -271,9 +291,10 @@ async def test_session_error_emits_error_event(make_adapter, tools) -> None:
         room_id="room-1",
     )
 
-    error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
-    assert error_events
-    assert "boom" in error_events[0]["content"].lower()
+    failures = reported_failures(tools)
+    assert failures
+    assert failures[0]["provider"] == "opencode"
+    assert "boom" in failures[0]["message"].lower()
 
 
 async def test_turn_timeout_aborts_session_and_emits_error() -> None:
@@ -300,8 +321,9 @@ async def test_turn_timeout_aborts_session_and_emits_error() -> None:
     )
 
     assert fake_client.aborted_sessions == ["sess-1"]
-    error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
-    assert any("timed out" in e["content"].lower() for e in error_events)
+    failures = reported_failures(tools)
+    assert any(f["provider"] == "opencode" and f["code"] == "timeout" for f in failures)
+    assert any("timed out" in f["message"].lower() for f in failures)
 
     await adapter.on_cleanup("room-1")
 
@@ -610,7 +632,8 @@ async def test_task_event_post_failure_does_not_drop_the_turn(make_adapter) -> N
         "Handled despite the event failure."
     ]
     assert not any(
-        "failed while processing" in e["content"].lower() for e in tools.events_sent
+        "failed while processing" in f["message"].lower()
+        for f in reported_failures(tools)
     )
 
 

--- a/tests/adapters/opencode/test_turns.py
+++ b/tests/adapters/opencode/test_turns.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 
+import httpx
+import pytest
 
 from band.adapters.opencode import OpencodeAdapter, OpencodeAdapterConfig
 from band.core.types import (
@@ -53,15 +55,16 @@ async def test_prompt_submission_failure_does_not_leave_room_stuck(
     adapter = make_adapter(fake_client)
 
     await adapter.on_started("OpenCode Agent", "A coding agent")
-    await adapter.on_message(
-        make_platform_message(content="first try"),
-        tools_protocol(tools),
-        OpencodeSessionState(),
-        participants_msg=None,
-        contacts_msg=None,
-        is_session_bootstrap=True,
-        room_id="room-1",
-    )
+    with pytest.raises(httpx.HTTPStatusError):
+        await adapter.on_message(
+            make_platform_message(content="first try"),
+            tools_protocol(tools),
+            OpencodeSessionState(),
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-1",
+        )
 
     await adapter.on_message(
         make_platform_message(content="second try"),
@@ -95,7 +98,8 @@ async def test_http_error_reports_status_code_as_failure_code(
     )
     adapter = make_adapter(fake_client)
 
-    await run_single_turn(adapter, tools)
+    with pytest.raises(httpx.HTTPStatusError):
+        await run_single_turn(adapter, tools)
 
     failures = reported_failures(tools)
     assert failures

--- a/tests/adapters/opencode/test_turns.py
+++ b/tests/adapters/opencode/test_turns.py
@@ -12,7 +12,7 @@ from band.core.types import (
     Emit,
 )
 from band.integrations.opencode.types import OpencodeSessionState
-from band.testing import FakeAgentTools
+from band.testing import FakeAgentTools, reported_failures
 from tests.adapters.usage_events import recorded_usage_payloads
 
 
@@ -32,7 +32,6 @@ from tests.adapters.opencode.helpers import (
     event_tool_part,
     event_user_message_updated,
     make_platform_message,
-    reported_failures,
     tools_protocol,
     wait_for,
 )

--- a/tests/adapters/test_anthropic_adapter.py
+++ b/tests/adapters/test_anthropic_adapter.py
@@ -21,6 +21,7 @@ from anthropic.types import TextBlock, ToolUseBlock
 from pydantic import BaseModel, Field
 
 from band.adapters.anthropic import AnthropicAdapter
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE
 from band.core.types import (
     USAGE_EVENT_TYPE,
     USAGE_METADATA_KEY,
@@ -735,7 +736,7 @@ class TestErrorHandling:
             mock_tools.send_failure.assert_called_once()
             failure = mock_tools.send_failure.call_args.args[0]
             assert failure.provider == "anthropic"
-            assert failure.message == "API Error"
+            assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
             assert failure.code is None
             assert failure.detail is None
 

--- a/tests/adapters/test_anthropic_adapter.py
+++ b/tests/adapters/test_anthropic_adapter.py
@@ -14,7 +14,9 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
+from anthropic import APIStatusError
 from anthropic.types import TextBlock, ToolUseBlock
 from pydantic import BaseModel, Field
 
@@ -67,6 +69,7 @@ def mock_tools():
     tools.get_tool_schemas = MagicMock(return_value=[])
     tools.send_message = AsyncMock(return_value={"status": "sent"})
     tools.send_event = AsyncMock(return_value={"status": "sent"})
+    tools.send_failure = AsyncMock(return_value={"status": "sent"})
     tools.execute_tool_call = AsyncMock(return_value={"status": "success"})
     return tools
 
@@ -698,6 +701,13 @@ class TestToolExecution:
         assert "Tool failed!" in results[0]["content"]
 
 
+def make_api_status_error(status_code: int, body: dict) -> APIStatusError:
+    """A real anthropic.APIStatusError, built the way the SDK itself would."""
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(status_code, request=request, json=body)
+    return APIStatusError(body["error"]["message"], response=response, body=body)
+
+
 class TestErrorHandling:
     """Tests for error handling."""
 
@@ -722,7 +732,41 @@ class TestErrorHandling:
                 )
 
             # Should have tried to report error
-            mock_tools.send_event.assert_called()
+            mock_tools.send_failure.assert_called_once()
+            failure = mock_tools.send_failure.call_args.args[0]
+            assert failure.provider == "anthropic"
+            assert failure.message == "API Error"
+            assert failure.code is None
+            assert failure.detail is None
+
+    @pytest.mark.asyncio
+    async def test_preserves_api_status_error_as_code_and_detail(
+        self, sample_message, mock_tools
+    ):
+        """An APIStatusError's status_code/body are real provider data --
+        preserve them rather than falling back to the generic shape."""
+        adapter = AnthropicAdapter()
+        await adapter.on_started("TestBot", "Test bot")
+        body = {"error": {"type": "overloaded_error", "message": "Overloaded"}}
+
+        with patch.object(adapter, "_call_anthropic") as mock_call:
+            mock_call.side_effect = make_api_status_error(529, body)
+
+            with pytest.raises(APIStatusError):
+                await adapter.on_message(
+                    msg=sample_message,
+                    tools=mock_tools,
+                    history=[],
+                    participants_msg=None,
+                    contacts_msg=None,
+                    is_session_bootstrap=True,
+                    room_id="room-123",
+                )
+
+            failure = mock_tools.send_failure.call_args.args[0]
+            assert failure.provider == "anthropic"
+            assert failure.code == "529"
+            assert failure.detail == body
 
 
 class EchoInput(BaseModel):

--- a/tests/adapters/test_claude_sdk_adapter.py
+++ b/tests/adapters/test_claude_sdk_adapter.py
@@ -67,9 +67,8 @@ if _CLAUDE_SDK_AVAILABLE:
 # The reply tool as the SDK namespaces it (MCP_TOOL_PREFIX + bare name).
 _SEND_MESSAGE_MCP_NAME = "mcp__band__band_send_message"
 _ANY_MODEL = "claude-sonnet-4-6"
-# What a turn that ended without a reply going out must say — the "Error: "
-# prefix is _report_error's own formatting, asserted by substring below
-# rather than re-derived here.
+# What a turn that ended without a reply going out must say, asserted by
+# substring below rather than re-derived here.
 _MISSING_REPLY_TEXT = missing_reply_error("Claude SDK")
 
 

--- a/tests/adapters/test_claude_sdk_adapter.py
+++ b/tests/adapters/test_claude_sdk_adapter.py
@@ -90,12 +90,8 @@ def _tool_turn(mcp_tool_name: str) -> list:
 
 
 def _error_events(mock_tools: MagicMock) -> list[str]:
-    """Contents of the error events posted through send_event."""
-    return [
-        call.kwargs["content"]
-        for call in mock_tools.send_event.call_args_list
-        if call.kwargs.get("message_type") == "error"
-    ]
+    """Room-visible message of each failure reported through send_failure."""
+    return [call.args[0].message for call in mock_tools.send_failure.call_args_list]
 
 
 def _narrated_message_types(mock_tools: MagicMock) -> list[str]:
@@ -190,6 +186,7 @@ def mock_tools():
     tools = MagicMock()
     tools.send_message = AsyncMock(return_value={"status": "sent"})
     tools.send_event = AsyncMock(return_value={"status": "sent"})
+    tools.send_failure = AsyncMock(return_value={"status": "sent"})
     tools.add_participant = AsyncMock(return_value={"id": "user-1"})
     tools.remove_participant = AsyncMock(return_value={"status": "removed"})
     tools.lookup_peers = AsyncMock(return_value={"peers": []})
@@ -457,7 +454,7 @@ class TestErrorHandling:
 
     @pytest.mark.asyncio
     async def test_reports_error_on_query_failure(self, sample_message, mock_tools):
-        """When client.query raises, adapter reports error via send_event and re-raises."""
+        """When client.query raises, adapter reports error via send_failure and re-raises."""
         adapter = ClaudeSDKAdapter()
         mock_client = MagicMock()
         mock_client.query = AsyncMock(side_effect=Exception("API Error"))
@@ -483,10 +480,10 @@ class TestErrorHandling:
                     room_id="room-123",
                 )
 
-            mock_tools.send_event.assert_called()
-            call_kwargs = mock_tools.send_event.call_args[1]
-            assert call_kwargs.get("message_type") == "error"
-            assert "API Error" in call_kwargs.get("content", "")
+            mock_tools.send_failure.assert_called_once()
+            failure = mock_tools.send_failure.call_args.args[0]
+            assert failure.provider == "claude_sdk"
+            assert "API Error" in failure.message
 
 
 class TestCLIConnectionError:
@@ -564,10 +561,10 @@ class TestCLIConnectionError:
                 )
 
             # Error should be surfaced to the user
-            mock_tools.send_event.assert_called()
-            call_kwargs = mock_tools.send_event.call_args[1]
-            assert call_kwargs.get("message_type") == "error"
-            assert "Process dead" in call_kwargs.get("content", "")
+            mock_tools.send_failure.assert_called_once()
+            failure = mock_tools.send_failure.call_args.args[0]
+            assert failure.provider == "claude_sdk"
+            assert "Process dead" in failure.message
 
     @pytest.mark.asyncio
     async def test_clears_session_id_on_cli_connection_error(
@@ -1107,6 +1104,80 @@ class TestSessionPersistence:
             # Second call should be without resume
             second_call = mock_manager.get_or_create_session.call_args_list[1]
             assert second_call == (("room-123",), {"resume_session_id": None})
+            # A self-healed retry is not a reportable failure.
+            mock_tools.send_failure.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reports_error_when_no_stored_session_to_retry(
+        self, sample_message, mock_tools
+    ):
+        """Previously a bare `raise` with zero report: no stored session id
+        means there is nothing to fall back to, so the failure must surface."""
+        adapter = ClaudeSDKAdapter()
+        mock_manager = AsyncMock()
+        mock_manager.get_or_create_session = AsyncMock(
+            side_effect=Exception("Session setup failed")
+        )
+
+        with patch(
+            "band.adapters.claude_sdk.ClaudeSessionManager",
+            return_value=mock_manager,
+        ):
+            await adapter.on_started(
+                agent_name="TestBot", agent_description="A test bot"
+            )
+
+            with pytest.raises(Exception, match="Session setup failed"):
+                await adapter.on_message(
+                    msg=sample_message,
+                    tools=mock_tools,
+                    history=ClaudeSDKSessionState(text=""),
+                    participants_msg=None,
+                    contacts_msg=None,
+                    is_session_bootstrap=True,
+                    room_id="room-123",
+                )
+
+        mock_tools.send_failure.assert_called_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "claude_sdk"
+        assert "Session setup failed" in failure.message
+
+    @pytest.mark.asyncio
+    async def test_reports_error_when_fallback_session_also_fails(
+        self, sample_message, mock_tools
+    ):
+        """The fallback session-creation attempt was previously uncaught by
+        this scope entirely -- a failure there escaped with zero report."""
+        adapter = ClaudeSDKAdapter()
+        mock_manager = AsyncMock()
+        mock_manager.get_or_create_session = AsyncMock(
+            side_effect=[Exception("Resume failed"), Exception("Fresh session failed")]
+        )
+
+        with patch(
+            "band.adapters.claude_sdk.ClaudeSessionManager",
+            return_value=mock_manager,
+        ):
+            await adapter.on_started(
+                agent_name="TestBot", agent_description="A test bot"
+            )
+
+            with pytest.raises(Exception, match="Fresh session failed"):
+                await adapter.on_message(
+                    msg=sample_message,
+                    tools=mock_tools,
+                    history=ClaudeSDKSessionState(text="", session_id="sess-broken"),
+                    participants_msg=None,
+                    contacts_msg=None,
+                    is_session_bootstrap=True,
+                    room_id="room-123",
+                )
+
+        mock_tools.send_failure.assert_called_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "claude_sdk"
+        assert "Fresh session failed" in failure.message
 
     @pytest.mark.asyncio
     async def test_task_event_failure_does_not_break_flow(self, mock_tools):
@@ -1177,6 +1248,11 @@ class TestTurnFailureSurfacing:
         errors = _error_events(mock_tools)
         assert len(errors) == 1
         assert "Not logged in · Please run /login" in errors[0]
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "claude_sdk"
+        # No structured api_error_status on this failure -- code stays unset
+        # rather than inventing one.
+        assert failure.code is None
 
     @pytest.mark.asyncio
     async def test_error_detail_includes_api_error_status(self, mock_tools):
@@ -1186,6 +1262,7 @@ class TestTurnFailureSurfacing:
             is_error=True,
             result="Failed to authenticate. API Error: 401",
             api_error_status=401,
+            errors=["authentication_error: invalid API key"],
         )
         mock_client = self._client_yielding(result_msg)
 
@@ -1194,6 +1271,9 @@ class TestTurnFailureSurfacing:
         errors = _error_events(mock_tools)
         assert len(errors) == 1
         assert "401" in errors[0]
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.code == "401"
+        assert failure.detail == ["authentication_error: invalid API key"]
 
     @pytest.mark.asyncio
     async def test_reports_missing_reply_when_no_terminal_tool_ran(self, mock_tools):

--- a/tests/adapters/test_claude_sdk_adapter.py
+++ b/tests/adapters/test_claude_sdk_adapter.py
@@ -1112,8 +1112,8 @@ class TestSessionPersistence:
     async def test_reports_error_when_no_stored_session_to_retry(
         self, sample_message, mock_tools
     ):
-        """Previously a bare `raise` with zero report: no stored session id
-        means there is nothing to fall back to, so the failure must surface."""
+        """No stored session id means there is nothing to fall back to, so
+        the failure must surface without leaking the raw exception text."""
         adapter = ClaudeSDKAdapter()
         mock_manager = AsyncMock()
         mock_manager.get_or_create_session = AsyncMock(
@@ -1142,14 +1142,15 @@ class TestSessionPersistence:
         mock_tools.send_failure.assert_called_once()
         failure = mock_tools.send_failure.call_args.args[0]
         assert failure.provider == "claude_sdk"
-        assert "Session setup failed" in failure.message
+        assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
+        assert "Session setup failed" not in failure.message
 
     @pytest.mark.asyncio
     async def test_reports_error_when_fallback_session_also_fails(
         self, sample_message, mock_tools
     ):
-        """The fallback session-creation attempt was previously uncaught by
-        this scope entirely -- a failure there escaped with zero report."""
+        """A failure in the fallback session-creation attempt must surface
+        without leaking the raw exception text."""
         adapter = ClaudeSDKAdapter()
         mock_manager = AsyncMock()
         mock_manager.get_or_create_session = AsyncMock(
@@ -1178,7 +1179,8 @@ class TestSessionPersistence:
         mock_tools.send_failure.assert_called_once()
         failure = mock_tools.send_failure.call_args.args[0]
         assert failure.provider == "claude_sdk"
-        assert "Fresh session failed" in failure.message
+        assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
+        assert "Fresh session failed" not in failure.message
 
     @pytest.mark.asyncio
     async def test_task_event_failure_does_not_break_flow(self, mock_tools):

--- a/tests/adapters/test_claude_sdk_adapter.py
+++ b/tests/adapters/test_claude_sdk_adapter.py
@@ -42,6 +42,7 @@ from band.runtime.tools import (
     missing_reply_error,
     mcp_tool_names,
 )
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE
 from band.core.types import Capability, Emit, PlatformMessage, ToolEventKey
 from claude_agent_sdk._errors import CLIConnectionError
 from claude_agent_sdk.types import PermissionResultAllow, ToolPermissionContext
@@ -483,7 +484,7 @@ class TestErrorHandling:
             mock_tools.send_failure.assert_called_once()
             failure = mock_tools.send_failure.call_args.args[0]
             assert failure.provider == "claude_sdk"
-            assert "API Error" in failure.message
+            assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
 
 
 class TestCLIConnectionError:
@@ -564,7 +565,7 @@ class TestCLIConnectionError:
             mock_tools.send_failure.assert_called_once()
             failure = mock_tools.send_failure.call_args.args[0]
             assert failure.provider == "claude_sdk"
-            assert "Process dead" in failure.message
+            assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
 
     @pytest.mark.asyncio
     async def test_clears_session_id_on_cli_connection_error(
@@ -645,7 +646,7 @@ class TestCLIConnectionError:
         assert "room-123" not in adapter._session_ids
         errors = _error_events(mock_tools)
         assert len(errors) == 1
-        assert "ended without a result" in errors[0]
+        assert errors[0] == GENERIC_PROVIDER_FAILURE_MESSAGE
 
 
 class TestRoomToolsStorage:

--- a/tests/adapters/test_claude_sdk_adapter.py
+++ b/tests/adapters/test_claude_sdk_adapter.py
@@ -27,6 +27,7 @@ from band.adapters.claude_sdk import (
     _FORCED_DECLINE,
     PendingApproval,
     _pre_tool_use_continue_hook,
+    TurnResultAlreadyReported,
     BAND_ALL_TOOLS,
     BAND_BASE_TOOLS,
     BAND_MEMORY_TOOLS,
@@ -1242,7 +1243,8 @@ class TestTurnFailureSurfacing:
         )
         mock_client = self._client_yielding(result_msg)
 
-        await adapter._process_response(mock_client, "room-123", mock_tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter._process_response(mock_client, "room-123", mock_tools)
 
         errors = _error_events(mock_tools)
         assert len(errors) == 1
@@ -1265,7 +1267,8 @@ class TestTurnFailureSurfacing:
         )
         mock_client = self._client_yielding(result_msg)
 
-        await adapter._process_response(mock_client, "room-123", mock_tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter._process_response(mock_client, "room-123", mock_tools)
 
         errors = _error_events(mock_tools)
         assert len(errors) == 1
@@ -1281,7 +1284,8 @@ class TestTurnFailureSurfacing:
         result_msg = _result_message(is_error=False)
         mock_client = self._client_yielding(result_msg)
 
-        await adapter._process_response(mock_client, "room-123", mock_tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter._process_response(mock_client, "room-123", mock_tools)
 
         errors = _error_events(mock_tools)
         assert len(errors) == 1
@@ -1350,7 +1354,8 @@ class TestTurnFailureSurfacing:
         )
         mock_client = self._client_yielding(assistant_msg, user_msg, _result_message())
 
-        await adapter._process_response(mock_client, "room-123", mock_tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter._process_response(mock_client, "room-123", mock_tools)
 
         payload = _tool_result_payload(mock_tools)
         assert payload[ToolEventKey.NAME] == "band_send_message"
@@ -1364,7 +1369,8 @@ class TestTurnFailureSurfacing:
         result_msg = _result_message(is_error=False)
         mock_client = self._client_yielding(*turn, result_msg)
 
-        await adapter._process_response(mock_client, "room-123", mock_tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter._process_response(mock_client, "room-123", mock_tools)
 
         errors = _error_events(mock_tools)
         assert len(errors) == 1
@@ -1489,7 +1495,8 @@ class TestTurnFailureSurfacing:
         )
         mock_client = self._client_yielding(assistant_msg, user_msg, result_msg)
 
-        await adapter._process_response(mock_client, "room-123", mock_tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter._process_response(mock_client, "room-123", mock_tools)
 
         errors = _error_events(mock_tools)
         assert len(errors) == 1
@@ -1627,7 +1634,8 @@ class TestTurnFailureSurfacing:
             assistant_msg, failed_result, _result_message(is_error=False)
         )
 
-        await adapter._process_response(mock_client, "room-123", mock_tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter._process_response(mock_client, "room-123", mock_tools)
 
         errors = _error_events(mock_tools)
         assert len(errors) == 1
@@ -1686,7 +1694,8 @@ class TestTurnFailureSurfacing:
         )
         mock_client = self._client_yielding(assistant_msg, user_msg, result_msg)
 
-        await adapter._process_response(mock_client, "room-123", mock_tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter._process_response(mock_client, "room-123", mock_tools)
 
         errors = _error_events(mock_tools)
         assert len(errors) == 1
@@ -1714,7 +1723,8 @@ class TestTurnFailureSurfacing:
 
         # A fresh, unrelated turn: no tool activity, no permission_denials.
         next_turn_client = self._client_yielding(_result_message(is_error=False))
-        await adapter._process_response(next_turn_client, "room-123", mock_tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter._process_response(next_turn_client, "room-123", mock_tools)
 
         errors = _error_events(mock_tools)
         assert len(errors) == 1
@@ -1740,7 +1750,8 @@ class TestTurnFailureSurfacing:
         result_msg = _result_message(is_error=False)
         mock_client = self._client_yielding(result_msg)
 
-        await adapter._process_response(mock_client, "room-123", mock_tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter._process_response(mock_client, "room-123", mock_tools)
 
         errors = _error_events(mock_tools)
         assert len(errors) == 1
@@ -1773,7 +1784,8 @@ class TestTurnFailureSurfacing:
         result_msg = _result_message(is_error=False)
         mock_client = self._client_yielding(result_msg)
 
-        await adapter._process_response(mock_client, "room-123", mock_tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter._process_response(mock_client, "room-123", mock_tools)
 
         errors = _error_events(mock_tools)
         assert len(errors) == 1

--- a/tests/adapters/test_claude_sdk_tool_names.py
+++ b/tests/adapters/test_claude_sdk_tool_names.py
@@ -47,6 +47,7 @@ async def test_tool_call_event_uses_bare_name() -> None:
     )
     tools = MagicMock()
     tools.send_event = AsyncMock(return_value={"status": "sent"})
+    tools.send_failure = AsyncMock(return_value={"status": "sent"})
 
     assistant = AssistantMessage(
         content=[

--- a/tests/adapters/test_claude_sdk_tool_names.py
+++ b/tests/adapters/test_claude_sdk_tool_names.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from claude_agent_sdk import AssistantMessage, ResultMessage, ToolUseBlock
 
-from band.adapters.claude_sdk import ClaudeSDKAdapter
+from band.adapters.claude_sdk import ClaudeSDKAdapter, TurnResultAlreadyReported
 from band.converters.claude_sdk import ClaudeSDKSessionState
 from band.core.types import Emit, PlatformMessage
 
@@ -79,15 +79,16 @@ async def test_tool_call_event_uses_bare_name() -> None:
 
     with patch("band.adapters.claude_sdk.ClaudeSessionManager", return_value=manager):
         await adapter.on_started(agent_name="Bot", agent_description="d")
-        await adapter.on_message(
-            msg=message,
-            tools=tools,
-            history=ClaudeSDKSessionState(text=""),
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-1",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                msg=message,
+                tools=tools,
+                history=ClaudeSDKSessionState(text=""),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
 
     tool_calls = [
         call

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -30,7 +30,7 @@ from band.integrations.codex.types import (
     CodexItemType,
     CodexSessionState,
     CodexTokenUsage,
-    build_structured_error_metadata,
+    build_agent_failure,
     parse_plan_steps,
 )
 from band.runtime.custom_tools import CustomToolDef
@@ -57,6 +57,11 @@ def make_platform_message(
 def events_of_type(tools: FakeAgentTools, message_type: str) -> list[dict[str, Any]]:
     """Events of ``message_type`` captured on ``tools.events_sent``."""
     return [e for e in tools.events_sent if e["message_type"] == message_type]
+
+
+def reported_failures(tools: FakeAgentTools) -> list[dict[str, Any]]:
+    """Every ``AgentFailure`` reported via ``send_failure``, as its wire dict."""
+    return [e["metadata"]["failure"] for e in events_of_type(tools, "error")]
 
 
 class ToolSchemaFakeTools(FakeAgentTools):
@@ -3320,6 +3325,11 @@ class TestHistoryInjection:
         model_list_calls = [m for m, _ in fake_client.requests if m == "model/list"]
         assert len(model_list_calls) == 0
 
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["provider"] == "codex"
+        assert "not available" in failures[0]["message"]
+
     @pytest.mark.asyncio
     async def test_model_selection_uses_default_when_model_list_empty(self) -> None:
         """Auto-selection uses the adapter default when Codex returns no visible models."""
@@ -3581,7 +3591,7 @@ class TestStructuredErrors:
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
-            config=CodexAdapterConfig(transport="ws", structured_errors=True),
+            config=CodexAdapterConfig(transport="ws"),
             client_factory=lambda _config: fake_client,
         )
         tools = ToolSchemaFakeTools()
@@ -3597,13 +3607,12 @@ class TestStructuredErrors:
             room_id="room-1",
         )
 
-        error_events = events_of_type(tools, "error")
-        assert len(error_events) == 1
-        meta = error_events[0]["metadata"]
-        assert meta["codex_error_type"] == "ContextWindowExceeded"
-        assert meta["codex_suggested_action"] == "compact_context"
-        assert meta["codex_is_retryable"] is False
-        assert "context window" in error_events[0]["content"].lower()
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["provider"] == "codex"
+        assert failures[0]["code"] == "ContextWindowExceeded"
+        assert failures[0]["detail"]["codex_is_retryable"] is False
+        assert "context window" in failures[0]["message"].lower()
 
     @pytest.mark.asyncio
     async def test_structured_error_from_failed_turn(self) -> None:
@@ -3629,7 +3638,7 @@ class TestStructuredErrors:
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
-            config=CodexAdapterConfig(transport="ws", structured_errors=True),
+            config=CodexAdapterConfig(transport="ws"),
             client_factory=lambda _config: fake_client,
         )
         tools = ToolSchemaFakeTools()
@@ -3645,51 +3654,9 @@ class TestStructuredErrors:
             room_id="room-1",
         )
 
-        error_events = events_of_type(tools, "error")
-        assert len(error_events) == 1
-        assert error_events[0]["metadata"]["codex_error_type"] == "UsageLimitExceeded"
-        assert (
-            error_events[0]["metadata"]["codex_suggested_action"] == "wait_or_upgrade"
-        )
-
-    @pytest.mark.asyncio
-    async def test_structured_errors_disabled_falls_back_to_plain_text(self) -> None:
-        """When structured_errors=False, errors use plain text format."""
-        events = [
-            _event_notification(
-                "error",
-                {
-                    "error": {
-                        "message": "Something failed",
-                        "codexErrorInfo": {"type": "ContextWindowExceeded"},
-                    },
-                    "willRetry": False,
-                },
-            ),
-            _turn_completed(),
-        ]
-        fake_client = FakeCodexClient(events=events)
-        adapter = CodexAdapter(
-            config=CodexAdapterConfig(transport="ws", structured_errors=False),
-            client_factory=lambda _config: fake_client,
-        )
-        tools = ToolSchemaFakeTools()
-
-        await adapter.on_started("Agent", "A coding agent")
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            CodexSessionState(),
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-1",
-        )
-
-        error_events = events_of_type(tools, "error")
-        assert len(error_events) == 1
-        assert error_events[0]["content"] == "Codex error: Something failed"
-        assert "codex_error_type" not in error_events[0]["metadata"]
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["code"] == "UsageLimitExceeded"
 
 
 # ===========================================================================
@@ -4649,7 +4616,7 @@ class TestDiffsAndTokenUsage:
 
 
 class TestCodexTypes:
-    def test_build_structured_error_metadata_known_type(self) -> None:
+    def test_build_agent_failure_known_type(self) -> None:
 
         error_obj = {
             "message": "Context overflow",
@@ -4659,25 +4626,22 @@ class TestCodexTypes:
                 "retryable": False,
             },
         }
-        content, meta = build_structured_error_metadata(
-            error_obj, thread_id="t1", turn_id="turn-1"
-        )
-        assert "context window" in content.lower()
-        assert meta["codex_error_type"] == "ContextWindowExceeded"
-        assert meta["codex_suggested_action"] == "compact_context"
-        assert meta["codex_thread_id"] == "t1"
-        assert meta["codex_turn_id"] == "turn-1"
+        failure = build_agent_failure(error_obj, thread_id="t1", turn_id="turn-1")
+        assert failure.provider == "codex"
+        assert "context overflow" in failure.message.lower()
+        assert failure.code == "ContextWindowExceeded"
+        assert failure.detail["codex_thread_id"] == "t1"
+        assert failure.detail["codex_turn_id"] == "turn-1"
 
-    def test_build_structured_error_metadata_unknown_type(self) -> None:
+    def test_build_agent_failure_unknown_type(self) -> None:
 
         error_obj = {
             "message": "Something weird happened",
             "codexErrorInfo": {"type": "UnknownError"},
         }
-        content, meta = build_structured_error_metadata(error_obj)
-        assert content == "Something weird happened"
-        assert meta["codex_error_type"] == "UnknownError"
-        assert meta["codex_suggested_action"] is None
+        failure = build_agent_failure(error_obj)
+        assert failure.message == "Something weird happened"
+        assert failure.code == "UnknownError"
 
     def test_parse_plan_steps(self) -> None:
 
@@ -4758,9 +4722,8 @@ class TestCodexTypes:
         assert usage.total_tokens == 14822
 
     def test_config_new_flags_default_false(self) -> None:
-        """All new config flags default to False (except structured_errors=True)."""
+        """All new config flags default to False."""
         config = CodexAdapterConfig()
-        assert config.structured_errors is True
         assert config.stream_reasoning_events is False
         assert config.stream_plan_events is False
         assert config.stream_commentary_events is False
@@ -5720,7 +5683,7 @@ class TestTokenUsageEmission:
 
 
 class TestStructuredErrorNormalization:
-    """build_structured_error_metadata handling of non-standard inputs."""
+    """build_agent_failure handling of non-standard inputs."""
 
     def test_structured_error_with_string_error_obj(self) -> None:
         """_handle_error_event normalizes string error_obj before structuring.
@@ -5731,12 +5694,12 @@ class TestStructuredErrorNormalization:
         """
 
         # Simulate the normalization the adapter performs: convert string to
-        # {"message": <str>} before passing to build_structured_error_metadata.
+        # {"message": <str>} before passing to build_agent_failure.
         error_obj: dict[str, Any] = {"message": "raw string error"}
-        content, meta = build_structured_error_metadata(error_obj)
-        assert "raw string error" in content
+        failure = build_agent_failure(error_obj)
+        assert "raw string error" in failure.message
         # No codexErrorInfo -> no known error type.
-        assert meta["codex_error_type"] is None
+        assert failure.code is None
 
 
 class TestSessionApprovalKeying:
@@ -5885,58 +5848,50 @@ class TestApprovalAuditRecording:
 
 
 class TestStructuredErrorMappings:
-    """Cover every entry in CODEX_ERROR_REMEDIATION plus the fallback path."""
+    """build_agent_failure passes codexErrorInfo through verbatim -- no
+    remediation/suggested-action policy; that belongs to a consumer, not
+    this shared shape."""
 
     @pytest.mark.parametrize(
-        ("error_type", "expected_action", "expected_phrase"),
+        "error_type",
         [
-            ("HttpConnectionFailed", "check_connectivity", "http connection"),
-            ("SandboxError", "review_sandbox_policy", "sandbox"),
-            ("Unauthorized", "re_authenticate", "unauthorized"),
-            ("BadRequest", "check_input_format", "bad request"),
-            (
-                "ResponseTooManyFailedAttempts",
-                "retry_different_approach",
-                "failed attempts",
-            ),
+            "HttpConnectionFailed",
+            "SandboxError",
+            "Unauthorized",
+            "BadRequest",
+            "ResponseTooManyFailedAttempts",
         ],
     )
-    def test_known_error_type_maps_to_remediation(
-        self, error_type: str, expected_action: str, expected_phrase: str
-    ) -> None:
-
-        content, meta = build_structured_error_metadata(
+    def test_error_type_becomes_the_failure_code(self, error_type: str) -> None:
+        failure = build_agent_failure(
             {"codexErrorInfo": {"type": error_type, "retryable": True}}
         )
-        assert meta["codex_error_type"] == error_type
-        assert meta["codex_suggested_action"] == expected_action
-        assert meta["codex_is_retryable"] is True
-        assert expected_phrase in content.lower()
+        assert failure.code == error_type
+        assert failure.detail["codex_is_retryable"] is True
 
     def test_non_dict_codex_error_info_is_tolerated(self) -> None:
 
-        content, meta = build_structured_error_metadata(
+        failure = build_agent_failure(
             {"message": "boom", "codexErrorInfo": "not-a-dict"}
         )
-        assert meta["codex_error_type"] is None
-        assert content == "boom"
+        assert failure.code is None
+        assert failure.message == "boom"
 
     def test_missing_codex_error_info_falls_back_to_message(self) -> None:
 
-        content, meta = build_structured_error_metadata({"message": "network down"})
-        assert meta["codex_error_type"] is None
-        assert meta["codex_suggested_action"] is None
-        assert content == "network down"
+        failure = build_agent_failure({"message": "network down"})
+        assert failure.code is None
+        assert failure.message == "network down"
 
-    def test_additional_details_preserved_in_metadata(self) -> None:
+    def test_additional_details_preserved_in_detail(self) -> None:
 
-        _, meta = build_structured_error_metadata(
+        failure = build_agent_failure(
             {
                 "codexErrorInfo": {"type": "Unauthorized"},
                 "additionalDetails": {"hint": "refresh token"},
             }
         )
-        assert meta["codex_additional_details"] == {"hint": "refresh token"}
+        assert failure.detail["codex_additional_details"] == {"hint": "refresh token"}
 
 
 class TestSlashCommandCoverage:
@@ -6050,6 +6005,45 @@ class TestSlashCommandCoverage:
         assert len(perm_msgs) == 1
         assert "read-only" in perm_msgs[0]["content"]
 
+    @pytest.mark.asyncio
+    async def test_local_command_reply_delivery_failure_is_not_reported(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """/help's answer failing to post is Band-side delivery, not a Codex
+        provider failure -- deliver_reply's DeliveryFailedError must be
+        recognized and left unreported here."""
+
+        class FailingSendMessageTools(ToolSchemaFakeTools):
+            async def send_message(
+                self, content: str, mentions: list[dict[str, str]] | None = None
+            ) -> Any:
+                raise RuntimeError("platform rejected the message")
+
+        fake_client = FakeCodexClient()
+        adapter = CodexAdapter(
+            config=CodexAdapterConfig(transport="ws"),
+            client_factory=lambda _config: fake_client,
+        )
+        tools = FailingSendMessageTools()
+
+        await adapter.on_started("Agent", "A coding agent")
+        with caplog.at_level(logging.ERROR, logger="band.adapters.codex"):
+            await adapter.on_message(
+                make_platform_message(content="/help"),
+                tools,
+                CodexSessionState(),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
+
+        assert not tools.messages_sent
+        assert not reported_failures(tools)
+        assert any(
+            "Codex reply delivery failed" in record.message for record in caplog.records
+        )
+
 
 class TestMalformedPayloadTolerance:
     """Adapter must survive notifications that are missing or misshapen."""
@@ -6063,7 +6057,7 @@ class TestMalformedPayloadTolerance:
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
-            config=CodexAdapterConfig(transport="ws", structured_errors=True),
+            config=CodexAdapterConfig(transport="ws"),
             client_factory=lambda _config: fake_client,
         )
         tools = ToolSchemaFakeTools()
@@ -6078,6 +6072,10 @@ class TestMalformedPayloadTolerance:
             is_session_bootstrap=True,
             room_id="room-1",
         )
+
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["message"] == "oops"
 
     @pytest.mark.asyncio
     async def test_turn_completed_without_items_key(self) -> None:
@@ -6256,13 +6254,13 @@ class TestStructuredErrorDetailCap:
     def test_long_additional_details_string_is_truncated(self) -> None:
 
         long_detail = "x" * (_MAX_ERROR_DETAIL_CHARS + 500)
-        _, meta = build_structured_error_metadata(
+        failure = build_agent_failure(
             {
                 "codexErrorInfo": {"type": "Unauthorized"},
                 "additionalDetails": long_detail,
             }
         )
-        detail = meta["codex_additional_details"]
+        detail = failure.detail["codex_additional_details"]
         assert isinstance(detail, str)
         assert len(detail) < len(long_detail)
         assert "truncated" in detail
@@ -6271,24 +6269,24 @@ class TestStructuredErrorDetailCap:
         """Only string details are capped; dict/list payloads pass through."""
 
         payload = {"hint": "refresh token", "code": 401}
-        _, meta = build_structured_error_metadata(
+        failure = build_agent_failure(
             {
                 "codexErrorInfo": {"type": "Unauthorized"},
                 "additionalDetails": payload,
             }
         )
-        assert meta["codex_additional_details"] == payload
+        assert failure.detail["codex_additional_details"] == payload
 
     def test_empty_additional_details_is_dropped(self) -> None:
-        """Empty strings are not echoed into metadata."""
+        """Empty strings are not echoed into detail."""
 
-        _, meta = build_structured_error_metadata(
+        failure = build_agent_failure(
             {
                 "codexErrorInfo": {"type": "Unauthorized"},
                 "additionalDetails": "",
             }
         )
-        assert "codex_additional_details" not in meta
+        assert failure.detail is None
 
     def test_oversized_dict_additional_details_is_replaced_with_marker(
         self,
@@ -6305,13 +6303,13 @@ class TestStructuredErrorDetailCap:
         oversized_value = "x" * (_MAX_ERROR_DETAIL_CHARS + 500)
         payload = {"nested": {"blob": oversized_value}}
 
-        _, meta = build_structured_error_metadata(
+        failure = build_agent_failure(
             {
                 "codexErrorInfo": {"type": "Unauthorized"},
                 "additionalDetails": payload,
             }
         )
-        detail = meta["codex_additional_details"]
+        detail = failure.detail["codex_additional_details"]
         assert isinstance(detail, str)
         assert "truncated" in detail
         assert len(detail) < len(oversized_value)
@@ -6325,13 +6323,13 @@ class TestStructuredErrorDetailCap:
         circular: dict[str, Any] = {}
         circular["self"] = circular
 
-        _, meta = build_structured_error_metadata(
+        failure = build_agent_failure(
             {
                 "codexErrorInfo": {"type": "Unauthorized"},
                 "additionalDetails": circular,
             }
         )
-        assert "codex_additional_details" not in meta
+        assert failure.detail is None
 
 
 class TestDiffByteCap:

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -6011,7 +6011,10 @@ class TestSlashCommandCoverage:
     ) -> None:
         """/help's answer failing to post is Band-side delivery, not a Codex
         provider failure -- deliver_reply's DeliveryFailedError must be
-        recognized and left unreported here."""
+        recognized and left unreported here. codex.py's on_message had no
+        try/except at all before this PR, so the original cause must still
+        propagate (the message still fails/retries at the platform level),
+        just never misreported as a Codex AgentFailure."""
 
         class FailingSendMessageTools(ToolSchemaFakeTools):
             async def send_message(
@@ -6027,7 +6030,10 @@ class TestSlashCommandCoverage:
         tools = FailingSendMessageTools()
 
         await adapter.on_started("Agent", "A coding agent")
-        with caplog.at_level(logging.ERROR, logger="band.adapters.codex"):
+        with (
+            caplog.at_level(logging.ERROR, logger="band.adapters.codex"),
+            pytest.raises(RuntimeError, match="platform rejected the message"),
+        ):
             await adapter.on_message(
                 make_platform_message(content="/help"),
                 tools,

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -35,7 +35,7 @@ from band.integrations.codex.types import (
 )
 from band.runtime.custom_tools import CustomToolDef
 from band.runtime.tools import ToolCallOutcome
-from band.testing import FakeAgentTools, reported_failures
+from band.testing import FakeAgentTools, events_of_type, reported_failures
 
 
 def make_platform_message(
@@ -52,11 +52,6 @@ def make_platform_message(
         metadata={},
         created_at=datetime.now(),
     )
-
-
-def events_of_type(tools: FakeAgentTools, message_type: str) -> list[dict[str, Any]]:
-    """Events of ``message_type`` captured on ``tools.events_sent``."""
-    return [e for e in tools.events_sent if e["message_type"] == message_type]
 
 
 class ToolSchemaFakeTools(FakeAgentTools):
@@ -1559,6 +1554,13 @@ class TestCodexAdapter:
 
         # Adapter should send a user-facing message about stopping.
         assert any("stopped" in msg["content"].lower() for msg in tools.messages_sent)
+
+        # A timed-out turn is a reportable Codex failure, same as every
+        # sibling adapter's own turn-timeout handling.
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["provider"] == "codex"
+        assert failures[0]["code"] == "timeout"
 
     @pytest.mark.asyncio
     async def test_item_completed_text_overrides_accumulated_deltas(self) -> None:
@@ -6045,6 +6047,48 @@ class TestSlashCommandCoverage:
             "Codex reply delivery failed" in record.message for record in caplog.records
         )
 
+    @pytest.mark.asyncio
+    async def test_approval_command_reply_delivery_failure_is_not_reported(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Same delivery-vs-provider-failure split as slash commands, but for
+        the approval-command path, which runs outside on_message's main
+        try/except and needs its own DeliveryFailedError handling."""
+
+        class FailingSendMessageTools(ToolSchemaFakeTools):
+            async def send_message(
+                self, content: str, mentions: list[dict[str, str]] | None = None
+            ) -> Any:
+                raise RuntimeError("platform rejected the message")
+
+        fake_client = FakeCodexClient()
+        adapter = CodexAdapter(
+            config=CodexAdapterConfig(transport="ws"),
+            client_factory=lambda _config: fake_client,
+        )
+        tools = FailingSendMessageTools()
+
+        await adapter.on_started("Agent", "A coding agent")
+        with (
+            caplog.at_level(logging.ERROR, logger="band.adapters.codex"),
+            pytest.raises(RuntimeError, match="platform rejected the message"),
+        ):
+            await adapter.on_message(
+                make_platform_message(content="/approvals"),
+                tools,
+                CodexSessionState(),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
+
+        assert not tools.messages_sent
+        assert not reported_failures(tools)
+        assert any(
+            "Codex reply delivery failed" in record.message for record in caplog.records
+        )
+
 
 class TestMalformedPayloadTolerance:
     """Adapter must survive notifications that are missing or misshapen."""
@@ -6077,6 +6121,85 @@ class TestMalformedPayloadTolerance:
         failures = reported_failures(tools)
         assert len(failures) == 1
         assert failures[0]["message"] == "oops"
+
+    @pytest.mark.asyncio
+    async def test_failed_turn_after_error_notification_reports_once(self) -> None:
+        """An `error` notification followed by a `turn/completed` with
+        status=failed for the same incident must report only one failure."""
+        events = [
+            _event_notification("error", {"error": {"message": "boom"}}),
+            _event_notification(
+                "turn/completed",
+                {
+                    "turn": {
+                        "id": "turn-1",
+                        "status": "failed",
+                        "items": [],
+                        "error": {"message": "boom"},
+                    }
+                },
+            ),
+        ]
+        fake_client = FakeCodexClient(events=events)
+        adapter = CodexAdapter(
+            config=CodexAdapterConfig(transport="ws"),
+            client_factory=lambda _config: fake_client,
+        )
+        tools = ToolSchemaFakeTools()
+        await adapter.on_started("Agent", "A coding agent")
+
+        await adapter.on_message(
+            make_platform_message(),
+            tools,
+            CodexSessionState(),
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-1",
+        )
+
+        assert len(reported_failures(tools)) == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_turn_with_falsy_scalar_error_uses_clean_fallback(
+        self,
+    ) -> None:
+        """A falsy, non-dict `error` (e.g. ``False``) must not become the
+        literal string "False" in the reported failure message."""
+        events = [
+            _event_notification(
+                "turn/completed",
+                {
+                    "turn": {
+                        "id": "turn-1",
+                        "status": "failed",
+                        "items": [],
+                        "error": False,
+                    }
+                },
+            ),
+        ]
+        fake_client = FakeCodexClient(events=events)
+        adapter = CodexAdapter(
+            config=CodexAdapterConfig(transport="ws"),
+            client_factory=lambda _config: fake_client,
+        )
+        tools = ToolSchemaFakeTools()
+        await adapter.on_started("Agent", "A coding agent")
+
+        await adapter.on_message(
+            make_platform_message(),
+            tools,
+            CodexSessionState(),
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-1",
+        )
+
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["message"] == "Codex error: unknown"
 
     @pytest.mark.asyncio
     async def test_turn_completed_without_items_key(self) -> None:

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -23,6 +23,7 @@ from band.adapters.codex import (
     CodexAdapterConfig,
     PendingApproval,
 )
+from band.core.protocols import TurnResultAlreadyReported
 from band.core.types import AgentInput, Emit, HistoryProvider, PlatformMessage
 from band.integrations.codex import CodexJsonRpcError, RpcEvent
 from band.integrations.codex.types import (
@@ -982,20 +983,7 @@ class TestCodexAdapter:
 
     @pytest.mark.asyncio
     async def test_reasoning_effort_passed_in_turn_overrides(self) -> None:
-        events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "t1",
-                        "threadId": "th1",
-                        "status": "completed",
-                    },
-                    "text": "Done",
-                },
-            ),
-        ]
-        fake_client = FakeCodexClient(events=events)
+        fake_client = FakeCodexClient(events=[_turn_completed()])
         adapter = CodexAdapter(
             config=CodexAdapterConfig(
                 transport="ws",
@@ -1023,20 +1011,7 @@ class TestCodexAdapter:
 
     @pytest.mark.asyncio
     async def test_reasoning_effort_omitted_when_none(self) -> None:
-        events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "t1",
-                        "threadId": "th1",
-                        "status": "completed",
-                    },
-                    "text": "Done",
-                },
-            ),
-        ]
-        fake_client = FakeCodexClient(events=events)
+        fake_client = FakeCodexClient(events=[_turn_completed()])
         adapter = CodexAdapter(
             config=CodexAdapterConfig(transport="ws"),
             client_factory=lambda _config: fake_client,
@@ -1104,20 +1079,7 @@ class TestCodexAdapter:
 
     @pytest.mark.asyncio
     async def test_self_config_tools_registered_when_enabled(self) -> None:
-        events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "t1",
-                        "threadId": "th1",
-                        "status": "completed",
-                    },
-                    "text": "Done",
-                },
-            ),
-        ]
-        fake_client = FakeCodexClient(events=events)
+        fake_client = FakeCodexClient(events=[_turn_completed()])
         adapter = CodexAdapter(
             config=CodexAdapterConfig(transport="ws", enable_self_config_tools=True),
             client_factory=lambda _config: fake_client,
@@ -1145,20 +1107,7 @@ class TestCodexAdapter:
 
     @pytest.mark.asyncio
     async def test_self_config_tools_not_registered_when_disabled(self) -> None:
-        events = [
-            _event_notification(
-                "turn/completed",
-                {
-                    "turn": {
-                        "id": "t1",
-                        "threadId": "th1",
-                        "status": "completed",
-                    },
-                    "text": "Done",
-                },
-            ),
-        ]
-        fake_client = FakeCodexClient(events=events)
+        fake_client = FakeCodexClient(events=[_turn_completed()])
         adapter = CodexAdapter(
             config=CodexAdapterConfig(transport="ws", enable_self_config_tools=False),
             client_factory=lambda _config: fake_client,
@@ -1393,20 +1342,20 @@ class TestCodexAdapter:
         tools = ToolSchemaFakeTools()
 
         await adapter.on_started("Codex Agent", "A coding agent")
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            CodexSessionState(),
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-1",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                CodexSessionState(),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
 
-        # Adapter should send a failure message mentioning the disconnect.
-        assert any(
-            "transport closed" in msg["content"].lower() for msg in tools.messages_sent
-        )
+        # Adapter should report a failure mentioning the disconnect.
+        failures = reported_failures(tools)
+        assert any("transport closed" in f["message"].lower() for f in failures)
 
     @pytest.mark.asyncio
     async def test_transport_closed_resets_client_state(self) -> None:
@@ -1426,15 +1375,16 @@ class TestCodexAdapter:
         tools = ToolSchemaFakeTools()
 
         await adapter.on_started("Codex Agent", "A coding agent")
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            CodexSessionState(),
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-1",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                CodexSessionState(),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
 
         # After transport/closed, client state should be reset
         assert adapter._client is None
@@ -1464,15 +1414,16 @@ class TestCodexAdapter:
         adapter._room_threads["room-1"] = "old-thread-id"
         adapter._raw_history_by_room["room-1"] = [{"role": "user", "content": "hi"}]
 
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            CodexSessionState(),
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=False,
-            room_id="room-1",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                CodexSessionState(),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=False,
+                room_id="room-1",
+            )
 
         # Per-room state should be cleared so next turn starts fresh.
         assert "room-1" not in adapter._room_threads
@@ -1508,15 +1459,16 @@ class TestCodexAdapter:
             input_tokens=100, total_tokens=150
         )
 
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            CodexSessionState(),
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=False,
-            room_id="room-1",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                CodexSessionState(),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=False,
+                room_id="room-1",
+            )
 
         # Dead thread's usage entry must be gone even without a matching
         # on_cleanup (the room id can no longer look up the thread id).
@@ -1524,7 +1476,9 @@ class TestCodexAdapter:
 
     @pytest.mark.asyncio
     async def test_turn_timeout_sends_interrupt_and_clean_error(self) -> None:
-        """When recv_event times out, the adapter sends turn/interrupt and reports cleanly."""
+        """When recv_event times out, the adapter sends turn/interrupt, reports
+        the failure, and fails the turn so the platform retries -- same as
+        every sibling adapter's own turn-timeout handling."""
         # No events means FakeCodexClient raises asyncio.TimeoutError immediately.
         fake_client = FakeCodexClient(events=[])
         adapter = CodexAdapter(
@@ -1534,15 +1488,16 @@ class TestCodexAdapter:
         tools = ToolSchemaFakeTools()
 
         await adapter.on_started("Codex Agent", "A coding agent")
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            CodexSessionState(),
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-1",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                CodexSessionState(),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
 
         # Adapter should have sent turn/interrupt with both identifiers.
         interrupt_requests = [
@@ -1552,11 +1507,10 @@ class TestCodexAdapter:
             ("turn/interrupt", {"threadId": "thr-1", "turnId": "turn-1"})
         ]
 
-        # Adapter should send a user-facing message about stopping.
-        assert any("stopped" in msg["content"].lower() for msg in tools.messages_sent)
+        # The turn fails the platform's turn, so no separate "I stopped..."
+        # chat reply goes out alongside the structured failure event.
+        assert not tools.messages_sent
 
-        # A timed-out turn is a reportable Codex failure, same as every
-        # sibling adapter's own turn-timeout handling.
         failures = reported_failures(tools)
         assert len(failures) == 1
         assert failures[0]["provider"] == "codex"
@@ -3447,15 +3401,16 @@ class TestHistoryInjection:
         await adapter.on_started("Agent", "An agent")
 
         msg = make_platform_message(room_id="room-1", content="do something")
-        await adapter.on_message(
-            msg,
-            tools,
-            CodexSessionState(),
-            None,
-            None,
-            is_session_bootstrap=False,
-            room_id="room-1",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                msg,
+                tools,
+                CodexSessionState(),
+                None,
+                None,
+                is_session_bootstrap=False,
+                room_id="room-1",
+            )
 
         error_events = events_of_type(tools, "error")
         assert len(error_events) == 1
@@ -3641,15 +3596,16 @@ class TestStructuredErrors:
         tools = ToolSchemaFakeTools()
 
         await adapter.on_started("Agent", "A coding agent")
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            CodexSessionState(),
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-1",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                CodexSessionState(),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
 
         failures = reported_failures(tools)
         assert len(failures) == 1
@@ -5749,6 +5705,7 @@ class TestSessionApprovalKeying:
                 "item/fileChange/requestApproval",
                 {"reason": "write something"},
             ),
+            _turn_completed(),
         ]
         fake_client = FakeCodexClient(events=events)
         adapter = CodexAdapter(
@@ -6028,7 +5985,7 @@ class TestSlashCommandCoverage:
 
         await adapter.on_started("Agent", "A coding agent")
         with (
-            caplog.at_level(logging.ERROR, logger="band.adapters.codex"),
+            caplog.at_level(logging.ERROR, logger="band.core.delivery"),
             pytest.raises(RuntimeError, match="platform rejected the message"),
         ):
             await adapter.on_message(
@@ -6044,7 +6001,7 @@ class TestSlashCommandCoverage:
         assert not tools.messages_sent
         assert not reported_failures(tools)
         assert any(
-            "Codex reply delivery failed" in record.message for record in caplog.records
+            "Reply delivery failed" in record.message for record in caplog.records
         )
 
     @pytest.mark.asyncio
@@ -6070,7 +6027,7 @@ class TestSlashCommandCoverage:
 
         await adapter.on_started("Agent", "A coding agent")
         with (
-            caplog.at_level(logging.ERROR, logger="band.adapters.codex"),
+            caplog.at_level(logging.ERROR, logger="band.core.delivery"),
             pytest.raises(RuntimeError, match="platform rejected the message"),
         ):
             await adapter.on_message(
@@ -6086,7 +6043,7 @@ class TestSlashCommandCoverage:
         assert not tools.messages_sent
         assert not reported_failures(tools)
         assert any(
-            "Codex reply delivery failed" in record.message for record in caplog.records
+            "Reply delivery failed" in record.message for record in caplog.records
         )
 
 
@@ -6148,15 +6105,16 @@ class TestMalformedPayloadTolerance:
         tools = ToolSchemaFakeTools()
         await adapter.on_started("Agent", "A coding agent")
 
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            CodexSessionState(),
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-1",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                CodexSessionState(),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
 
         assert len(reported_failures(tools)) == 1
 
@@ -6187,15 +6145,16 @@ class TestMalformedPayloadTolerance:
         tools = ToolSchemaFakeTools()
         await adapter.on_started("Agent", "A coding agent")
 
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            CodexSessionState(),
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-1",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                CodexSessionState(),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
 
         failures = reported_failures(tools)
         assert len(failures) == 1

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -35,7 +35,7 @@ from band.integrations.codex.types import (
 )
 from band.runtime.custom_tools import CustomToolDef
 from band.runtime.tools import ToolCallOutcome
-from band.testing import FakeAgentTools
+from band.testing import FakeAgentTools, reported_failures
 
 
 def make_platform_message(
@@ -57,11 +57,6 @@ def make_platform_message(
 def events_of_type(tools: FakeAgentTools, message_type: str) -> list[dict[str, Any]]:
     """Events of ``message_type`` captured on ``tools.events_sent``."""
     return [e for e in tools.events_sent if e["message_type"] == message_type]
-
-
-def reported_failures(tools: FakeAgentTools) -> list[dict[str, Any]]:
-    """Every ``AgentFailure`` reported via ``send_failure``, as its wire dict."""
-    return [e["metadata"]["failure"] for e in events_of_type(tools, "error")]
 
 
 class ToolSchemaFakeTools(FakeAgentTools):

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -23,7 +23,10 @@ from band.adapters.codex import (
     CodexAdapterConfig,
     PendingApproval,
 )
-from band.core.protocols import TurnResultAlreadyReported
+from band.core.protocols import (
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    TurnResultAlreadyReported,
+)
 from band.core.types import AgentInput, Emit, HistoryProvider, PlatformMessage
 from band.integrations.codex import CodexJsonRpcError, RpcEvent
 from band.integrations.codex.types import (
@@ -3611,6 +3614,73 @@ class TestStructuredErrors:
         assert len(failures) == 1
         assert failures[0]["code"] == "UsageLimitExceeded"
 
+    @pytest.mark.asyncio
+    async def test_structured_error_from_failed_turn_with_no_error_key(self) -> None:
+        """turn/completed with status=failed but no "error" key at all must
+        still report a failure before raising, not just claim it did."""
+        events = [
+            _event_notification(
+                "turn/completed",
+                {"turn": {"id": "turn-1", "status": "failed", "items": []}},
+            ),
+        ]
+        fake_client = FakeCodexClient(events=events)
+        adapter = CodexAdapter(
+            config=CodexAdapterConfig(transport="ws"),
+            client_factory=lambda _config: fake_client,
+        )
+        tools = ToolSchemaFakeTools()
+
+        await adapter.on_started("Agent", "A coding agent")
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                CodexSessionState(),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
+
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["provider"] == "codex"
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_reports_and_propagates(self) -> None:
+        """A bare exception outside Codex's structured-error paths (not a
+        CodexJsonRpcError, not a delivery/already-reported failure) must
+        still surface via the generic fallback and propagate."""
+        fake_client = FakeCodexClient(
+            events=[],
+            turn_start_error=RuntimeError("transport hiccup"),
+            turn_start_error_once=False,
+        )
+        adapter = CodexAdapter(
+            config=CodexAdapterConfig(transport="ws"),
+            client_factory=lambda _config: fake_client,
+        )
+        tools = ToolSchemaFakeTools()
+
+        await adapter.on_started("Agent", "A coding agent")
+        with pytest.raises(RuntimeError, match="transport hiccup"):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                CodexSessionState(),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
+
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["provider"] == "codex"
+        assert failures[0]["message"] == GENERIC_PROVIDER_FAILURE_MESSAGE
+        assert "transport hiccup" not in failures[0]["message"]
+
 
 # ===========================================================================
 # Phase 1: Enriched approvals & session-level acceptance
@@ -5965,9 +6035,8 @@ class TestSlashCommandCoverage:
     ) -> None:
         """/help's answer failing to post is Band-side delivery, not a Codex
         provider failure -- deliver_reply's DeliveryFailedError must be
-        recognized and left unreported here. codex.py's on_message had no
-        try/except at all before this PR, so the original cause must still
-        propagate (the message still fails/retries at the platform level),
+        recognized and left unreported here. The original cause still
+        propagates (the message still fails/retries at the platform level),
         just never misreported as a Codex AgentFailure."""
 
         class FailingSendMessageTools(ToolSchemaFakeTools):

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -95,6 +95,7 @@ def mock_tools():
     tools.get_openai_tool_schemas = MagicMock(return_value=[])
     tools.send_message = AsyncMock(return_value={"status": "sent"})
     tools.send_event = AsyncMock(return_value={"status": "sent"})
+    tools.send_failure = AsyncMock(return_value={"status": "sent"})
     tools.execute_tool_call = AsyncMock(return_value={"status": "success"})
     tools.add_participant = AsyncMock(
         return_value={"id": "123", "name": "Test", "status": "added"}

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -19,11 +19,15 @@ import warnings
 import json
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import DEFAULT, AsyncMock, MagicMock
 
 import pytest
 from pydantic import BaseModel, Field
 
+from band.core.protocols import (
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    TurnResultAlreadyReported,
+)
 from band.core.types import Capability, Emit, PlatformMessage
 from band.runtime.prompts import render_system_prompt
 
@@ -172,6 +176,24 @@ def mock_crewai_agent():
 
 
 @pytest.fixture
+def mock_crewai_agent_replied(mock_crewai_agent):
+    """``mock_crewai_agent`` whose ``kickoff_async`` also marks the turn as
+    replied, for tests that only care about kickoff/history/message
+    plumbing rather than the reply-tracking behavior itself (which has its
+    own dedicated tests under ``TestErrorHandling``)."""
+    module = importlib.import_module("band.adapters.crewai")
+
+    def _mark_replied(*args, **kwargs):
+        tracker = module._reply_tracker_var.get()
+        if tracker is not None:
+            tracker.replied = True
+        return DEFAULT
+
+    mock_crewai_agent.kickoff_async.side_effect = _mark_replied
+    return mock_crewai_agent
+
+
+@pytest.fixture
 def room_context(crewai_mocks, mock_tools):
     """Context manager fixture for setting up room context in tests.
 
@@ -304,11 +326,11 @@ class TestOnStarted:
 class TestOnMessage:
     @pytest.mark.asyncio
     async def test_initializes_history_on_bootstrap(
-        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
+        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent_replied
     ):
         adapter = CrewAIAdapter()
         await adapter.on_started("TestBot", "Test bot")
-        adapter._crewai_agent = mock_crewai_agent
+        adapter._crewai_agent = mock_crewai_agent_replied
 
         await adapter.on_message(
             msg=sample_message,
@@ -324,11 +346,11 @@ class TestOnMessage:
 
     @pytest.mark.asyncio
     async def test_loads_existing_history(
-        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
+        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent_replied
     ):
         adapter = CrewAIAdapter()
         await adapter.on_started("TestBot", "Test bot")
-        adapter._crewai_agent = mock_crewai_agent
+        adapter._crewai_agent = mock_crewai_agent_replied
 
         existing_history = [
             {"role": "user", "content": "[Bob]: Previous message"},
@@ -349,11 +371,11 @@ class TestOnMessage:
 
     @pytest.mark.asyncio
     async def test_calls_kickoff_async(
-        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
+        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent_replied
     ):
         adapter = CrewAIAdapter()
         await adapter.on_started("TestBot", "Test bot")
-        adapter._crewai_agent = mock_crewai_agent
+        adapter._crewai_agent = mock_crewai_agent_replied
 
         await adapter.on_message(
             msg=sample_message,
@@ -365,11 +387,11 @@ class TestOnMessage:
             room_id="room-123",
         )
 
-        mock_crewai_agent.kickoff_async.assert_called_once()
+        mock_crewai_agent_replied.kickoff_async.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_replays_history_on_followup_turn(
-        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
+        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent_replied
     ):
         """A non-bootstrap turn must replay accumulated in-session history.
 
@@ -381,7 +403,7 @@ class TestOnMessage:
         """
         adapter = CrewAIAdapter()
         await adapter.on_started("TestBot", "Test bot")
-        adapter._crewai_agent = mock_crewai_agent
+        adapter._crewai_agent = mock_crewai_agent_replied
 
         # Turn 1 (bootstrap): states something the agent must recall later.
         await adapter.on_message(
@@ -418,7 +440,9 @@ class TestOnMessage:
 
         # The second kickoff must carry the prior turn as replayed context, not
         # just the current message.
-        second_call_messages = mock_crewai_agent.kickoff_async.call_args_list[1][0][0]
+        second_call_messages = mock_crewai_agent_replied.kickoff_async.call_args_list[
+            1
+        ][0][0]
         blob = "\n".join(m["content"] for m in second_call_messages)
         assert "[Previous conversation:]" in blob
         assert "Hello, agent!" in blob  # turn-1 content replayed to the model
@@ -463,7 +487,7 @@ class TestErrorHandling:
         mock_tools.send_failure.assert_awaited_once()
         failure = mock_tools.send_failure.call_args.args[0]
         assert failure.provider == "crewai"
-        assert failure.message == "Agent Error"
+        assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
 
     @pytest.mark.asyncio
     async def test_reports_error_when_crewai_completes_without_reply(
@@ -478,15 +502,16 @@ class TestErrorHandling:
         await adapter.on_started("TestBot", "Test bot")
         adapter._crewai_agent = mock_crewai_agent
 
-        await adapter.on_message(
-            msg=sample_message,
-            tools=mock_tools,
-            history=[],
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-123",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                msg=sample_message,
+                tools=mock_tools,
+                history=[],
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-123",
+            )
 
         mock_tools.send_failure.assert_awaited_once()
         failure = mock_tools.send_failure.call_args.args[0]
@@ -505,15 +530,16 @@ class TestErrorHandling:
         await adapter.on_started("TestBot", "Test bot")
         adapter._crewai_agent = mock_crewai_agent
 
-        await adapter.on_message(
-            msg=sample_message,
-            tools=mock_tools,
-            history=[],
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-123",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                msg=sample_message,
+                tools=mock_tools,
+                history=[],
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-123",
+            )
 
         mock_tools.send_failure.assert_awaited_once()
         failure = mock_tools.send_failure.call_args.args[0]
@@ -692,7 +718,7 @@ class TestErrorHandling:
         mock_tools.send_failure.assert_awaited_once()
         failure = mock_tools.send_failure.call_args.args[0]
         assert failure.provider == "crewai"
-        assert failure.message == str(error)
+        assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
 
     @pytest.mark.asyncio
     async def test_raises_error_when_agent_not_initialized(
@@ -794,11 +820,11 @@ class TestAllowDelegation:
 class TestParticipantsUpdate:
     @pytest.mark.asyncio
     async def test_includes_participants_update_in_message(
-        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
+        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent_replied
     ):
         adapter = CrewAIAdapter()
         await adapter.on_started("TestBot", "Test bot")
-        adapter._crewai_agent = mock_crewai_agent
+        adapter._crewai_agent = mock_crewai_agent_replied
 
         await adapter.on_message(
             msg=sample_message,
@@ -810,7 +836,7 @@ class TestParticipantsUpdate:
             room_id="room-123",
         )
 
-        call_args = mock_crewai_agent.kickoff_async.call_args
+        call_args = mock_crewai_agent_replied.kickoff_async.call_args
         messages = call_args[0][0]
 
         found = any("Alice joined" in str(m.get("content", "")) for m in messages)
@@ -820,11 +846,11 @@ class TestParticipantsUpdate:
 class TestContactsUpdate:
     @pytest.mark.asyncio
     async def test_includes_contacts_update_in_message(
-        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
+        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent_replied
     ):
         adapter = CrewAIAdapter()
         await adapter.on_started("TestBot", "Test bot")
-        adapter._crewai_agent = mock_crewai_agent
+        adapter._crewai_agent = mock_crewai_agent_replied
 
         await adapter.on_message(
             msg=sample_message,
@@ -836,7 +862,7 @@ class TestContactsUpdate:
             room_id="room-123",
         )
 
-        call_args = mock_crewai_agent.kickoff_async.call_args
+        call_args = mock_crewai_agent_replied.kickoff_async.call_args
         messages = call_args[0][0]
 
         found = any(

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -460,7 +460,10 @@ class TestErrorHandling:
                 room_id="room-123",
             )
 
-        mock_tools.send_event.assert_called()
+        mock_tools.send_failure.assert_awaited_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "crewai"
+        assert failure.message == "Agent Error"
 
     @pytest.mark.asyncio
     async def test_reports_error_when_crewai_completes_without_reply(
@@ -485,11 +488,11 @@ class TestErrorHandling:
             room_id="room-123",
         )
 
-        mock_tools.send_event.assert_awaited_once()
-        event_kwargs = mock_tools.send_event.await_args.kwargs
-        assert event_kwargs["message_type"] == "error"
-        assert "band_send_message" in event_kwargs["content"]
-        assert "max_iter=20" in event_kwargs["content"]
+        mock_tools.send_failure.assert_awaited_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "crewai"
+        assert "band_send_message" in failure.message
+        assert "max_iter=20" in failure.message
 
     @pytest.mark.asyncio
     async def test_reports_error_when_crewai_returns_none_without_reply(
@@ -512,10 +515,10 @@ class TestErrorHandling:
             room_id="room-123",
         )
 
-        mock_tools.send_event.assert_awaited_once()
-        event_kwargs = mock_tools.send_event.await_args.kwargs
-        assert event_kwargs["message_type"] == "error"
-        assert "band_send_message" in event_kwargs["content"]
+        mock_tools.send_failure.assert_awaited_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "crewai"
+        assert "band_send_message" in failure.message
 
     @pytest.mark.asyncio
     async def test_does_not_report_completion_error_after_reply(
@@ -550,7 +553,7 @@ class TestErrorHandling:
             room_id="room-123",
         )
 
-        mock_tools.send_event.assert_not_called()
+        mock_tools.send_failure.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_suppresses_empty_final_answer_after_reply(
@@ -591,8 +594,8 @@ class TestErrorHandling:
             room_id="room-123",
         )
 
-        # No error event posted to the room.
-        mock_tools.send_event.assert_not_called()
+        # No failure reported to the room.
+        mock_tools.send_failure.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_suppresses_empty_final_answer_after_tool_only_turn(
@@ -635,8 +638,8 @@ class TestErrorHandling:
             room_id="room-123",
         )
 
-        # No error event posted to the room.
-        mock_tools.send_event.assert_not_called()
+        # No failure reported to the room.
+        mock_tools.send_failure.assert_not_awaited()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -685,8 +688,11 @@ class TestErrorHandling:
                 room_id="room-123",
             )
 
-        # And it must surface as an error event in the room.
-        mock_tools.send_event.assert_called()
+        # And it must surface as a reported failure.
+        mock_tools.send_failure.assert_awaited_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "crewai"
+        assert failure.message == str(error)
 
     @pytest.mark.asyncio
     async def test_raises_error_when_agent_not_initialized(
@@ -706,6 +712,11 @@ class TestErrorHandling:
                 is_session_bootstrap=True,
                 room_id="room-123",
             )
+
+        mock_tools.send_failure.assert_awaited_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "crewai"
+        assert "not initialized" in failure.message
 
 
 class TestVerboseMode:

--- a/tests/adapters/test_crewai_adapter_soak.py
+++ b/tests/adapters/test_crewai_adapter_soak.py
@@ -1,13 +1,18 @@
 """Soak test: 100 sequential on_message calls across 3 mocked rooms.
 
 Asserts:
-- No exceptions across the run
 - nest_asyncio.apply is invoked at most once (lazy patch idempotency)
 - Per-room state in `_message_history` does not leak between rooms
+
+The mocked ``crewai_agent`` never drives a real ``band_send_message`` tool
+call, so every turn is a genuine "missing reply" turn and raises
+``TurnResultAlreadyReported`` (expected, not a soak failure) — history
+bookkeeping still runs before that raise, which is what this test checks.
 """
 
 from __future__ import annotations
 
+import contextlib
 import importlib
 import sys
 from datetime import datetime, timezone
@@ -15,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from band.core.protocols import TurnResultAlreadyReported
 from band.core.types import PlatformMessage
 
 
@@ -85,15 +91,16 @@ async def test_soak_100_turns_3_rooms(crewai_mocks):
     for i in range(100):
         room_id = rooms[i % 3]
         msg = _make_msg(i, room_id)
-        await adapter.on_message(
-            msg=msg,
-            tools=tools_per_room[room_id],
-            history=[],
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=(i < 3),
-            room_id=room_id,
-        )
+        with contextlib.suppress(TurnResultAlreadyReported):
+            await adapter.on_message(
+                msg=msg,
+                tools=tools_per_room[room_id],
+                history=[],
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=(i < 3),
+                room_id=room_id,
+            )
 
     # Per-room state present, no cross-room leakage: each room has only its own
     # message ids in its history.

--- a/tests/adapters/test_crewai_flow_phase4.py
+++ b/tests/adapters/test_crewai_flow_phase4.py
@@ -926,6 +926,10 @@ class TestDelegationAmbiguity:
         assert len(failures) == 1
         assert failures[0]["code"] == "ambiguous_participant"
         assert len(failures[0]["message"]) <= 500
+        # The full, untruncated list survives in detail for a structured
+        # consumer, even though the room-visible message is capped.
+        assert failures[0]["detail"].startswith(failures[0]["message"])
+        assert len(failures[0]["detail"]) > 500
 
     @pytest.mark.asyncio
     async def test_delegation_send_failure_stops_later_delegations(

--- a/tests/adapters/test_crewai_flow_phase4.py
+++ b/tests/adapters/test_crewai_flow_phase4.py
@@ -891,6 +891,47 @@ class TestDelegationAmbiguity:
         assert payloads[-1]["error"]["code"] == "ambiguous_participant"
 
     @pytest.mark.asyncio
+    async def test_ambiguous_delegation_failure_message_is_capped(self) -> None:
+        """The ambiguous-identity error embeds every colliding participant id
+        -- room-visible content stays capped like every other post in this
+        adapter (record_waiting, reply_ambiguous), even with a large room."""
+        colliding_ids = [f"participant-id-{i:040d}" for i in range(30)]
+        flow = _flow(
+            {
+                "decision": "delegate",
+                "delegations": [
+                    {
+                        "delegation_id": "d-A",
+                        "target": "peer-a",
+                        "content": "do A",
+                        "mentions": ["@example/peer-a"],
+                    }
+                ],
+            }
+        )
+        adapter = CrewAIFlowAdapter(
+            flow_factory=lambda: flow,
+            state_source=HistoryCrewAIFlowStateSource(acknowledge_test_only=True),
+        )
+        tools = FakeAgentTools(
+            participants=[
+                {"id": pid, "handle": "@example/peer-a", "name": "Peer A"}
+                for pid in colliding_ids
+            ]
+        )
+        await _start(adapter, "router")
+        await _turn(adapter, tools, _msg(id="msg-1"), is_session_bootstrap=True)
+
+        failures = [
+            e["metadata"]["failure"]
+            for e in tools.events_sent
+            if e["message_type"] == "error"
+        ]
+        assert len(failures) == 1
+        assert failures[0]["code"] == "ambiguous_participant"
+        assert len(failures[0]["message"]) <= 500
+
+    @pytest.mark.asyncio
     async def test_delegation_send_failure_stops_later_delegations(
         self,
     ) -> None:

--- a/tests/adapters/test_crewai_flow_phase4.py
+++ b/tests/adapters/test_crewai_flow_phase4.py
@@ -29,7 +29,7 @@ from band.adapters.crewai_flow import (  # noqa: E402
     RestCrewAIFlowStateSource,
 )
 from band.core.types import PlatformMessage  # noqa: E402
-from band.testing.fake_tools import FakeAgentTools  # noqa: E402
+from band.testing.fake_tools import FakeAgentTools, reported_failures  # noqa: E402
 
 NS_PREFIX = "crewai_flow:"
 
@@ -922,11 +922,7 @@ class TestDelegationAmbiguity:
         await _start(adapter, "router")
         await _turn(adapter, tools, _msg(id="msg-1"), is_session_bootstrap=True)
 
-        failures = [
-            e["metadata"]["failure"]
-            for e in tools.events_sent
-            if e["message_type"] == "error"
-        ]
+        failures = reported_failures(tools)
         assert len(failures) == 1
         assert failures[0]["code"] == "ambiguous_participant"
         assert len(failures[0]["message"]) <= 500

--- a/tests/adapters/test_gemini_adapter.py
+++ b/tests/adapters/test_gemini_adapter.py
@@ -13,6 +13,7 @@ from google.genai.errors import ServerError
 from pydantic import BaseModel, Field, ValidationError
 
 from band.adapters.gemini import GeminiAdapter
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE
 from band.core.types import Emit, PlatformMessage, ToolEventKey
 
 
@@ -224,7 +225,7 @@ class TestErrorReporting:
         mock_tools.send_failure.assert_called_once()
         failure = mock_tools.send_failure.call_args.args[0]
         assert failure.provider == "gemini"
-        assert failure.message == "boom"
+        assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
         assert failure.code is None
         assert failure.detail is None
 

--- a/tests/adapters/test_gemini_adapter.py
+++ b/tests/adapters/test_gemini_adapter.py
@@ -640,7 +640,7 @@ class TestMaxToolRounds:
                     room_id="room-123",
                 )
 
-        # Previously reported nothing at all -- this is the added report.
+        # Exceeding max tool rounds is a reportable provider failure.
         mock_tools.send_failure.assert_called_once()
         failure = mock_tools.send_failure.call_args.args[0]
         assert failure.provider == "gemini"

--- a/tests/adapters/test_gemini_adapter.py
+++ b/tests/adapters/test_gemini_adapter.py
@@ -39,6 +39,7 @@ def mock_tools() -> MagicMock:
     tools.get_openai_tool_schemas = MagicMock(return_value=[])
     tools.send_message = AsyncMock(return_value={"status": "sent"})
     tools.send_event = AsyncMock(return_value={"status": "sent"})
+    tools.send_failure = AsyncMock(return_value={"status": "sent"})
     tools.execute_tool_call = AsyncMock(return_value={"status": "success"})
     return tools
 
@@ -198,6 +199,63 @@ class TestOnMessage:
         assert function_call.id == "c1"
         assert function_call.name == "band_lookup_peers"
         assert function_call.args == {"page": "1"}
+
+
+class TestErrorReporting:
+    @pytest.mark.asyncio
+    async def test_reports_generic_failure(self, sample_message, mock_tools):
+        adapter = GeminiAdapter(provider_key="test-key")
+        await adapter.on_started("TestBot", "Test bot")
+
+        with patch.object(
+            adapter, "_call_gemini", AsyncMock(side_effect=Exception("boom"))
+        ):
+            with pytest.raises(Exception, match="boom"):
+                await adapter.on_message(
+                    msg=sample_message,
+                    tools=mock_tools,
+                    history=[],
+                    participants_msg=None,
+                    contacts_msg=None,
+                    is_session_bootstrap=True,
+                    room_id="room-123",
+                )
+
+        mock_tools.send_failure.assert_called_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "gemini"
+        assert failure.message == "boom"
+        assert failure.code is None
+        assert failure.detail is None
+
+    @pytest.mark.asyncio
+    async def test_preserves_server_error_status_and_message(
+        self, sample_message, mock_tools
+    ):
+        """ServerError's status/message are real provider data -- preserve
+        them as code/detail rather than falling back to the generic shape."""
+        adapter = GeminiAdapter(provider_key="test-key")
+        await adapter.on_started("TestBot", "Test bot")
+        error = ServerError(
+            503, {"error": {"status": "UNAVAILABLE", "message": "overloaded"}}, None
+        )
+
+        with patch.object(adapter, "_call_gemini", AsyncMock(side_effect=error)):
+            with pytest.raises(ServerError):
+                await adapter.on_message(
+                    msg=sample_message,
+                    tools=mock_tools,
+                    history=[],
+                    participants_msg=None,
+                    contacts_msg=None,
+                    is_session_bootstrap=True,
+                    room_id="room-123",
+                )
+
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "gemini"
+        assert failure.code == "UNAVAILABLE"
+        assert failure.detail == "overloaded"
 
 
 class TestRetries:
@@ -581,6 +639,12 @@ class TestMaxToolRounds:
                     is_session_bootstrap=True,
                     room_id="room-123",
                 )
+
+        # Previously reported nothing at all -- this is the added report.
+        mock_tools.send_failure.assert_called_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "gemini"
+        assert "Exceeded max tool rounds" in failure.message
 
 
 class TestHttpxRetries:

--- a/tests/adapters/test_google_adk_adapter.py
+++ b/tests/adapters/test_google_adk_adapter.py
@@ -970,8 +970,7 @@ class TestErrorHandling:
     async def test_reports_error_when_runner_construction_itself_fails(
         self, sample_message, mock_tools
     ):
-        """Previously uncaught entirely: _create_runner ran outside the try,
-        so a construction failure escaped with zero report."""
+        """A runner-construction failure must be reported, not escape uncaught."""
         adapter = GoogleADKAdapter()
         await adapter.on_started("TestBot", "Test bot")
 

--- a/tests/adapters/test_google_adk_adapter.py
+++ b/tests/adapters/test_google_adk_adapter.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel, Field
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE
 from band.core.types import ALL_CAPABILITIES, Capability, Emit, PlatformMessage
 from band.runtime.tools import AgentTools, BandTool
 
@@ -961,7 +962,7 @@ class TestErrorHandling:
             mock_tools.send_failure.assert_called_once()
             failure = mock_tools.send_failure.call_args.args[0]
             assert failure.provider == "google_adk"
-            assert failure.message == "Runner Error"
+            assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
             # Runner should be closed even on error (via finally)
             mock_runner.close.assert_called_once()
 
@@ -991,7 +992,7 @@ class TestErrorHandling:
         mock_tools.send_failure.assert_called_once()
         failure = mock_tools.send_failure.call_args.args[0]
         assert failure.provider == "google_adk"
-        assert failure.message == "bad tool schema"
+        assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
 
 
 class TestHistoryTranscript:

--- a/tests/adapters/test_google_adk_adapter.py
+++ b/tests/adapters/test_google_adk_adapter.py
@@ -75,6 +75,7 @@ def mock_tools():
     )
     tools.send_message = AsyncMock(return_value={"status": "sent"})
     tools.send_event = AsyncMock(return_value={"status": "sent"})
+    tools.send_failure = AsyncMock(return_value={"status": "sent"})
     tools.execute_tool_call = AsyncMock(return_value={"status": "success"})
     return tools
 
@@ -957,9 +958,40 @@ class TestErrorHandling:
                     room_id="room-123",
                 )
 
-            mock_tools.send_event.assert_called()
+            mock_tools.send_failure.assert_called_once()
+            failure = mock_tools.send_failure.call_args.args[0]
+            assert failure.provider == "google_adk"
+            assert failure.message == "Runner Error"
             # Runner should be closed even on error (via finally)
             mock_runner.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reports_error_when_runner_construction_itself_fails(
+        self, sample_message, mock_tools
+    ):
+        """Previously uncaught entirely: _create_runner ran outside the try,
+        so a construction failure escaped with zero report."""
+        adapter = GoogleADKAdapter()
+        await adapter.on_started("TestBot", "Test bot")
+
+        with patch.object(
+            adapter, "_create_runner", side_effect=RuntimeError("bad tool schema")
+        ):
+            with pytest.raises(RuntimeError, match="bad tool schema"):
+                await adapter.on_message(
+                    msg=sample_message,
+                    tools=mock_tools,
+                    history=[],
+                    participants_msg=None,
+                    contacts_msg=None,
+                    is_session_bootstrap=True,
+                    room_id="room-123",
+                )
+
+        mock_tools.send_failure.assert_called_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "google_adk"
+        assert failure.message == "bad tool schema"
 
 
 class TestHistoryTranscript:
@@ -1407,19 +1439,6 @@ class TestFinalResponseCapture:
 
         result = GoogleADKAdapter._extract_event_text(mock_event)
         assert result == ""
-
-
-class TestReportErrorFailure:
-    """Tests for _report_error own failure handling."""
-
-    @pytest.mark.asyncio
-    async def test_report_error_handles_own_failure(self, mock_tools):
-        """Should not raise when _report_error itself fails."""
-        adapter = GoogleADKAdapter()
-        mock_tools.send_event = AsyncMock(side_effect=Exception("Network down"))
-
-        # Should not raise
-        await adapter._report_error(mock_tools, "some error")
 
 
 class TestConcurrentMessages:

--- a/tests/adapters/test_letta_adapter.py
+++ b/tests/adapters/test_letta_adapter.py
@@ -21,6 +21,7 @@ from band.adapters.letta import (
     RoomContext,
 )
 from band.converters.letta import LettaSessionState
+from band.core.protocols import TurnResultAlreadyReported
 from band.core.types import Emit
 from band.testing import FakeAgentTools, reported_failures
 from tests.adapters.lettakit import (
@@ -1274,15 +1275,16 @@ class TestAutoRelayDisabled:
         )
 
         tools = FakeAgentTools()
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            LettaSessionState(),
-            None,
-            None,
-            is_session_bootstrap=False,
-            room_id="room-1",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                LettaSessionState(),
+                None,
+                None,
+                is_session_bootstrap=False,
+                room_id="room-1",
+            )
 
         assert len(tools.messages_sent) == 0
         error_events = [e for e in tools.events_sent if e["message_type"] == "error"]

--- a/tests/adapters/test_letta_adapter.py
+++ b/tests/adapters/test_letta_adapter.py
@@ -250,12 +250,11 @@ class TestLettaAdapterOnMessagePerRoom:
                 room_id="room-1",
             )
 
-        error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
-        assert len(error_events) == 1
-        assert "timed out" in error_events[0]["content"]
-        failure = reported_failures(tools)[0]
-        assert failure["provider"] == "letta"
-        assert failure["code"] == "timeout"
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert "timed out" in failures[0]["message"]
+        assert failures[0]["provider"] == "letta"
+        assert failures[0]["code"] == "timeout"
 
     @pytest.mark.asyncio
     async def test_generic_exception_reports_and_propagates(

--- a/tests/adapters/test_letta_adapter.py
+++ b/tests/adapters/test_letta_adapter.py
@@ -172,15 +172,16 @@ class TestLettaAdapterOnMessagePerRoom:
         msg = make_platform_message()
         history = LettaSessionState()
 
-        await adapter.on_message(
-            msg,
-            tools,
-            history,
-            None,
-            None,
-            is_session_bootstrap=False,
-            room_id="room-1",
-        )
+        with pytest.raises(RuntimeError, match="platform rejected the message"):
+            await adapter.on_message(
+                msg,
+                tools,
+                history,
+                None,
+                None,
+                is_session_bootstrap=False,
+                room_id="room-1",
+            )
 
         assert not reported_failures(tools)
 
@@ -234,15 +235,16 @@ class TestLettaAdapterOnMessagePerRoom:
         msg = make_platform_message()
         history = LettaSessionState()
 
-        await adapter.on_message(
-            msg,
-            tools,
-            history,
-            None,
-            None,
-            is_session_bootstrap=False,
-            room_id="room-1",
-        )
+        with pytest.raises(TimeoutError):
+            await adapter.on_message(
+                msg,
+                tools,
+                history,
+                None,
+                None,
+                is_session_bootstrap=False,
+                room_id="room-1",
+            )
 
         error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert len(error_events) == 1
@@ -321,15 +323,16 @@ class TestLettaAdapterOnMessagePerRoom:
         msg = make_platform_message()
         history = LettaSessionState()
 
-        await adapter.on_message(
-            msg,
-            tools,
-            history,
-            None,
-            None,
-            is_session_bootstrap=True,
-            room_id="room-1",
-        )
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await adapter.on_message(
+                msg,
+                tools,
+                history,
+                None,
+                None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
 
         error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert len(error_events) == 1
@@ -1378,15 +1381,16 @@ class TestColdBootSeeding:
             replay_messages=["[Alice]: The secret word is kumquat."]
         )
         tools = FakeAgentTools()
-        await adapter.on_message(
-            make_platform_message(content="what was the secret word?"),
-            tools,
-            history,
-            None,
-            None,
-            is_session_bootstrap=True,
-            room_id="room-1",
-        )
+        with pytest.raises(TimeoutError):
+            await adapter.on_message(
+                make_platform_message(content="what was the secret word?"),
+                tools,
+                history,
+                None,
+                None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
 
         assert adapter._rooms["room-1"].pending_seed == [
             "[Alice]: The secret word is kumquat."

--- a/tests/adapters/test_letta_adapter.py
+++ b/tests/adapters/test_letta_adapter.py
@@ -22,7 +22,7 @@ from band.adapters.letta import (
 )
 from band.converters.letta import LettaSessionState
 from band.core.types import Emit
-from band.testing import FakeAgentTools
+from band.testing import FakeAgentTools, reported_failures
 from tests.adapters.lettakit import (
     default_enforcement,
     make_assistant_message,
@@ -182,7 +182,7 @@ class TestLettaAdapterOnMessagePerRoom:
             room_id="room-1",
         )
 
-        assert not [e for e in tools.events_sent if e["message_type"] == "error"]
+        assert not reported_failures(tools)
 
     @pytest.mark.asyncio
     async def test_skip_auto_relay_when_send_message_used(
@@ -1312,7 +1312,7 @@ class TestAutoRelayDisabled:
         )
 
         assert len(tools.messages_sent) == 0
-        assert not [e for e in tools.events_sent if e["message_type"] == "error"]
+        assert not reported_failures(tools)
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/adapters/test_letta_adapter.py
+++ b/tests/adapters/test_letta_adapter.py
@@ -21,7 +21,10 @@ from band.adapters.letta import (
     RoomContext,
 )
 from band.converters.letta import LettaSessionState
-from band.core.protocols import TurnResultAlreadyReported
+from band.core.protocols import (
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    TurnResultAlreadyReported,
+)
 from band.core.types import Emit
 from band.testing import FakeAgentTools, reported_failures
 from tests.adapters.lettakit import (
@@ -250,9 +253,41 @@ class TestLettaAdapterOnMessagePerRoom:
         error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert len(error_events) == 1
         assert "timed out" in error_events[0]["content"]
-        failure = error_events[0]["metadata"]["failure"]
+        failure = reported_failures(tools)[0]
         assert failure["provider"] == "letta"
         assert failure["code"] == "timeout"
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_reports_and_propagates(
+        self, adapter_with_client: tuple[LettaAdapter, AsyncMock]
+    ) -> None:
+        """A bare exception from the Letta client (not a timeout, not a
+        delivery failure) must still surface via the generic fallback."""
+        adapter, mock_client = adapter_with_client
+        adapter._rooms["room-1"] = RoomContext(agent_id="agent-1")
+        mock_client.agents.messages.create.side_effect = ConnectionError(
+            "letta connection reset"
+        )
+
+        tools = FakeAgentTools()
+        msg = make_platform_message()
+        history = LettaSessionState()
+
+        with pytest.raises(ConnectionError, match="letta connection reset"):
+            await adapter.on_message(
+                msg,
+                tools,
+                history,
+                None,
+                None,
+                is_session_bootstrap=False,
+                room_id="room-1",
+            )
+
+        failure = reported_failures(tools)[0]
+        assert failure["provider"] == "letta"
+        assert failure["message"] == GENERIC_PROVIDER_FAILURE_MESSAGE
+        assert "letta connection reset" not in failure["message"]
 
     @pytest.mark.asyncio
     async def test_participants_and_contacts_injected(

--- a/tests/adapters/test_letta_adapter.py
+++ b/tests/adapters/test_letta_adapter.py
@@ -149,6 +149,42 @@ class TestLettaAdapterOnMessagePerRoom:
         assert tools.messages_sent[0]["content"] == "I'll help you!"
 
     @pytest.mark.asyncio
+    async def test_send_message_failure_is_not_reported_as_provider_failure(
+        self, adapter_with_client: tuple[LettaAdapter, AsyncMock]
+    ) -> None:
+        """The Letta agent answered fine; the room POST is what failed. That
+        must not surface as a Letta AgentFailure -- deliver_reply's
+        DeliveryFailedError must be recognized and left unreported here."""
+        adapter, mock_client = adapter_with_client
+        adapter._rooms["room-1"] = RoomContext(agent_id="agent-1")
+
+        mock_client.agents.messages.create.return_value = make_letta_response(
+            make_assistant_message("I'll help you!")
+        )
+
+        tools = FakeAgentTools()
+
+        async def _raise(*args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("platform rejected the message")
+
+        tools.send_message = _raise  # type: ignore[method-assign]
+
+        msg = make_platform_message()
+        history = LettaSessionState()
+
+        await adapter.on_message(
+            msg,
+            tools,
+            history,
+            None,
+            None,
+            is_session_bootstrap=False,
+            room_id="room-1",
+        )
+
+        assert not [e for e in tools.events_sent if e["message_type"] == "error"]
+
+    @pytest.mark.asyncio
     async def test_skip_auto_relay_when_send_message_used(
         self, adapter_with_client: tuple[LettaAdapter, AsyncMock]
     ) -> None:
@@ -211,6 +247,9 @@ class TestLettaAdapterOnMessagePerRoom:
         error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert len(error_events) == 1
         assert "timed out" in error_events[0]["content"]
+        failure = error_events[0]["metadata"]["failure"]
+        assert failure["provider"] == "letta"
+        assert failure["code"] == "timeout"
 
     @pytest.mark.asyncio
     async def test_participants_and_contacts_injected(

--- a/tests/adapters/test_letta_mcp.py
+++ b/tests/adapters/test_letta_mcp.py
@@ -22,12 +22,13 @@ from band.adapters.letta import (
     RoomContext,
 )
 from band.converters.letta import LettaSessionState
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE
 from band.integrations.letta.prompts import (
     SEND_EVENT_TOOL_NAMES,
     SEND_MESSAGE_TOOL_NAMES,
 )
 from band.runtime.tools import BandTool
-from band.testing import FakeAgentTools
+from band.testing import FakeAgentTools, reported_failures
 from tests.adapters.lettakit import (
     make_assistant_message,
     make_fake_mcp_backend,
@@ -532,6 +533,9 @@ class TestSelfHostedMCPLifecycle:
 
         error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert len(error_events) == 1
+        failure = reported_failures(tools)[0]
+        assert failure["provider"] == "letta"
+        assert failure["message"] == GENERIC_PROVIDER_FAILURE_MESSAGE
         mock_client.agents.messages.create.assert_not_called()
 
     @pytest.mark.asyncio
@@ -779,6 +783,9 @@ class TestSelfHostedMCPLifecycle:
 
         error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert len(error_events) == 1
+        failure = reported_failures(tools)[0]
+        assert failure["provider"] == "letta"
+        assert failure["message"] == GENERIC_PROVIDER_FAILURE_MESSAGE
         mock_client.agents.messages.create.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/adapters/test_letta_mcp.py
+++ b/tests/adapters/test_letta_mcp.py
@@ -531,11 +531,10 @@ class TestSelfHostedMCPLifecycle:
                 room_id="room-1",
             )
 
-        error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
-        assert len(error_events) == 1
-        failure = reported_failures(tools)[0]
-        assert failure["provider"] == "letta"
-        assert failure["message"] == GENERIC_PROVIDER_FAILURE_MESSAGE
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["provider"] == "letta"
+        assert failures[0]["message"] == GENERIC_PROVIDER_FAILURE_MESSAGE
         mock_client.agents.messages.create.assert_not_called()
 
     @pytest.mark.asyncio
@@ -781,11 +780,10 @@ class TestSelfHostedMCPLifecycle:
                 room_id="room-1",
             )
 
-        error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
-        assert len(error_events) == 1
-        failure = reported_failures(tools)[0]
-        assert failure["provider"] == "letta"
-        assert failure["message"] == GENERIC_PROVIDER_FAILURE_MESSAGE
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["provider"] == "letta"
+        assert failures[0]["message"] == GENERIC_PROVIDER_FAILURE_MESSAGE
         mock_client.agents.messages.create.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/adapters/test_letta_mcp.py
+++ b/tests/adapters/test_letta_mcp.py
@@ -519,15 +519,16 @@ class TestSelfHostedMCPLifecycle:
         mock_client.agents.tools.list.side_effect = ConnectionError("letta hiccup")
 
         tools = FakeAgentTools()
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            LettaSessionState(),
-            None,
-            None,
-            is_session_bootstrap=False,
-            room_id="room-1",
-        )
+        with pytest.raises(RuntimeError, match="not attached"):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                LettaSessionState(),
+                None,
+                None,
+                is_session_bootstrap=False,
+                room_id="room-1",
+            )
 
         error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert len(error_events) == 1
@@ -765,15 +766,16 @@ class TestSelfHostedMCPLifecycle:
         mock_client.mcp_servers.list.side_effect = ConnectionError("letta down")
 
         tools = FakeAgentTools()
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            LettaSessionState(),
-            None,
-            None,
-            is_session_bootstrap=True,
-            room_id="room-1",
-        )
+        with pytest.raises(RuntimeError, match="MCP server registration failed"):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                LettaSessionState(),
+                None,
+                None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
 
         error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert len(error_events) == 1

--- a/tests/adapters/test_parlant_adapter.py
+++ b/tests/adapters/test_parlant_adapter.py
@@ -833,6 +833,73 @@ class TestErrorHandling:
         assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
 
     @pytest.mark.asyncio
+    async def test_send_message_failure_is_not_reported_as_provider_failure(
+        self, mock_parlant_server, mock_parlant_agent, sample_message, mock_tools
+    ):
+        """A Band-side send_message failure while delivering the reply must
+        propagate as itself, not get misreported as a Parlant provider failure.
+
+        ``deliver_reply`` wraps the ``send_message`` error in
+        ``DeliveryFailedError``; ``on_message``'s dedicated except branch must
+        re-raise the original cause before its generic ``except Exception``
+        (which reports ``send_failure``) ever sees it.
+        """
+        adapter = ParlantAdapter(
+            server=mock_parlant_server,
+            parlant_agent=mock_parlant_agent,
+            response_timeout=0.2,
+            response_poll=0.01,
+        )
+        adapter.agent_name = "TestBot"
+
+        agent_event = MagicMock()
+        agent_event.kind = "message"
+        agent_event.source = "ai_agent"
+        agent_event.offset = 2
+        agent_event.data = {"message": "Hello there!", "tags": []}
+
+        mock_app = MagicMock()
+        mock_app.sessions = AsyncMock()
+        mock_app.sessions.create = AsyncMock(return_value=MagicMock(id="session-123"))
+        mock_app.sessions.create_customer_message = AsyncMock(
+            return_value=MagicMock(offset=1)
+        )
+        mock_app.sessions.wait_for_more_events = AsyncMock(return_value=True)
+        mock_app.sessions.find_events = AsyncMock(return_value=[agent_event])
+        adapter._app = mock_app
+
+        mock_tools.send_message.side_effect = ConnectionError("band down")
+
+        mock_moderation = MagicMock()
+        mock_moderation.NONE = "none"
+
+        with patch.dict(
+            sys.modules,
+            {
+                "parlant.core.app_modules.sessions": MagicMock(
+                    Moderation=mock_moderation
+                ),
+                "parlant.core.sessions": MagicMock(
+                    EventSource=MagicMock(CUSTOMER="customer", AI_AGENT="ai_agent"),
+                    EventKind=MagicMock(MESSAGE="message"),
+                ),
+                "parlant.core.async_utils": MagicMock(Timeout=lambda x: x),
+            },
+        ):
+            with pytest.raises(ConnectionError, match="band down"):
+                await adapter.on_message(
+                    msg=sample_message,
+                    tools=mock_tools,
+                    history=[],
+                    participants_msg=None,
+                    contacts_msg=None,
+                    is_session_bootstrap=True,
+                    room_id="room-123",
+                )
+
+        mock_tools.send_failure.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_clears_tools_on_error(
         self, mock_parlant_server, mock_parlant_agent, sample_message, mock_tools
     ):

--- a/tests/adapters/test_parlant_adapter.py
+++ b/tests/adapters/test_parlant_adapter.py
@@ -15,6 +15,7 @@ import sys
 import pytest
 
 from band.adapters.parlant import PARLANT_PREAMBLE_TAG, ParlantAdapter
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE
 from band.core.types import PlatformMessage
 
 
@@ -797,7 +798,7 @@ class TestErrorHandling:
         mock_tools.send_failure.assert_awaited_once()
         failure = mock_tools.send_failure.call_args.args[0]
         assert failure.provider == "parlant"
-        assert failure.message == "API error"
+        assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
 
     @pytest.mark.asyncio
     async def test_reports_error_on_session_init_failure(
@@ -829,7 +830,7 @@ class TestErrorHandling:
         mock_tools.send_failure.assert_awaited_once()
         failure = mock_tools.send_failure.call_args.args[0]
         assert failure.provider == "parlant"
-        assert "Session initialization failed" in failure.message
+        assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
 
     @pytest.mark.asyncio
     async def test_clears_tools_on_error(

--- a/tests/adapters/test_parlant_adapter.py
+++ b/tests/adapters/test_parlant_adapter.py
@@ -42,6 +42,7 @@ def mock_tools():
     tools.get_openai_tool_schemas = MagicMock(return_value=[])
     tools.send_message = AsyncMock(return_value={"status": "sent"})
     tools.send_event = AsyncMock(return_value={"status": "sent"})
+    tools.send_failure = AsyncMock(return_value={"status": "sent"})
     tools.execute_tool_call = AsyncMock(return_value={"status": "success"})
     return tools
 

--- a/tests/adapters/test_parlant_adapter.py
+++ b/tests/adapters/test_parlant_adapter.py
@@ -793,8 +793,43 @@ class TestErrorHandling:
                     room_id="room-123",
                 )
 
-        # Should have tried to report error
-        mock_tools.send_event.assert_called()
+        # Should have tried to report the failure
+        mock_tools.send_failure.assert_awaited_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "parlant"
+        assert failure.message == "API error"
+
+    @pytest.mark.asyncio
+    async def test_reports_error_on_session_init_failure(
+        self, mock_parlant_server, mock_parlant_agent, sample_message, mock_tools
+    ):
+        """A session-creation failure reports and returns without raising."""
+        adapter = ParlantAdapter(
+            server=mock_parlant_server,
+            parlant_agent=mock_parlant_agent,
+        )
+        adapter.agent_name = "TestBot"
+
+        mock_app = MagicMock()
+        mock_app.sessions = AsyncMock()
+        mock_app.sessions.create = AsyncMock(side_effect=Exception("db unreachable"))
+        adapter._app = mock_app
+
+        # Must not raise: session init failures are reported, not propagated.
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        mock_tools.send_failure.assert_awaited_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "parlant"
+        assert "Session initialization failed" in failure.message
 
     @pytest.mark.asyncio
     async def test_clears_tools_on_error(
@@ -848,14 +883,13 @@ class TestErrorHandling:
     async def test_handles_uninitialized_app(
         self, mock_parlant_server, mock_parlant_agent, sample_message, mock_tools
     ):
-        """Should handle case when app is not initialized."""
+        """An uninitialized app returns early, but must still report the failure."""
         adapter = ParlantAdapter(
             server=mock_parlant_server,
             parlant_agent=mock_parlant_agent,
         )
         # Don't set _app
 
-        # Should return early without error
         await adapter.on_message(
             msg=sample_message,
             tools=mock_tools,
@@ -866,8 +900,12 @@ class TestErrorHandling:
             room_id="room-123",
         )
 
-        # No calls should be made
+        # No reply attempt, but the failure is reported.
         mock_tools.send_message.assert_not_called()
+        mock_tools.send_failure.assert_awaited_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "parlant"
+        assert "not initialized" in failure.message
 
 
 class TestResponseWaitBudget:

--- a/tests/adapters/test_parlant_adapter.py
+++ b/tests/adapters/test_parlant_adapter.py
@@ -803,7 +803,7 @@ class TestErrorHandling:
     async def test_reports_error_on_session_init_failure(
         self, mock_parlant_server, mock_parlant_agent, sample_message, mock_tools
     ):
-        """A session-creation failure reports and returns without raising."""
+        """A session-creation failure is reported, then fails the turn."""
         adapter = ParlantAdapter(
             server=mock_parlant_server,
             parlant_agent=mock_parlant_agent,
@@ -815,16 +815,16 @@ class TestErrorHandling:
         mock_app.sessions.create = AsyncMock(side_effect=Exception("db unreachable"))
         adapter._app = mock_app
 
-        # Must not raise: session init failures are reported, not propagated.
-        await adapter.on_message(
-            msg=sample_message,
-            tools=mock_tools,
-            history=[],
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-123",
-        )
+        with pytest.raises(Exception, match="db unreachable"):
+            await adapter.on_message(
+                msg=sample_message,
+                tools=mock_tools,
+                history=[],
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-123",
+            )
 
         mock_tools.send_failure.assert_awaited_once()
         failure = mock_tools.send_failure.call_args.args[0]
@@ -883,22 +883,23 @@ class TestErrorHandling:
     async def test_handles_uninitialized_app(
         self, mock_parlant_server, mock_parlant_agent, sample_message, mock_tools
     ):
-        """An uninitialized app returns early, but must still report the failure."""
+        """An uninitialized app reports the failure, then fails the turn."""
         adapter = ParlantAdapter(
             server=mock_parlant_server,
             parlant_agent=mock_parlant_agent,
         )
         # Don't set _app
 
-        await adapter.on_message(
-            msg=sample_message,
-            tools=mock_tools,
-            history=[],
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-123",
-        )
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await adapter.on_message(
+                msg=sample_message,
+                tools=mock_tools,
+                history=[],
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-123",
+            )
 
         # No reply attempt, but the failure is reported.
         mock_tools.send_message.assert_not_called()

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -1787,8 +1787,7 @@ class TestEmptyFinalAnswer:
         self, sample_message, mock_tools, mock_pydantic_agent
     ):
         """A failure that isn't UnexpectedModelBehavior at all (a raw provider/API
-        error) must still surface as a failure and propagate — previously this
-        class of error had no except clause at all and vanished uncaught."""
+        error) must still surface as a failure and propagate, not vanish uncaught."""
         adapter = PydanticAIAdapter(model="openai:gpt-5.4")
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started("TestBot", "Test bot")

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -152,6 +152,7 @@ def mock_tools():
     tools = MagicMock()
     tools.send_message = AsyncMock(return_value={"status": "sent"})
     tools.send_event = AsyncMock(return_value={"status": "sent"})
+    tools.send_failure = AsyncMock(return_value={"status": "sent"})
     tools.add_participant = AsyncMock(return_value={"id": "user-1"})
     tools.remove_participant = AsyncMock(return_value={"status": "removed"})
     tools.lookup_peers = AsyncMock(return_value={"peers": []})

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -980,6 +980,36 @@ class TestOnMessage:
 
             mock_create.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_reports_failure_when_no_terminal_tool_ran(
+        self, sample_message, mock_tools, mock_pydantic_agent
+    ):
+        """A clean run that never called a reply/terminal tool is a silently
+        dropped turn — must still surface as a failure, even without an
+        exception."""
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
+        with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
+            await adapter.on_started("TestBot", "Test bot")
+
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(result_messages=[])
+        )
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        mock_tools.send_failure.assert_awaited_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "pydantic_ai"
+        assert "band_send_message" in failure.message
+
 
 class TestOnCleanup:
     """Tests for on_cleanup() method."""
@@ -1430,9 +1460,10 @@ class TestExecutionReporting:
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started("TestBot", "Test bot")
 
-        # Mock tools where send_event fails with a real transport error (the kind
-        # _report_error narrowly tolerates); a generic Exception would be a bug and
-        # is intentionally left to propagate.
+        # Mock tools where send_event fails with a real transport error — the
+        # tool_call event's own local guard swallows this and logs a warning;
+        # a generic Exception would be a bug and is intentionally left to
+        # propagate.
         failing_tools = AsyncMock()
         failing_tools.send_event = AsyncMock(
             side_effect=httpx.ConnectError("Network error")
@@ -1555,6 +1586,7 @@ class TestEmptyFinalAnswer:
             isinstance(part, UserPromptPart) and "Hello, agent!" in str(part.content)
             for part in preserved[-1].parts
         )
+        mock_tools.send_failure.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_empty_output_preserves_full_captured_turn(
@@ -1627,6 +1659,10 @@ class TestEmptyFinalAnswer:
                 is_session_bootstrap=True,
                 room_id="room-123",
             )
+
+        mock_tools.send_failure.assert_awaited_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "pydantic_ai"
 
     @pytest.mark.asyncio
     async def test_failed_run_still_emits_captured_usage(
@@ -1710,6 +1746,43 @@ class TestEmptyFinalAnswer:
                 is_session_bootstrap=True,
                 room_id="room-123",
             )
+
+        mock_tools.send_failure.assert_awaited_once()
+        assert mock_tools.send_failure.call_args.args[0].provider == "pydantic_ai"
+
+    @pytest.mark.asyncio
+    async def test_generic_provider_error_reports_and_propagates(
+        self, sample_message, mock_tools, mock_pydantic_agent
+    ):
+        """A failure that isn't UnexpectedModelBehavior at all (a raw provider/API
+        error) must still surface as a failure and propagate — previously this
+        class of error had no except clause at all and vanished uncaught."""
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
+        with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
+            await adapter.on_started("TestBot", "Test bot")
+
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_raising_stream(
+                RuntimeError("provider connection reset"),
+                tool_result=False,
+            )
+        )
+
+        with pytest.raises(RuntimeError, match="provider connection reset"):
+            await adapter.on_message(
+                msg=sample_message,
+                tools=mock_tools,
+                history=[],
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-123",
+            )
+
+        mock_tools.send_failure.assert_awaited_once()
+        failure = mock_tools.send_failure.call_args.args[0]
+        assert failure.provider == "pydantic_ai"
+        assert failure.message == "provider connection reset"
 
     @pytest.mark.asyncio
     async def test_empty_output_after_read_only_tool_propagates(

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -55,7 +55,11 @@ from band.adapters.pydantic_ai import (
     _is_output_retries_exhausted,
     _is_replayable_history_message,
 )
-from band.core.protocols import AgentToolsProtocol
+from band.core.protocols import (
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    AgentToolsProtocol,
+    TurnResultAlreadyReported,
+)
 from band.core.types import Capability, Emit, PlatformMessage, TurnUsage
 from band.runtime.custom_tools import get_custom_tool_name
 from tests.adapters.usage_events import sent_usage_payloads
@@ -864,7 +868,10 @@ class TestOnMessage:
 
         result_messages = [ModelRequest(parts=[UserPromptPart(content="test")])]
         adapter._agent.run_stream_events = MagicMock(
-            return_value=make_stream_events(result_messages=result_messages)
+            return_value=make_stream_events(
+                result_messages=result_messages,
+                tool_results=[("band_send_message", "Message sent", "call-1")],
+            )
         )
 
         await adapter.on_message(
@@ -898,7 +905,10 @@ class TestOnMessage:
             ModelRequest(parts=[UserPromptPart(content="new")])
         ]
         adapter._agent.run_stream_events = MagicMock(
-            return_value=make_stream_events(result_messages=result_messages)
+            return_value=make_stream_events(
+                result_messages=result_messages,
+                tool_results=[("band_send_message", "Message sent", "call-1")],
+            )
         )
 
         await adapter.on_message(
@@ -927,7 +937,10 @@ class TestOnMessage:
             await adapter.on_started("TestBot", "Test bot")
 
         adapter._agent.run_stream_events = MagicMock(
-            return_value=make_stream_events(result_messages=[])
+            return_value=make_stream_events(
+                result_messages=[],
+                tool_results=[("band_send_message", "Message sent", "call-1")],
+            )
         )
 
         await adapter.on_message(
@@ -964,7 +977,10 @@ class TestOnMessage:
         with patch.object(adapter, "_create_agent") as mock_create:
             mock_agent = MagicMock()
             mock_agent.run_stream_events = MagicMock(
-                return_value=make_stream_events(result_messages=[])
+                return_value=make_stream_events(
+                    result_messages=[],
+                    tool_results=[("band_send_message", "Message sent", "call-1")],
+                )
             )
             mock_create.return_value = mock_agent
 
@@ -995,15 +1011,16 @@ class TestOnMessage:
             return_value=make_stream_events(result_messages=[])
         )
 
-        await adapter.on_message(
-            msg=sample_message,
-            tools=mock_tools,
-            history=[],
-            participants_msg=None,
-            contacts_msg=None,
-            is_session_bootstrap=True,
-            room_id="room-123",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter.on_message(
+                msg=sample_message,
+                tools=mock_tools,
+                history=[],
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-123",
+            )
 
         mock_tools.send_failure.assert_awaited_once()
         failure = mock_tools.send_failure.call_args.args[0]
@@ -1049,7 +1066,10 @@ class TestHistoryManagement:
         ]
 
         adapter._agent.run_stream_events = MagicMock(
-            return_value=make_stream_events(result_messages=new_messages)
+            return_value=make_stream_events(
+                result_messages=new_messages,
+                tool_results=[("band_send_message", "Message sent", "call-1")],
+            )
         )
 
         await adapter.on_message(
@@ -1103,7 +1123,10 @@ class TestHistoryManagement:
             text_response,
         ]
         adapter._agent.run_stream_events = MagicMock(
-            return_value=make_stream_events(result_messages=result_messages)
+            return_value=make_stream_events(
+                result_messages=result_messages,
+                tool_results=[("band_send_message", {"id": "msg_1"}, "call_1")],
+            )
         )
 
         await adapter.on_message(
@@ -1195,7 +1218,10 @@ class TestHistoryManagement:
             await adapter.on_started("TestBot", "Test bot")
 
         adapter._agent.run_stream_events = MagicMock(
-            return_value=make_stream_events(result_messages=[])
+            return_value=make_stream_events(
+                result_messages=[],
+                tool_results=[("band_send_message", "Message sent", "call-1")],
+            )
         )
 
         await adapter.on_message(
@@ -1232,6 +1258,7 @@ class TestExecutionReporting:
             return_value=make_stream_events(
                 result_messages=[],
                 tool_calls=[("band_send_message", {"content": "Hello"}, "call-123")],
+                tool_results=[("band_send_message", "Message sent", "call-123")],
             )
         )
 
@@ -1276,6 +1303,7 @@ class TestExecutionReporting:
                         "call-123",
                     )
                 ],
+                tool_results=[("band_send_message", "Message sent", "call-2")],
             )
         )
 
@@ -1353,7 +1381,10 @@ class TestExecutionReporting:
         adapter._agent.run_stream_events = MagicMock(
             return_value=make_stream_events(
                 result_messages=[],
-                tool_results=[("band_read_room_file", [image], "call-1")],
+                tool_results=[
+                    ("band_read_room_file", [image], "call-1"),
+                    ("band_send_message", "Message sent", "call-2"),
+                ],
             )
         )
 
@@ -1473,6 +1504,7 @@ class TestExecutionReporting:
             return_value=make_stream_events(
                 result_messages=[ModelRequest(parts=[UserPromptPart(content="test")])],
                 tool_calls=[("band_send_message", {"content": "Hello"}, "call-123")],
+                tool_results=[("band_send_message", "Message sent", "call-123")],
             )
         )
 
@@ -1782,7 +1814,7 @@ class TestEmptyFinalAnswer:
         mock_tools.send_failure.assert_awaited_once()
         failure = mock_tools.send_failure.call_args.args[0]
         assert failure.provider == "pydantic_ai"
-        assert failure.message == "provider connection reset"
+        assert failure.message == GENERIC_PROVIDER_FAILURE_MESSAGE
 
     @pytest.mark.asyncio
     async def test_empty_output_after_read_only_tool_propagates(
@@ -1968,7 +2000,10 @@ class TestCustomTools:
 
         result_messages = [ModelRequest(parts=[UserPromptPart(content="test")])]
         adapter._agent.run_stream_events = MagicMock(
-            return_value=make_stream_events(result_messages=result_messages)
+            return_value=make_stream_events(
+                result_messages=result_messages,
+                tool_results=[("band_send_message", "Message sent", "call-1")],
+            )
         )
 
         # Should not raise

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -635,6 +635,7 @@ class TestTurnFailure:
         assert usage[0]["metadata"][USAGE_METADATA_KEY]["input_tokens"] == (
             _INPUT_TOKENS_PER_CALL
         )
+        assert "provider down" in _errors(tools)[0]
 
 
 class TestUsageMapping:

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -35,7 +35,11 @@ from band.adapters.strands import (  # noqa: E402
     _tool_result,
 )
 from band.converters.strands import StrandsHistoryConverter  # noqa: E402
-from band.core.protocols import AgentToolsProtocol  # noqa: E402
+from band.core.protocols import (  # noqa: E402
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    AgentToolsProtocol,
+    TurnResultAlreadyReported,
+)
 from band.core.types import (  # noqa: E402
     USAGE_METADATA_KEY,
     AgentInput,
@@ -447,11 +451,16 @@ class TestOnMessage:
         A later turn that reseeded would replay the room's own transcript on top
         of the one the adapter is already holding.
         """
-        adapter = await scripted(SEND_TURN, SEND_TURN)
+        adapter = await scripted(SEND_TURN)
         await _run_message(adapter, tools, history=[])
         after_first = list(adapter._message_history[ROOM])
 
-        await _run_message(adapter, tools, history=[], is_session_bootstrap=False)
+        # The scripted model has no turn left for a second reply, so this
+        # turn ends without calling band_send_message -- irrelevant to what
+        # this test checks (the transcript isn't re-seeded), so only the
+        # failure is asserted here, not suppressed.
+        with pytest.raises(TurnResultAlreadyReported):
+            await _run_message(adapter, tools, history=[], is_session_bootstrap=False)
 
         assert adapter._message_history[ROOM][: len(after_first)] == after_first
 
@@ -526,7 +535,8 @@ class TestTurnProductivity:
         tools = FailingTools(room_id=ROOM)
         adapter = await scripted(SEND_TURN)
 
-        await _run_message(adapter, tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await _run_message(adapter, tools)
 
         assert tools.messages_sent == []
         assert len(_errors(tools)) == 1
@@ -548,7 +558,8 @@ class TestTurnProductivity:
         tools = FailingTools(room_id=ROOM)
         adapter = await scripted(SEND_TURN, emit=Emit.TOOL_CALLS)
 
-        await _run_message(adapter, tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await _run_message(adapter, tools)
 
         rehydrated = StrandsHistoryConverter(agent_name="Bot").convert(
             [
@@ -570,7 +581,8 @@ class TestTurnProductivity:
         """Looking peers up succeeds but posts nothing, so the reply is still missing."""
         adapter = await scripted(ToolTurn("band_lookup_peers", {}))
 
-        await _run_message(adapter, tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await _run_message(adapter, tools)
 
         assert _tool_results(adapter)  # the lookup did run and succeed
         assert tools.messages_sent == []
@@ -583,7 +595,8 @@ class TestTurnProductivity:
         """A malformed call is the model's mistake to correct, not a turn-ending crash."""
         adapter = await scripted(ToolTurn("band_send_message", {"mentions": ["@x"]}))
 
-        await _run_message(adapter, tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await _run_message(adapter, tools)
 
         assert tools.messages_sent == []
         assert _tool_results(adapter) == [
@@ -604,7 +617,8 @@ class TestTurnProductivity:
             ToolTurn("boom", {"note": "go"}), additional_tools=[(BoomInput, boom)]
         )
 
-        await _run_message(adapter, tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await _run_message(adapter, tools)
 
         assert _tool_results(adapter) == ["Error executing tool 'boom': no network"]
 
@@ -635,7 +649,7 @@ class TestTurnFailure:
         assert usage[0]["metadata"][USAGE_METADATA_KEY]["input_tokens"] == (
             _INPUT_TOKENS_PER_CALL
         )
-        assert "provider down" in _errors(tools)[0]
+        assert GENERIC_PROVIDER_FAILURE_MESSAGE in _errors(tools)[0]
 
 
 class TestUsageMapping:
@@ -780,7 +794,8 @@ class TestSendRoomFileArgsRedaction:
         )
         await adapter.on_started("Bot", "A bot")
 
-        await _run_message(adapter, tools)
+        with pytest.raises(TurnResultAlreadyReported):
+            await _run_message(adapter, tools)
 
         tool_calls = [
             json.loads(e["content"])

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -57,6 +57,7 @@ from band.testing import (  # noqa: E402
     ScriptedStrandsModel,
     ScriptedTurn,
     ToolTurn,
+    reported_failures,
 )
 
 _INPUT_TOKENS_PER_CALL = 7
@@ -144,10 +145,6 @@ def _alternates(history: list) -> bool:
     """Whether the transcript never puts two same-role turns in a row."""
     roles = [message["role"] for message in history]
     return all(first != second for first, second in zip(roles, roles[1:]))
-
-
-def _errors(tools: FakeAgentTools) -> list[str]:
-    return [e["content"] for e in tools.events_sent if e["message_type"] == "error"]
 
 
 class TestCustomToolWiring:
@@ -539,7 +536,9 @@ class TestTurnProductivity:
             await _run_message(adapter, tools)
 
         assert tools.messages_sent == []
-        assert len(_errors(tools)) == 1
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["provider"] == "strands"
         # The shared bridge returns a normalized, model-visible tool failure.
         assert any(
             text.startswith("Error executing band_send_message:")
@@ -586,7 +585,9 @@ class TestTurnProductivity:
 
         assert _tool_results(adapter)  # the lookup did run and succeed
         assert tools.messages_sent == []
-        assert "band_send_message" in _errors(tools)[0]
+        failure = reported_failures(tools)[0]
+        assert failure["provider"] == "strands"
+        assert "band_send_message" in failure["message"]
 
     @pytest.mark.asyncio
     async def test_invalid_tool_arguments_are_answered_not_raised(
@@ -649,7 +650,9 @@ class TestTurnFailure:
         assert usage[0]["metadata"][USAGE_METADATA_KEY]["input_tokens"] == (
             _INPUT_TOKENS_PER_CALL
         )
-        assert GENERIC_PROVIDER_FAILURE_MESSAGE in _errors(tools)[0]
+        failure = reported_failures(tools)[0]
+        assert failure["provider"] == "strands"
+        assert failure["message"] == GENERIC_PROVIDER_FAILURE_MESSAGE
 
 
 class TestUsageMapping:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,13 @@ return SDK-native types for pattern matching compatibility.
 
 from __future__ import annotations
 
-import asyncio
 import os
+
+# Must be set before crewai is first imported: its event bus installs a
+# global OpenTelemetry provider and a live exporter thread at import time.
+os.environ.setdefault("CREWAI_DISABLE_TELEMETRY", "true")
+
+import asyncio
 from datetime import datetime, timezone
 from functools import cache
 from itertools import count

--- a/tests/core/test_delivery.py
+++ b/tests/core/test_delivery.py
@@ -1,0 +1,32 @@
+"""Tests for the delivery-vs-provider-failure misclassification guard."""
+
+from __future__ import annotations
+
+import pytest
+
+from band.core.delivery import DeliveryFailedError, deliver_reply
+from band.testing.fake_tools import FakeAgentTools
+
+
+class TestDeliverReply:
+    async def test_forwards_a_successful_send(self) -> None:
+        tools = FakeAgentTools()
+
+        result = await deliver_reply(tools, "hello", mentions=["@alice"])
+
+        assert tools.messages_sent[0]["content"] == "hello"
+        assert result["content"] == "hello"
+
+    async def test_wraps_a_send_message_failure(self) -> None:
+        """A raised send_message must become DeliveryFailedError, not
+        propagate as-is -- so a shared except block reading for a provider
+        failure can tell delivery and provider failures apart."""
+        tools = FakeAgentTools()
+
+        with pytest.raises(DeliveryFailedError) as exc_info:
+            # FakeAgentTools.send_message raises BandToolError for a
+            # mention-less send, mirroring the real platform requirement.
+            await deliver_reply(tools, "hello", mentions=None)
+
+        assert exc_info.value.__cause__ is exc_info.value.cause
+        assert "mention" in str(exc_info.value.cause).lower()

--- a/tests/core/test_protocols.py
+++ b/tests/core/test_protocols.py
@@ -1,0 +1,50 @@
+"""Tests for shared AgentToolsProtocol helpers."""
+
+from __future__ import annotations
+
+import pytest
+from band_sdk_core import AgentFailure
+
+from band.core.protocols import to_failure_event
+
+
+class TestToFailureEvent:
+    """``to_failure_event`` is the one place both SDKs put the failure ->
+    room-event shape, so its parity string and metadata key are load-bearing."""
+
+    def test_carries_the_message_and_failure_metadata(self) -> None:
+        failure = AgentFailure("codex", "boom", "timeout", {"http_status": 500})
+
+        content, metadata = to_failure_event(failure)
+
+        assert content == "boom"
+        assert metadata == {
+            "failure": {
+                "provider": "codex",
+                "code": "timeout",
+                "message": "boom",
+                "detail": {"http_status": 500},
+            }
+        }
+
+    @pytest.mark.parametrize("blank_message", ["", "   ", "\n\t"])
+    def test_blank_message_falls_back_to_a_generic_one(
+        self, blank_message: str
+    ) -> None:
+        """A provider message can arrive blank -- the platform rejects a blank
+        chat event, so an unguarded blank message would make the failure
+        vanish from the room entirely. The fallback string must match TS's
+        ``toFailureEvent`` exactly for cross-SDK parity."""
+        content, _metadata = to_failure_event(AgentFailure("acp", blank_message))
+
+        assert content == "acp failed without an error message."
+
+    def test_generic_fallback_has_no_code_or_detail(self) -> None:
+        """A provider/adapter that gives no structured signal at all still
+        produces a valid failure -- code and detail default to None rather
+        than an invented value."""
+        content, metadata = to_failure_event(AgentFailure("anthropic", "boom"))
+
+        assert content == "boom"
+        assert metadata["failure"]["code"] is None
+        assert metadata["failure"]["detail"] is None

--- a/tests/core/test_protocols.py
+++ b/tests/core/test_protocols.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from band_sdk_core import AgentFailure
 
-from band.core.protocols import to_failure_event
+from band.core.protocols import send_event_safe, to_failure_event
+from band.testing.fake_tools import FakeAgentTools
 
 
 class TestToFailureEvent:
@@ -48,3 +51,51 @@ class TestToFailureEvent:
         assert content == "boom"
         assert metadata["failure"]["code"] is None
         assert metadata["failure"]["detail"] is None
+
+
+class TestSendEventSafe:
+    """send_event_safe is the shared best-effort event sender every migrated
+    adapter's non-critical telemetry (thoughts, task/lifecycle markers) goes
+    through -- a regression here silently drops events across every one of
+    them."""
+
+    async def test_forwards_a_successful_send_and_returns_true(self) -> None:
+        tools = FakeAgentTools()
+
+        sent = await send_event_safe(tools, "hello", "thought")
+
+        assert sent is True
+        assert tools.events_sent[0]["content"] == "hello"
+
+    async def test_swallows_a_send_event_failure_and_logs_at_the_given_level(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        tools = FakeAgentTools()
+        tools.send_event_error = RuntimeError("platform rejected the event")
+
+        with caplog.at_level(logging.DEBUG, logger="band.core.protocols"):
+            sent = await send_event_safe(
+                tools,
+                "hello",
+                "task",
+                log_label="widget event",
+                log_level=logging.DEBUG,
+            )
+
+        assert sent is False
+        assert tools.events_sent == []
+        record = next(r for r in caplog.records if r.name == "band.core.protocols")
+        assert record.levelno == logging.DEBUG
+        assert "widget event" in record.message
+
+    async def test_default_log_level_is_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        tools = FakeAgentTools()
+        tools.send_event_error = RuntimeError("boom")
+
+        with caplog.at_level(logging.WARNING, logger="band.core.protocols"):
+            await send_event_safe(tools, "hello", "task")
+
+        record = next(r for r in caplog.records if r.name == "band.core.protocols")
+        assert record.levelno == logging.WARNING

--- a/tests/docker/launcher/conftest.py
+++ b/tests/docker/launcher/conftest.py
@@ -7,6 +7,7 @@ and pins the apparent uid to the agent uid the launcher requires.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -28,6 +29,13 @@ def scrub_launcher_env(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture(autouse=True)
 def as_agent_uid(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(launcher_run, "current_uid", lambda: AGENT_UID)
+
+
+@pytest.fixture(autouse=True)
+def restore_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() sets the real process HOME as a deliberate side effect; pin it
+    through monkeypatch so a test calling main() in-process doesn't leak it."""
+    monkeypatch.setenv("HOME", os.environ.get("HOME", ""))
 
 
 @pytest.fixture

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -625,10 +625,10 @@ def _build_codex_config() -> AdapterConfig:
             "config": CodexAdapterConfig(),
         },
         custom_kwargs={
-            "config": CodexAdapterConfig(structured_errors=False),
+            "config": CodexAdapterConfig(stream_plan_events=True),
         },
         custom_expected={
-            "config": CodexAdapterConfig(structured_errors=False),
+            "config": CodexAdapterConfig(stream_plan_events=True),
         },
         has_custom_tools_attr=True,
         custom_tools_attr="_custom_tools",

--- a/tests/framework_conformance/test_strands_injection_spike.py
+++ b/tests/framework_conformance/test_strands_injection_spike.py
@@ -66,7 +66,10 @@ from pydantic import BaseModel
 pytest.importorskip("strands", reason="strands extra not installed")
 
 from band.adapters.strands import StrandsAdapter  # noqa: E402
-from band.core.protocols import AgentToolsProtocol  # noqa: E402
+from band.core.protocols import (  # noqa: E402
+    AgentToolsProtocol,
+    TurnResultAlreadyReported,
+)
 from band.core.types import Emit, PlatformMessage  # noqa: E402
 from band.testing import (  # noqa: E402
     FakeAgentTools,
@@ -205,7 +208,8 @@ async def test_negative_control_text_only_sends_no_message() -> None:
     adapter = StrandsAdapter(
         model=ScriptedStrandsModel([TextTurn("just a reply, no tools")])
     )
-    await _run(adapter, tools, room_id)
+    with pytest.raises(TurnResultAlreadyReported):
+        await _run(adapter, tools, room_id)
 
     assert tools.messages_sent == [], (
         f"expected no send for a text-only decision, got: {tools.messages_sent}"

--- a/tests/integrations/a2a/gateway/test_adapter.py
+++ b/tests/integrations/a2a/gateway/test_adapter.py
@@ -24,7 +24,11 @@ from a2a.types import (
 from band.core.types import PlatformMessage
 from band.client.rest import DEFAULT_REQUEST_OPTIONS
 from band.integrations.a2a.gateway import A2AGatewayAdapter, A2AGatewayAdapterConfig
-from band.integrations.a2a.gateway.adapter import BandAgentExecutor, GatewayRequest
+from band.integrations.a2a.gateway.adapter import (
+    BandAgentExecutor,
+    GatewayRequest,
+    _redact_credentials,
+)
 from band.integrations.a2a.gateway.types import GatewaySessionState, PendingA2ATask
 from band.testing import FakeAgentTools
 from tests.integrations.a2a.gateway.helpers import make_peer, peers_page
@@ -356,6 +360,13 @@ class TestGatewayExecution:
         assert "Bearer [REDACTED]" in message
         assert "api_key=[REDACTED]" in message
 
+    def test_redact_credentials_full_value_scheme_prefixed(self) -> None:
+        """A scheme-prefixed credential value (a space between the key and
+        the secret) must be redacted in full, not just up to that space."""
+        redacted = _redact_credentials("Authorization: ApiKey sk-live-abcdef123456")
+        assert "sk-live-abcdef123456" not in redacted
+        assert redacted == "Authorization=[REDACTED]"
+
     @pytest.mark.asyncio
     async def test_establish_request_raises_when_peer_missing(self) -> None:
         adapter = A2AGatewayAdapter(rest_client=MagicMock())
@@ -611,6 +622,36 @@ class TestGatewayResponses:
         assert event.status.state == TaskState.TASK_STATE_FAILED
         assert event.metadata["failure"]["provider"] == "codex"
         assert event.metadata["failure"]["code"] == "ContextWindowExceeded"
+
+    @pytest.mark.asyncio
+    async def test_relayed_peer_failure_redacts_embedded_credentials(self) -> None:
+        """A peer's own AgentFailure can embed a raw provider exception
+        message -- redact it the same as this gateway's own exception path
+        before it reaches an external A2A client."""
+        adapter = A2AGatewayAdapter(rest_client=MagicMock())
+        queue = EventQueueLegacy()
+        pending = make_pending(queue)
+        secret_message = "upstream rejected token=sk-live-secret"
+        peer_failure = {
+            "provider": "codex",
+            "code": "Unauthorized",
+            "message": secret_message,
+            "detail": None,
+        }
+
+        await adapter._publish_band_response(
+            pending,
+            make_platform_message(
+                secret_message,
+                message_type="error",
+                metadata={"failure": peer_failure},
+            ),
+        )
+        event = await queue.dequeue_event()
+
+        assert event.status.state == TaskState.TASK_STATE_FAILED
+        assert "sk-live-secret" not in event.metadata["failure"]["message"]
+        assert "sk-live-secret" not in event.status.message.parts[0].text
 
     @pytest.mark.asyncio
     async def test_plain_error_message_without_failure_metadata_still_fails(

--- a/tests/integrations/a2a/gateway/test_adapter.py
+++ b/tests/integrations/a2a/gateway/test_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -33,6 +34,7 @@ def make_platform_message(
     content: str,
     room_id: str = "room-123",
     message_type: str = "text",
+    metadata: dict[str, Any] | None = None,
 ) -> PlatformMessage:
     return PlatformMessage(
         id=str(uuid4()),
@@ -42,7 +44,7 @@ def make_platform_message(
         sender_type="Agent",
         sender_name="Weather Agent",
         message_type=message_type,
-        metadata={},
+        metadata=metadata if metadata is not None else {},
         created_at=datetime.now(),
     )
 
@@ -295,6 +297,8 @@ class TestGatewayExecution:
         await queue.dequeue_event()
         terminal = await queue.dequeue_event()
         assert terminal.status.state == TaskState.TASK_STATE_FAILED
+        assert terminal.metadata["failure"]["provider"] == "a2a-gateway"
+        assert terminal.metadata["failure"]["code"] == "Timeout"
         assert adapter._pending_tasks == {}
         assert not any(
             "A2A request completed" in record.message for record in caplog.records
@@ -322,6 +326,35 @@ class TestGatewayExecution:
         assert terminal.status.message.parts[0].text == "A2A request failed"
         assert "Band unavailable" not in terminal.status.message.parts[0].text
         assert adapter._pending_tasks == {}
+        failure = terminal.metadata["failure"]
+        assert failure["provider"] == "a2a-gateway"
+        assert failure["code"] == "RuntimeError"
+        assert "Band unavailable" in failure["message"]
+
+    @pytest.mark.asyncio
+    async def test_send_failure_redacts_secrets_from_reported_metadata(self) -> None:
+        """The sanitized exception text reaches the A2A client's metadata --
+        a leaked bearer token or API key must not."""
+        adapter = A2AGatewayAdapter(rest_client=MagicMock())
+        adapter._peers = {"weather": make_peer("weather", "Weather Agent")}
+        configure_room_creation(adapter)
+        adapter._rest.agent_api_messages.create_agent_chat_message = AsyncMock(
+            side_effect=RuntimeError(
+                "upstream rejected Bearer abc123.def456 (api_key=sk-live-secret)"
+            )
+        )
+        queue = EventQueueLegacy()
+
+        with pytest.raises(RuntimeError):
+            await BandAgentExecutor(adapter, "weather").execute(make_request(), queue)
+
+        await queue.dequeue_event()
+        terminal = await queue.dequeue_event()
+        message = terminal.metadata["failure"]["message"]
+        assert "abc123.def456" not in message
+        assert "sk-live-secret" not in message
+        assert "Bearer [REDACTED]" in message
+        assert "api_key=[REDACTED]" in message
 
     @pytest.mark.asyncio
     async def test_establish_request_raises_when_peer_missing(self) -> None:
@@ -378,6 +411,7 @@ class TestGatewayExecution:
 
         terminal = await queue.dequeue_event()
         assert terminal.status.state == TaskState.TASK_STATE_FAILED
+        assert not terminal.metadata, "a gateway shutdown is not a provider failure"
         assert pending.done.is_set()
         assert adapter._pending_tasks == {}
 
@@ -409,6 +443,7 @@ class TestGatewayExecution:
 
         terminal = await queue.dequeue_event()
         assert terminal.status.state == TaskState.TASK_STATE_FAILED
+        assert not terminal.metadata, "a room closing is not a provider failure"
         assert pending.done.is_set()
         assert adapter._pending_tasks == {}
 
@@ -547,3 +582,51 @@ class TestGatewayResponses:
 
         assert event.status.state == state
         assert event.status.message.parts[0].text == "response"
+
+    @pytest.mark.asyncio
+    async def test_relays_peers_own_agent_failure_unchanged(self) -> None:
+        """The peer's adapter already built this AgentFailure (send_failure) --
+        the gateway must relay it as-is, not re-tag its provider as
+        "a2a-gateway"."""
+        adapter = A2AGatewayAdapter(rest_client=MagicMock())
+        queue = EventQueueLegacy()
+        pending = make_pending(queue)
+        peer_failure = {
+            "provider": "codex",
+            "code": "ContextWindowExceeded",
+            "message": "context window exceeded",
+            "detail": None,
+        }
+
+        await adapter._publish_band_response(
+            pending,
+            make_platform_message(
+                "context window exceeded",
+                message_type="error",
+                metadata={"failure": peer_failure},
+            ),
+        )
+        event = await queue.dequeue_event()
+
+        assert event.status.state == TaskState.TASK_STATE_FAILED
+        assert event.metadata["failure"]["provider"] == "codex"
+        assert event.metadata["failure"]["code"] == "ContextWindowExceeded"
+
+    @pytest.mark.asyncio
+    async def test_plain_error_message_without_failure_metadata_still_fails(
+        self,
+    ) -> None:
+        """A peer that never migrated to send_failure still fails the task --
+        it just carries no structured metadata."""
+        adapter = A2AGatewayAdapter(rest_client=MagicMock())
+        queue = EventQueueLegacy()
+        pending = make_pending(queue)
+
+        await adapter._publish_band_response(
+            pending,
+            make_platform_message("something broke", message_type="error"),
+        )
+        event = await queue.dequeue_event()
+
+        assert event.status.state == TaskState.TASK_STATE_FAILED
+        assert not event.metadata

--- a/tests/integrations/a2a/gateway/test_adapter.py
+++ b/tests/integrations/a2a/gateway/test_adapter.py
@@ -298,7 +298,7 @@ class TestGatewayExecution:
         terminal = await queue.dequeue_event()
         assert terminal.status.state == TaskState.TASK_STATE_FAILED
         assert terminal.metadata["failure"]["provider"] == "a2a-gateway"
-        assert terminal.metadata["failure"]["code"] == "Timeout"
+        assert terminal.metadata["failure"]["code"] == "timeout"
         assert adapter._pending_tasks == {}
         assert not any(
             "A2A request completed" in record.message for record in caplog.records

--- a/tests/integrations/a2a/test_adapter.py
+++ b/tests/integrations/a2a/test_adapter.py
@@ -30,7 +30,7 @@ from band.core.protocols import (
 from band.core.types import PlatformMessage
 from band.integrations.a2a import A2AAdapter, A2AAuth, A2ASessionState
 from band.integrations.a2a.adapter import _SSE_READ_TIMEOUT_S
-from band.testing import FakeAgentTools
+from band.testing import FakeAgentTools, reported_failures
 
 
 def make_platform_message(content: str = "Hello") -> PlatformMessage:
@@ -361,7 +361,7 @@ class TestA2AAdapterMessageFlow:
         ]
         assert error_events, "an auth-required task must produce an error event"
         assert error_events[-1]["content"] == "Please authenticate"
-        failure = error_events[-1]["metadata"]["failure"]
+        failure = reported_failures(tools)[-1]
         assert failure["provider"] == "a2a"
         assert failure["code"] == "TASK_STATE_AUTH_REQUIRED"
 
@@ -464,7 +464,7 @@ class TestA2AAdapterMessageFlow:
         ]
         assert error_events, "a failed task must produce an error event"
         assert error_events[-1]["content"] == "boom"
-        failure = error_events[-1]["metadata"]["failure"]
+        failure = reported_failures(tools)[-1]
         assert failure["provider"] == "a2a"
         assert failure["code"] == "TASK_STATE_FAILED"
 

--- a/tests/integrations/a2a/test_adapter.py
+++ b/tests/integrations/a2a/test_adapter.py
@@ -313,6 +313,26 @@ class TestA2AAdapterMessageFlow:
         assert adapter._task_senders == {}
 
     @pytest.mark.asyncio
+    async def test_finally_block_failure_does_not_replace_try_blocks_exception(
+        self, adapter: A2AAdapter
+    ) -> None:
+        """The terminal task-event emission in ``finally`` must never clobber
+        a ``DeliveryFailedError`` already propagating from the try block --
+        Python's try/finally semantics otherwise let the finally's own
+        exception silently replace it."""
+        tools = FakeAgentTools()
+        tools.send_message = AsyncMock(side_effect=RuntimeError("Band unavailable"))
+        tools.send_event_error = RuntimeError("task event post also failed")
+        task = make_task(artifact_text="Final response")
+
+        with pytest.raises(DeliveryFailedError) as exc_info:
+            await adapter._handle_event(
+                task_event(task), tools, "room-123", "user-456", "Test User"
+            )
+        assert "Band unavailable" in str(exc_info.value.cause)
+        assert adapter._tasks == {}, "next turn must start a fresh task"
+
+    @pytest.mark.asyncio
     async def test_auth_required_task_is_posted_as_error_event(
         self, adapter: A2AAdapter
     ) -> None:

--- a/tests/integrations/a2a/test_adapter.py
+++ b/tests/integrations/a2a/test_adapter.py
@@ -23,6 +23,10 @@ from a2a.types import (
 )
 
 from band.core.delivery import DeliveryFailedError
+from band.core.protocols import (
+    GENERIC_PROVIDER_FAILURE_MESSAGE,
+    TurnResultAlreadyReported,
+)
 from band.core.types import PlatformMessage
 from band.integrations.a2a import A2AAdapter, A2AAuth, A2ASessionState
 from band.integrations.a2a.adapter import _SSE_READ_TIMEOUT_S
@@ -338,18 +342,19 @@ class TestA2AAdapterMessageFlow:
     ) -> None:
         tools = FakeAgentTools()
 
-        await adapter._handle_event(
-            task_event(
-                make_task(
-                    TaskState.TASK_STATE_AUTH_REQUIRED,
-                    status_message="Please authenticate",
-                )
-            ),
-            tools,
-            "room-123",
-            "user-456",
-            "Test User",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter._handle_event(
+                task_event(
+                    make_task(
+                        TaskState.TASK_STATE_AUTH_REQUIRED,
+                        status_message="Please authenticate",
+                    )
+                ),
+                tools,
+                "room-123",
+                "user-456",
+                "Test User",
+            )
 
         error_events = [
             event for event in tools.events_sent if event["message_type"] == "error"
@@ -407,7 +412,7 @@ class TestA2AAdapterMessageFlow:
             )
 
         assert tools.events_sent[-1]["message_type"] == "error"
-        assert "remote down" in tools.events_sent[-1]["content"]
+        assert tools.events_sent[-1]["content"] == GENERIC_PROVIDER_FAILURE_MESSAGE
 
     @pytest.mark.asyncio
     async def test_on_message_reraises_delivery_failure_without_reporting_it(
@@ -443,13 +448,16 @@ class TestA2AAdapterMessageFlow:
     ) -> None:
         tools = FakeAgentTools()
 
-        await adapter._handle_event(
-            task_event(make_task(TaskState.TASK_STATE_FAILED, status_message="boom")),
-            tools,
-            "room-123",
-            "user-456",
-            "Test User",
-        )
+        with pytest.raises(TurnResultAlreadyReported):
+            await adapter._handle_event(
+                task_event(
+                    make_task(TaskState.TASK_STATE_FAILED, status_message="boom")
+                ),
+                tools,
+                "room-123",
+                "user-456",
+                "Test User",
+            )
 
         error_events = [
             event for event in tools.events_sent if event["message_type"] == "error"

--- a/tests/integrations/a2a/test_adapter.py
+++ b/tests/integrations/a2a/test_adapter.py
@@ -22,6 +22,7 @@ from a2a.types import (
     TaskStatus,
 )
 
+from band.core.delivery import DeliveryFailedError
 from band.core.types import PlatformMessage
 from band.integrations.a2a import A2AAdapter, A2AAuth, A2ASessionState
 from band.integrations.a2a.adapter import _SSE_READ_TIMEOUT_S
@@ -298,10 +299,11 @@ class TestA2AAdapterMessageFlow:
         tools.send_message = AsyncMock(side_effect=RuntimeError("Band unavailable"))
         task = make_task(artifact_text="Final response")
 
-        with pytest.raises(RuntimeError, match="Band unavailable"):
+        with pytest.raises(DeliveryFailedError) as exc_info:
             await adapter._handle_event(
                 task_event(task), tools, "room-123", "user-456", "Test User"
             )
+        assert "Band unavailable" in str(exc_info.value.cause)
 
         assert tools.events_sent[-1]["metadata"]["a2a_task_state"] == (
             "TASK_STATE_COMPLETED"
@@ -334,7 +336,9 @@ class TestA2AAdapterMessageFlow:
         ]
         assert error_events, "an auth-required task must produce an error event"
         assert error_events[-1]["content"] == "Please authenticate"
-        assert error_events[-1]["metadata"]["a2a_state"] == "TASK_STATE_AUTH_REQUIRED"
+        failure = error_events[-1]["metadata"]["failure"]
+        assert failure["provider"] == "a2a"
+        assert failure["code"] == "TASK_STATE_AUTH_REQUIRED"
 
     @pytest.mark.asyncio
     async def test_input_required_is_forwarded_and_persisted(
@@ -403,7 +407,9 @@ class TestA2AAdapterMessageFlow:
         ]
         assert error_events, "a failed task must produce an error event"
         assert error_events[-1]["content"] == "boom"
-        assert error_events[-1]["metadata"]["a2a_state"] == "TASK_STATE_FAILED"
+        failure = error_events[-1]["metadata"]["failure"]
+        assert failure["provider"] == "a2a"
+        assert failure["code"] == "TASK_STATE_FAILED"
 
     @pytest.mark.asyncio
     async def test_working_status_text_is_narrated_as_thought(

--- a/tests/integrations/a2a/test_adapter.py
+++ b/tests/integrations/a2a/test_adapter.py
@@ -356,14 +356,11 @@ class TestA2AAdapterMessageFlow:
                 "Test User",
             )
 
-        error_events = [
-            event for event in tools.events_sent if event["message_type"] == "error"
-        ]
-        assert error_events, "an auth-required task must produce an error event"
-        assert error_events[-1]["content"] == "Please authenticate"
-        failure = reported_failures(tools)[-1]
-        assert failure["provider"] == "a2a"
-        assert failure["code"] == "TASK_STATE_AUTH_REQUIRED"
+        failures = reported_failures(tools)
+        assert failures, "an auth-required task must produce an error event"
+        assert failures[-1]["message"] == "Please authenticate"
+        assert failures[-1]["provider"] == "a2a"
+        assert failures[-1]["code"] == "TASK_STATE_AUTH_REQUIRED"
 
     @pytest.mark.asyncio
     async def test_input_required_is_forwarded_and_persisted(
@@ -459,14 +456,11 @@ class TestA2AAdapterMessageFlow:
                 "Test User",
             )
 
-        error_events = [
-            event for event in tools.events_sent if event["message_type"] == "error"
-        ]
-        assert error_events, "a failed task must produce an error event"
-        assert error_events[-1]["content"] == "boom"
-        failure = reported_failures(tools)[-1]
-        assert failure["provider"] == "a2a"
-        assert failure["code"] == "TASK_STATE_FAILED"
+        failures = reported_failures(tools)
+        assert failures, "a failed task must produce an error event"
+        assert failures[-1]["message"] == "boom"
+        assert failures[-1]["provider"] == "a2a"
+        assert failures[-1]["code"] == "TASK_STATE_FAILED"
 
     @pytest.mark.asyncio
     async def test_working_status_text_is_narrated_as_thought(

--- a/tests/integrations/a2a/test_adapter.py
+++ b/tests/integrations/a2a/test_adapter.py
@@ -388,25 +388,54 @@ class TestA2AAdapterMessageFlow:
     async def test_remote_error_is_posted_as_error_event(
         self, adapter: A2AAdapter
     ) -> None:
-        """A remote A2A outage must surface in the room, not crash the turn."""
+        """A remote A2A outage must surface in the room and fail the turn."""
         adapter._client = MagicMock()
         adapter._client.send_message = MagicMock(
             side_effect=RuntimeError("remote down")
         )
         tools = FakeAgentTools()
 
-        await adapter.on_message(
-            make_platform_message(),
-            tools,
-            A2ASessionState(),
-            None,
-            None,
-            is_session_bootstrap=False,
-            room_id="room-123",
-        )
+        with pytest.raises(RuntimeError, match="remote down"):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                A2ASessionState(),
+                None,
+                None,
+                is_session_bootstrap=False,
+                room_id="room-123",
+            )
 
         assert tools.events_sent[-1]["message_type"] == "error"
         assert "remote down" in tools.events_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_on_message_reraises_delivery_failure_without_reporting_it(
+        self, adapter: A2AAdapter
+    ) -> None:
+        """A Band-side post failure must fail the turn for retry, without
+        being reported as an A2A provider failure."""
+        adapter._client = MagicMock()
+
+        async def _events() -> AsyncIterator[StreamResponse]:
+            yield task_event(make_task(artifact_text="Final response"))
+
+        adapter._client.send_message = MagicMock(return_value=_events())
+        tools = FakeAgentTools()
+        tools.send_message = AsyncMock(side_effect=RuntimeError("Band unavailable"))
+
+        with pytest.raises(RuntimeError, match="Band unavailable"):
+            await adapter.on_message(
+                make_platform_message(),
+                tools,
+                A2ASessionState(),
+                None,
+                None,
+                is_session_bootstrap=False,
+                room_id="room-123",
+            )
+
+        assert not [e for e in tools.events_sent if e["message_type"] == "error"]
 
     @pytest.mark.asyncio
     async def test_failed_task_is_posted_as_error_event(

--- a/tests/integrations/acp/acp_toolkit/harness.py
+++ b/tests/integrations/acp/acp_toolkit/harness.py
@@ -214,6 +214,23 @@ class AcpSession:
     def __init__(self, adapter: ACPClientAdapter, agent: FakeACPAgent) -> None:
         self.adapter = adapter
         self.agent = agent
+        self._last_tools: TranscriptTools | None = None
+
+    @property
+    def last_reply(self) -> Reply:
+        """What the most recent ``send`` posted, even if it raised.
+
+        A genuine provider failure now fails the turn (raises out of
+        ``on_message``) instead of returning normally, so a test covering
+        that path can't get the posted error event from ``send``'s return
+        value — it reads this instead.
+        """
+        assert self._last_tools is not None, "send() has not been called yet"
+        return Reply(
+            messages=self._last_tools.messages_sent,
+            events=self._last_tools.events_sent,
+            transcript=self._last_tools.transcript,
+        )
 
     async def send(
         self,
@@ -238,6 +255,7 @@ class AcpSession:
         tools = TranscriptTools()
         if room_context is not None:
             tools.set_room_context(room_context)
+        self._last_tools = tools
         await self.adapter.on_message(
             _message(content, room),
             tools,

--- a/tests/integrations/acp/test_client_adapter.py
+++ b/tests/integrations/acp/test_client_adapter.py
@@ -11,6 +11,7 @@ from acp.exceptions import RequestError
 from acp.helpers import update_agent_message_text
 
 from band.converters.parsing import parse_tool_call, parse_tool_result
+from band.core.protocols import GENERIC_PROVIDER_FAILURE_MESSAGE
 from band.core.types import Capability
 from band.integrations.acp.client_adapter import ACPClientAdapter, _resolve_launcher
 from band.integrations.acp.client_profiles import CursorACPClientProfile
@@ -749,20 +750,21 @@ class TestACPClientAdapterOnMessage:
         tools = FakeAgentTools()
         msg = make_platform_message("Hello", room_id="room-123")
 
-        await adapter_with_mocks.on_message(
-            msg,
-            tools,
-            ACPClientSessionState(),
-            None,
-            None,
-            is_session_bootstrap=False,
-            room_id="room-123",
-        )
+        with pytest.raises(RuntimeError, match="Agent crashed"):
+            await adapter_with_mocks.on_message(
+                msg,
+                tools,
+                ACPClientSessionState(),
+                None,
+                None,
+                is_session_bootstrap=False,
+                room_id="room-123",
+            )
 
         failures = reported_failures(tools)
         assert len(failures) == 1
         assert failures[0]["provider"] == "acp"
-        assert "Agent crashed" in failures[0]["message"]
+        assert failures[0]["message"] == GENERIC_PROVIDER_FAILURE_MESSAGE
 
     @pytest.mark.asyncio
     async def test_on_message_request_error_captures_code_and_data(
@@ -776,15 +778,16 @@ class TestACPClientAdapterOnMessage:
         tools = FakeAgentTools()
         msg = make_platform_message("Hello", room_id="room-123")
 
-        await adapter_with_mocks.on_message(
-            msg,
-            tools,
-            ACPClientSessionState(),
-            None,
-            None,
-            is_session_bootstrap=False,
-            room_id="room-123",
-        )
+        with pytest.raises(RequestError):
+            await adapter_with_mocks.on_message(
+                msg,
+                tools,
+                ACPClientSessionState(),
+                None,
+                None,
+                is_session_bootstrap=False,
+                room_id="room-123",
+            )
 
         failures = reported_failures(tools)
         assert len(failures) == 1
@@ -1336,15 +1339,16 @@ class TestACPClientAdapterDeadConnectionRecovery:
         tools = FakeAgentTools()
         msg = make_platform_message("Hello", room_id="room-1")
 
-        await adapter.on_message(
-            msg,
-            tools,
-            ACPClientSessionState(),
-            None,
-            None,
-            is_session_bootstrap=False,
-            room_id="room-1",
-        )
+        with pytest.raises(RuntimeError, match="Process died"):
+            await adapter.on_message(
+                msg,
+                tools,
+                ACPClientSessionState(),
+                None,
+                None,
+                is_session_bootstrap=False,
+                room_id="room-1",
+            )
 
         # Connection should be cleared after error
         assert adapter._runtime._conn is None
@@ -1386,15 +1390,16 @@ class TestACPClientAdapterDeadConnectionRecovery:
 
         msg = make_platform_message("Hello", room_id="room-1")
 
-        await adapter.on_message(
-            msg,
-            tools,
-            ACPClientSessionState(),
-            None,
-            None,
-            is_session_bootstrap=False,
-            room_id="room-1",
-        )
+        with pytest.raises(RuntimeError, match="platform rejected the message"):
+            await adapter.on_message(
+                msg,
+                tools,
+                ACPClientSessionState(),
+                None,
+                None,
+                is_session_bootstrap=False,
+                room_id="room-1",
+            )
 
         assert adapter._runtime._conn is not None
         assert adapter._runtime._ctx is not None
@@ -1426,15 +1431,16 @@ class TestACPClientAdapterDeadConnectionRecovery:
         tools = FakeAgentTools()
         msg = make_platform_message("Hello", room_id="room-1")
 
-        await adapter.on_message(
-            msg,
-            tools,
-            ACPClientSessionState(),
-            None,
-            None,
-            is_session_bootstrap=False,
-            room_id="room-1",
-        )
+        with pytest.raises(TimeoutError):
+            await adapter.on_message(
+                msg,
+                tools,
+                ACPClientSessionState(),
+                None,
+                None,
+                is_session_bootstrap=False,
+                room_id="room-1",
+            )
 
         assert adapter._runtime._conn is None
         assert adapter._runtime._ctx is None

--- a/tests/integrations/acp/test_client_adapter.py
+++ b/tests/integrations/acp/test_client_adapter.py
@@ -21,7 +21,7 @@ from band.integrations.acp.client_types import (
 )
 from band.integrations.acp.room_emitter import turn_replied_in_room
 from band.integrations.acp.types import ACPToolCall, ACPToolResult, CollectedChunk
-from band.testing import FakeAgentTools, reported_failures
+from band.testing import FakeAgentTools, events_of_type, reported_failures
 
 from tests.integrations.acp.conftest import make_platform_message
 
@@ -38,11 +38,6 @@ def permission_events(tools: FakeAgentTools) -> list[dict[str, object]]:
 def event_types(events: list[dict[str, object]]) -> list[object]:
     """The ordered ``message_type`` of each event — for asserting a pair's shape."""
     return [event["message_type"] for event in events]
-
-
-def events_of_type(tools: FakeAgentTools, message_type: str) -> list[dict[str, object]]:
-    """Events the handler sent, filtered to one message_type."""
-    return [e for e in tools.events_sent if e.get("message_type") == message_type]
 
 
 def metadata_values(events: list[dict[str, object]], key: str) -> list[object]:

--- a/tests/integrations/acp/test_client_adapter.py
+++ b/tests/integrations/acp/test_client_adapter.py
@@ -7,6 +7,7 @@ import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from acp.exceptions import RequestError
 from acp.helpers import update_agent_message_text
 
 from band.converters.parsing import parse_tool_call, parse_tool_result
@@ -42,6 +43,11 @@ def event_types(events: list[dict[str, object]]) -> list[object]:
 def events_of_type(tools: FakeAgentTools, message_type: str) -> list[dict[str, object]]:
     """Events the handler sent, filtered to one message_type."""
     return [e for e in tools.events_sent if e.get("message_type") == message_type]
+
+
+def reported_failures(tools: FakeAgentTools) -> list[dict[str, object]]:
+    """Every ``AgentFailure`` reported via ``send_failure``, as its wire dict."""
+    return [e["metadata"]["failure"] for e in events_of_type(tools, "error")]
 
 
 def metadata_values(events: list[dict[str, object]], key: str) -> list[object]:
@@ -745,7 +751,7 @@ class TestACPClientAdapterOnMessage:
     async def test_on_message_error_sends_error_event(
         self, adapter_with_mocks: ACPClientAdapter
     ) -> None:
-        """Should send error event when ACP agent fails."""
+        """Should report an AgentFailure when the ACP agent fails."""
         adapter_with_mocks._runtime._conn.prompt = AsyncMock(
             side_effect=RuntimeError("Agent crashed")
         )
@@ -763,9 +769,38 @@ class TestACPClientAdapterOnMessage:
             room_id="room-123",
         )
 
-        error_events = events_of_type(tools, "error")
-        assert len(error_events) == 1
-        assert "Agent crashed" in error_events[0]["content"]
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["provider"] == "acp"
+        assert "Agent crashed" in failures[0]["message"]
+
+    @pytest.mark.asyncio
+    async def test_on_message_request_error_captures_code_and_data(
+        self, adapter_with_mocks: ACPClientAdapter
+    ) -> None:
+        """A JSON-RPC RequestError's code/data survive into the AgentFailure."""
+        adapter_with_mocks._runtime._conn.prompt = AsyncMock(
+            side_effect=RequestError(-32603, "Internal error", {"detail": "oom"})
+        )
+
+        tools = FakeAgentTools()
+        msg = make_platform_message("Hello", room_id="room-123")
+
+        await adapter_with_mocks.on_message(
+            msg,
+            tools,
+            ACPClientSessionState(),
+            None,
+            None,
+            is_session_bootstrap=False,
+            room_id="room-123",
+        )
+
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["provider"] == "acp"
+        assert failures[0]["code"] == "-32603"
+        assert failures[0]["detail"] == {"detail": "oom"}
 
     @pytest.mark.asyncio
     async def test_on_message_not_initialized_raises(self) -> None:
@@ -1325,9 +1360,55 @@ class TestACPClientAdapterDeadConnectionRecovery:
         assert adapter._runtime._conn is None
         assert adapter._runtime._ctx is None
 
-        # Error event should be sent
-        error_events = events_of_type(tools, "error")
-        assert len(error_events) == 1
+        # AgentFailure should be reported
+        assert len(reported_failures(tools)) == 1
+
+    @pytest.mark.asyncio
+    async def test_reply_delivery_failure_leaves_connection_up(self) -> None:
+        """The agent answered fine; posting its reply to the room is what
+        failed. That must not tear down and respawn a healthy connection,
+        nor be reported as an ACP provider failure."""
+        adapter = ACPClientAdapter(command="codex", inject_band_tools=False)
+        adapter._runtime._conn = AsyncMock()
+        mock_session = MagicMock()
+        mock_session.session_id = "sess-1"
+        adapter._runtime._conn.new_session = AsyncMock(return_value=mock_session)
+        adapter._runtime._client = BandACPClient()
+
+        mock_ctx = MagicMock()
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        adapter._runtime._ctx = mock_ctx
+
+        async def prompt_with_reply(**kwargs):
+            session_id = kwargs["session_id"]
+            await adapter._runtime._client.session_update(
+                session_id, update_agent_message_text("Here's the answer")
+            )
+
+        adapter._runtime._conn.prompt = AsyncMock(side_effect=prompt_with_reply)
+
+        tools = FakeAgentTools()
+
+        async def _raise(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("platform rejected the message")
+
+        tools.send_message = _raise  # type: ignore[method-assign]
+
+        msg = make_platform_message("Hello", room_id="room-1")
+
+        await adapter.on_message(
+            msg,
+            tools,
+            ACPClientSessionState(),
+            None,
+            None,
+            is_session_bootstrap=False,
+            room_id="room-1",
+        )
+
+        assert adapter._runtime._conn is not None
+        assert adapter._runtime._ctx is not None
+        assert not reported_failures(tools)
 
 
 class TestACPClientAdapterInjectToolsConfig:

--- a/tests/integrations/acp/test_client_adapter.py
+++ b/tests/integrations/acp/test_client_adapter.py
@@ -1410,6 +1410,49 @@ class TestACPClientAdapterDeadConnectionRecovery:
         assert adapter._runtime._ctx is not None
         assert not reported_failures(tools)
 
+    @pytest.mark.asyncio
+    async def test_turn_timeout_reports_failure_and_clears_connection(self) -> None:
+        """A silent/stuck agent must become an observable failure instead of
+        hanging the turn indefinitely, and the presumed-wedged connection is
+        torn down so the next turn respawns it."""
+        adapter = ACPClientAdapter(
+            command="codex", inject_band_tools=False, turn_timeout_s=0.01
+        )
+        adapter._runtime._conn = AsyncMock()
+        mock_session = MagicMock()
+        mock_session.session_id = "sess-1"
+        adapter._runtime._conn.new_session = AsyncMock(return_value=mock_session)
+        adapter._runtime._client = BandACPClient()
+
+        mock_ctx = MagicMock()
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        adapter._runtime._ctx = mock_ctx
+
+        async def hang(**kwargs: object) -> None:
+            await asyncio.sleep(10)
+
+        adapter._runtime._conn.prompt = AsyncMock(side_effect=hang)
+
+        tools = FakeAgentTools()
+        msg = make_platform_message("Hello", room_id="room-1")
+
+        await adapter.on_message(
+            msg,
+            tools,
+            ACPClientSessionState(),
+            None,
+            None,
+            is_session_bootstrap=False,
+            room_id="room-1",
+        )
+
+        assert adapter._runtime._conn is None
+        assert adapter._runtime._ctx is None
+        failures = reported_failures(tools)
+        assert len(failures) == 1
+        assert failures[0]["provider"] == "acp"
+        assert failures[0]["code"] == "timeout"
+
 
 class TestACPClientAdapterInjectToolsConfig:
     """Tests for inject_band_tools configuration."""

--- a/tests/integrations/acp/test_client_adapter.py
+++ b/tests/integrations/acp/test_client_adapter.py
@@ -21,7 +21,7 @@ from band.integrations.acp.client_types import (
 )
 from band.integrations.acp.room_emitter import turn_replied_in_room
 from band.integrations.acp.types import ACPToolCall, ACPToolResult, CollectedChunk
-from band.testing import FakeAgentTools
+from band.testing import FakeAgentTools, reported_failures
 
 from tests.integrations.acp.conftest import make_platform_message
 
@@ -43,11 +43,6 @@ def event_types(events: list[dict[str, object]]) -> list[object]:
 def events_of_type(tools: FakeAgentTools, message_type: str) -> list[dict[str, object]]:
     """Events the handler sent, filtered to one message_type."""
     return [e for e in tools.events_sent if e.get("message_type") == message_type]
-
-
-def reported_failures(tools: FakeAgentTools) -> list[dict[str, object]]:
-    """Every ``AgentFailure`` reported via ``send_failure``, as its wire dict."""
-    return [e["metadata"]["failure"] for e in events_of_type(tools, "error")]
 
 
 def metadata_values(events: list[dict[str, object]], key: str) -> list[object]:

--- a/tests/integrations/acp/test_client_adapter_behavior.py
+++ b/tests/integrations/acp/test_client_adapter_behavior.py
@@ -813,7 +813,9 @@ async def test_replay_after_midrun_respawn() -> None:
 
     async with acp_adapter(agent) as session:
         await session.send("My favorite color is blue.", bootstrap=True)
-        crashed = await session.send("anything")  # prompt raises -> adapter stop()
+        with pytest.raises(RequestError):
+            await session.send("anything")  # prompt raises -> adapter stop()
+        crashed = session.last_reply
         reply = await session.send(
             "What is my favorite color?", room_context=transcript
         )

--- a/tests/integrations/claude_sdk/test_dedup_tools.py
+++ b/tests/integrations/claude_sdk/test_dedup_tools.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from band_sdk_core import AgentFailure
 
 from band.integrations.claude_sdk.dedup_tools import (
     DEFAULT_DEDUP_MAX_ENTRIES,
@@ -20,6 +21,7 @@ def _make_inner() -> MagicMock:
     inner = MagicMock()
     inner.send_message = AsyncMock(return_value={"id": "msg-1"})
     inner.send_event = AsyncMock(return_value={"id": "evt-1"})
+    inner.send_failure = AsyncMock(return_value={"id": "evt-2"})
     inner.add_participant = AsyncMock(return_value={"id": "u"})
     inner.participants = ["p1", "p2"]
     return inner
@@ -291,6 +293,18 @@ class TestTransparentPassthrough:
             content="ping", message_type="thought"
         )
         inner.add_participant.assert_awaited_once_with("@svc/bot")
+
+    @pytest.mark.asyncio
+    async def test_send_failure_forwards_unchanged(self):
+        """No dedup special-casing for send_failure -- __getattr__ forwards
+        it straight through, same as every other AgentToolsProtocol method."""
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner)
+        failure = AgentFailure("codex", "boom")
+
+        await wrapper.send_failure(failure)
+
+        inner.send_failure.assert_awaited_once_with(failure)
 
     def test_attributes_forward_unchanged(self):
         inner = _make_inner()

--- a/tests/integrations/parlant/test_tools.py
+++ b/tests/integrations/parlant/test_tools.py
@@ -500,6 +500,7 @@ class TestParlantToolFunctions:
         tools = MagicMock()
         tools.send_message = AsyncMock()
         tools.send_event = AsyncMock()
+        tools.send_failure = AsyncMock()
         tools.add_participant = AsyncMock(return_value={"status": "added"})
         tools.remove_participant = AsyncMock()
         tools.lookup_peers = AsyncMock(

--- a/tests/runtime/test_tools.py
+++ b/tests/runtime/test_tools.py
@@ -14,6 +14,7 @@ from band_rest import (
     GetAgentChatContextResponse,
     GetAgentChatContextResponseMetadata,
 )
+from band_sdk_core import AgentFailure
 from pydantic import BaseModel, ValidationError
 
 from band.client.rest import (
@@ -1487,6 +1488,50 @@ class TestAgentToolsSendEvent:
 
         assert result is None
         mock_rest_client.agent_api_events.create_agent_chat_event.assert_not_called()
+
+
+class TestAgentToolsSendFailure:
+    """Test send_failure's best-effort delegation over the real REST boundary."""
+
+    async def test_send_failure_posts_an_error_event(self, mock_rest_client):
+        tools = AgentTools("room-123", mock_rest_client)
+
+        await tools.send_failure(AgentFailure("codex", "boom", "timeout"))
+
+        call_args = mock_rest_client.agent_api_events.create_agent_chat_event.call_args
+        event = call_args.kwargs["event"]
+        assert event.message_type == "error"
+        assert event.metadata["failure"] == {
+            "provider": "codex",
+            "code": "timeout",
+            "message": "boom",
+            "detail": None,
+        }
+
+    async def test_send_failure_swallows_a_rest_rejection(self, mock_rest_client):
+        """A failed report must resolve, not raise -- it runs inside a
+        caller's except block reporting a real provider failure already."""
+        mock_rest_client.agent_api_events.create_agent_chat_event.side_effect = (
+            RuntimeError("REST rejected the event")
+        )
+        tools = AgentTools("room-123", mock_rest_client)
+
+        result = await tools.send_failure(AgentFailure("codex", "boom"))
+
+        assert result == {"ok": False, "error": "REST rejected the event"}
+
+    async def test_send_event_itself_still_raises_on_the_same_rejection(
+        self, mock_rest_client
+    ):
+        """The other half of the best-effort contract: send_event's own
+        raising behavior is unchanged by send_failure wrapping it."""
+        mock_rest_client.agent_api_events.create_agent_chat_event.side_effect = (
+            RuntimeError("REST rejected the event")
+        )
+        tools = AgentTools("room-123", mock_rest_client)
+
+        with pytest.raises(RuntimeError, match="REST rejected the event"):
+            await tools.send_event("task update", "task")
 
 
 class TestMatchesIdentifier:

--- a/tests/testing/test_fake_tools.py
+++ b/tests/testing/test_fake_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from band_sdk_core import AgentFailure
 
 from band.core.exceptions import BandToolError
 from band.core.protocols import AgentToolsProtocol
@@ -234,6 +235,54 @@ class TestSendEvent:
 
         assert result is None
         assert tools.events_sent == []
+
+
+class TestSendFailure:
+    """Tests for send_failure's best-effort delegation to send_event."""
+
+    async def test_posts_an_error_event_carrying_the_failure(self):
+        tools = FakeAgentTools()
+
+        result = await tools.send_failure(AgentFailure("codex", "boom", "timeout"))
+
+        assert len(tools.events_sent) == 1
+        assert tools.events_sent[0]["message_type"] == "error"
+        assert tools.events_sent[0]["metadata"]["failure"] == {
+            "provider": "codex",
+            "code": "timeout",
+            "message": "boom",
+            "detail": None,
+        }
+        assert result["message_type"] == "error"
+
+    async def test_blank_message_falls_back_to_a_generic_one(self):
+        tools = FakeAgentTools()
+
+        await tools.send_failure(AgentFailure("acp", ""))
+
+        assert tools.events_sent[0]["content"] == "acp failed without an error message."
+
+    async def test_swallows_a_send_event_failure_instead_of_raising(self):
+        """send_failure must resolve even when the underlying report fails --
+        raising here would replace the provider failure being reported with
+        an unrelated one."""
+        tools = FakeAgentTools()
+        tools.send_event_error = RuntimeError("platform rejected the event")
+
+        result = await tools.send_failure(AgentFailure("codex", "boom"))
+
+        assert result == {"ok": False, "error": "platform rejected the event"}
+        assert tools.events_sent == []
+
+    async def test_send_event_itself_still_raises_on_the_same_failure(self):
+        """The other half of the best-effort contract: send_event's raising
+        callers (e.g. OpenCode's session-persistence retry) must be
+        unaffected by send_failure's swallowing."""
+        tools = FakeAgentTools()
+        tools.send_event_error = RuntimeError("platform rejected the event")
+
+        with pytest.raises(RuntimeError, match="platform rejected the event"):
+            await tools.send_event("task update", "task")
 
 
 class TestParticipantOperations:

--- a/tests/testing/test_fake_tools.py
+++ b/tests/testing/test_fake_tools.py
@@ -10,7 +10,7 @@ from band_sdk_core import AgentFailure
 from band.core.exceptions import BandToolError
 from band.core.protocols import AgentToolsProtocol
 from band.runtime.tools import DEFAULT_FILE_CAPTION, serialize_tool_result
-from band.testing import FakeAgentTools
+from band.testing import FakeAgentTools, reported_failures
 from tests.content import BLANK_CONTENT_CASES
 
 
@@ -283,6 +283,37 @@ class TestSendFailure:
 
         with pytest.raises(RuntimeError, match="platform rejected the event"):
             await tools.send_event("task update", "task")
+
+
+class TestReportedFailures:
+    """reported_failures() is the shared projection every migrated adapter's
+    test suite uses to assert on a reported AgentFailure -- a regression here
+    would silently weaken failure assertions across the whole test suite."""
+
+    async def test_returns_each_reported_failure_in_order(self):
+        tools = FakeAgentTools()
+
+        await tools.send_failure(AgentFailure("codex", "first"))
+        await tools.send_failure(AgentFailure("letta", "second"))
+
+        failures = reported_failures(tools)
+
+        assert [f["message"] for f in failures] == ["first", "second"]
+        assert [f["provider"] for f in failures] == ["codex", "letta"]
+
+    async def test_ignores_a_plain_error_event_with_no_failure_metadata(self):
+        """A pre-migration send_event(..., "error") call carries no
+        ``failure`` metadata -- it must not be mistaken for a reported
+        AgentFailure."""
+        tools = FakeAgentTools()
+
+        await tools.send_event("legacy error text", "error")
+        await tools.send_failure(AgentFailure("codex", "structured failure"))
+
+        failures = reported_failures(tools)
+
+        assert len(failures) == 1
+        assert failures[0]["message"] == "structured failure"
 
 
 class TestParticipantOperations:

--- a/uv.lock
+++ b/uv.lock
@@ -774,7 +774,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'dev-parlant'", specifier = ">=0.75.0" },
     { name = "async-lru", specifier = ">=2.3.0" },
     { name = "band-client-rest", specifier = "==0.0.27" },
-    { name = "band-sdk-core", specifier = "==2.0.0" },
+    { name = "band-sdk-core", specifier = "==2.3.0" },
     { name = "band-testing-python", marker = "extra == 'dev'", specifier = "==0.1.4" },
     { name = "band-testing-python", marker = "extra == 'dev-crewai'", specifier = "==0.1.4" },
     { name = "band-testing-python", marker = "extra == 'dev-parlant'", specifier = "==0.1.4" },
@@ -918,17 +918,17 @@ provides-extras = ["logging", "desktop", "codex", "opencode", "letta", "pydantic
 
 [[package]]
 name = "band-sdk-core"
-version = "2.0.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/b0/c0450d0df122aa46ffaf11aabacd5dcf27b81e35ff1f5b08639c0cfa1457/band_sdk_core-2.0.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7db8f08f4dc4616ecee2aa5e8a7bd61d846d959a309a6b25da598e649d4ac278", size = 457389, upload-time = "2026-08-29T12:00:47.019Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/99/12d8e5a5fb4ef42e684117de2687cbb7bf8df0b706eeb65587caa9867b49/band_sdk_core-2.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:556f420711b7026b0b3dbb9abf0a2dcdd6f7126f2c09ec40ca281c081229851c", size = 458700, upload-time = "2026-08-29T12:00:48.396Z" },
-    { url = "https://files.pythonhosted.org/packages/16/c3/a894dd0a873a80184bdf443e770917c2ec85e671a8c72f4c8400584692e9/band_sdk_core-2.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:19e58438cf932bb0324c0358a8c332437eade63bb253e6f7cddbfa02c928051e", size = 509782, upload-time = "2026-08-29T12:00:49.711Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/95/18d976f8a12d24819e3788a2c880ec7d07945673c6a34b68fd7653142ee8/band_sdk_core-2.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9f581c2173967e44a219d86f124a65650fc915c8c99a1f9ddf69c0e98612253f", size = 510429, upload-time = "2026-08-29T12:00:50.849Z" },
-    { url = "https://files.pythonhosted.org/packages/67/87/1eef985931ddddf2f2ff9623622f15bab460d4d943aa7dc96d1da8227d37/band_sdk_core-2.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:430fb51e32080fa58a1c84f8d2342c443865c85a05f8ad727288063e5bdb425a", size = 687161, upload-time = "2026-08-29T12:00:51.987Z" },
-    { url = "https://files.pythonhosted.org/packages/08/8d/61d49368320438ad8ee7ebfc689cfc62163cdb9a5d7592e8d48a3438aae4/band_sdk_core-2.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3606b58f5a3d9ff006fcd9db425cc4ac47c4482380146a282e23299ca6f0fcab", size = 724455, upload-time = "2026-08-29T12:00:53.376Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/17/c795774be4b1b1c96633c68b5a8f2966bfd0752004835920f6f0a676153a/band_sdk_core-2.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:8ac8e95b466e8110f4e3dd99afaa4520f825c294e2b731d04c246efe1edd7685", size = 331961, upload-time = "2026-08-29T12:00:54.47Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/93/aa331d33db1d8436dba57df83d4592c6534223ffc11bf94c1eb5090714cc/band_sdk_core-2.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:d802cb5a411afa5b7e6089962cdc3b4573ad6d43048fc2b28a8a9079a247aa0b", size = 314808, upload-time = "2026-08-29T12:00:55.707Z" },
+    { url = "https://files.pythonhosted.org/packages/af/f4/25f7be88054b13dbba887eee2dedcbf50c33e46cb4b4d14b71359b7fcb0d/band_sdk_core-2.3.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9a12f9a447a684b50eccf8fb779928938f72edac02b11bc1b0da67597ff1daa1", size = 478061, upload-time = "2026-09-06T05:54:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/0d/7adc5f3cb9b001ead33ea829932958bb0fff8f5d543a891d1338b94f3ea4/band_sdk_core-2.3.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:4b5232055f48da4d788d83502d9e14453c6153d41c4e9750133f960a6fd18f4d", size = 479953, upload-time = "2026-09-06T05:54:18.464Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ab/14449d8967d2fcde4d84455070f5e1d011d9b2f76b22383af97971d20134/band_sdk_core-2.3.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ee15965fc503b372adc6965999acb26dc67cac4d92d7fe7d876b6786b8ae73e4", size = 531154, upload-time = "2026-09-06T05:54:19.997Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ff/5de82d4e5d72436039be905de68436ae5689ac44892214fbca652b0b2f30/band_sdk_core-2.3.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:044769078b6e7ed28062f8280c269e4e904e700c4112f791913ba48d0f255449", size = 530174, upload-time = "2026-09-06T05:54:21.272Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b4/cfe7d0d8eaad24c975f4bc6e9d29634225caee6537c1be197a35cc3b0d8a/band_sdk_core-2.3.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4d44b363199fb5bb7b3a21d26c70d443ed381c923cd48f0df2f20f690ac79e23", size = 710040, upload-time = "2026-09-06T05:54:22.7Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f2/7758410757818756395449a653f4ba44098af104612eca478c585ec36f59/band_sdk_core-2.3.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:eb541d6c12437e4f12cee4b8db2b5674d8414a8ae018e92267ec237bb1302599", size = 746399, upload-time = "2026-09-06T05:54:24.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/72/6de9b5820723c04f41ea2644cda496857f0e3151418bf090b80e750f7734/band_sdk_core-2.3.0-cp311-abi3-win_amd64.whl", hash = "sha256:ad2df3ff7ab79d06fe17dd970b95fd9f19c38687368d871bd3e3ab7a328de1de", size = 351424, upload-time = "2026-09-06T05:54:25.483Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/cdf700c5553dd0ba879f190b02774b9dff64c7d3438f0acfcb5212477509/band_sdk_core-2.3.0-cp311-abi3-win_arm64.whl", hash = "sha256:adbbdb9cf318bd69e369a02f4fafa7323c2202b903acaaae7ef91175ed61faa1", size = 333893, upload-time = "2026-09-06T05:54:26.84Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adopts band-sdk-core's shared `AgentFailure` shape (`provider`/`code`/`message`/`detail`)
across band-sdk-python adapters, replacing the free-text `"error"` event and
its ad hoc per-adapter metadata keys.

## Changes

- Bump `band-sdk-core` to 2.3.0
- `send_failure`/`to_failure_event` on `AgentToolsProtocol`, `AgentTools`, `FakeAgentTools`
- `DeliveryFailedError`/`deliver_reply` for Band-delivery vs. provider-failure separation
- Migrated adapters: Anthropic, Gemini, Google ADK, Claude SDK, Copilot SDK, LangGraph, Letta, A2A, A2A Gateway, CrewAI, CrewAI Flow, Pydantic AI, Parlant, Strands, Agno, OpenCode, Codex, ACP client
- ACP client: turn-level timeout (`turn_timeout_s`, default 300s) around `_runtime.prompt`
- A2A Gateway: structured failure channel on `PendingA2ATask.fail`, credential redaction on both the adapter's own exception path and the peer-forwarded-failure relay path
- Codex: removed the old remediation/suggested-action policy; turn-timeout, error-notification, and turn/completed failure paths each report exactly once
- Shared `FAILURE_CODE_TIMEOUT` constant; `MessageType.ERROR` used instead of a raw `"error"` literal
- `to_failure_event` blank-content check uses `has_visible_content()`
- Centralized `reported_failures()`/`events_of_type()` test helpers in `band.testing`
- A2A adapter: terminal task-event emission isolated from the try block's exception in `finally`
- CrewAI Flow: `record_failed` caps the room-visible message at 500 chars, preserves the full message in `AgentFailure.detail`

## Breaking Changes

- **Codex**: `CodexAdapterConfig.structured_errors` (previously `bool = True`, documented in `docs/adapters/codex.md`) is removed. The model uses `extra="forbid"`, so any existing deployment config, constructor kwarg, or `CODEX_STRUCTURED_ERRORS` env var still setting this field will now raise `pydantic.ValidationError` at construction instead of being silently ignored. No deprecation alias/passthrough is added — this repo's own conventions reject backwards-compat shims in favor of a clean break. **The eventual merge commit needs a `!` on its type (e.g. `refactor!:`) and a `BREAKING CHANGE:` footer** so release-please's changelog actually reflects this.

## Out of scope

- Pydantic AI's `band_respond_contact_request` tool handler's own error event (a platform-tool failure, not a provider failure)
- ACP client's per-room timeout isolation (currently tears down the adapter-wide shared runtime; pre-existing behavior, not introduced by this PR)
- Transport-health-scoped connection classification, `cancel_turn`/`stop_reason` propagation

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyrefly check`
- [x] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/` — 5620 passed, 146 skipped, 0 failed
- [x] `uv run pytest --markdown-docs $(git ls-files '*.md' ':!:examples/*')`

## Follow-up: cross-SDK review fixes (99b660a1)

Fixed in 99b660a1, found against band-sdk-typescript#178's parallel implementation: several adapters reported a terminal provider failure via `send_failure` but then returned/fell through normally instead of failing the turn.

| File:location | Before → After | Reason | Reasoning |
|---|---|---|---|
| `a2a/adapter.py` `DeliveryFailedError` except | Logged + returned normally → raises `e.cause` | bug fix | Room-post failure silently swallowed; turn marked processed despite the reply never landing. |
| `a2a/adapter.py` generic `except Exception` | `send_failure` + return → `send_failure` + `raise` | bug fix | Reported but still marked successful — lost retry. |
| `claude_sdk.py` `_on_turn_complete` (2 branches) | `send_failure` + return → raises new `TurnResultAlreadyReported` | bug fix | Terminal error / no-reply turn reported but completed "successfully." |
| `claude_sdk.py` `on_message` | No handling for already-reported failures → new `except TurnResultAlreadyReported: raise` clause | bug fix (support) | Prevents the above fix from double-reporting via the outer catch-all. |
| `letta.py` client-not-initialized guard | `send_failure` + return → synthesizes `RuntimeError`, reports, raises | bug fix | Dropped message counted as processed. |
| `letta.py` session-prep `except Exception` | `send_failure` + return → `send_failure` + bare `raise` | bug fix | Same swallow-after-report pattern. |
| `letta.py` `_handle_message` missing-room-context | `send_failure` + return → synthesizes `RuntimeError`, reports, raises | bug fix | Turn dropped for lack of context looked like a normal no-op. |
| `letta.py` `_run_turn` `DeliveryFailedError` except | Logged only, no raise → raises `e.cause` (still no `send_failure`, correctly) | bug fix | Band-side delivery failure was invisible to retry, though correctly never misattributed to the provider. |
| `letta.py` `_run_turn` timeout / generic except | `send_failure` then fall through → `send_failure` then `raise` | bug fix | Timed-out/errored turn still counted as successfully processed. |
| `parlant.py` app-not-initialized guard | `send_failure` + return → synthesizes `RuntimeError`, reports, raises | bug fix | Same pattern as Letta. |
| `parlant.py` session-init `except Exception` | `send_failure` + return → `send_failure` + `raise` | bug fix | Same pattern. |

**Net effect:** across four adapters, a reported provider failure now also fails the turn, so the platform's retry mechanism actually engages instead of silently losing the message. `TurnResultAlreadyReported` prevents this from causing double-reporting in `claude_sdk`. Band-side delivery failures remain correctly un-attributed to the provider but are now also retryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195k7AdghCyZgBPgs4TdxE3



