### PR TITLE
fix: report always-skipped file/image E2E cells as N/A, not missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -357,6 +357,7 @@ markers = [
     "docker_build: builds/runs a real Docker image via subprocess (requires a local Docker daemon; skipped unless DOCKER_TESTS_ENABLED=true, including in CI, which has Docker but shouldn't pay this cost by default)",
     "sandbox: drives a Docker Sandbox via the sbx CLI (needs sbx + a nested-virtualization-capable host + live Band; skipped unless SANDBOX_TESTS_ENABLED=true — CI has neither the CLI nor nested virt)",
     "vscode_chat: drives a real signed-in VS Code window via the code chat CLI (GUI + interactive Copilot sign-in; skipped unless VSCODE_CHAT_TESTS_ENABLED=true — can never run in CI)",
+    "env_gated_skip: tags a skipif whose condition is a deployment flag permanently off in some environment, so tests/e2e/baseline/scorecard.py reports its skip as N/A rather than missing coverage",
 ]
 
 [tool.uv.workspace]

--- a/tests/e2e/baseline/scorecard.py
+++ b/tests/e2e/baseline/scorecard.py
@@ -26,10 +26,10 @@ import argparse
 import json
 import logging
 import sys
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
-from typing import Literal
+from typing import Literal, TypeVar
 
 import pytest
 
@@ -49,6 +49,32 @@ _ADAPTER_IDS: frozenset[str] = frozenset(str(adapter) for adapter in Adapter)
 # per-lane scorecards are unioned, and an ``N/A`` is never overwritten by a ``skip``.
 Status = Literal["pass", "fail", "skip", "na"]
 _RANK: dict[Status, int] = {"skip": 0, "na": 1, "pass": 2, "fail": 3}
+
+# Tags a ``skipif`` whose condition is a deployment flag that is permanently off in
+# some environment (e.g. an on-prem-only capability, never on for SaaS CI) rather than
+# transiently unavailable. Without this, ``outcome_row`` reports the same ``skip``
+# status a lane-scoping or flaky skip would, and ``gate`` -- which cannot tell those
+# apart -- would call it "missing" forever: the cell can never pass in that
+# environment, so the release gate would stay red for a condition that is not a
+# regression. See ``env_gated_skip``.
+ENV_GATED_MARKER = "env_gated_skip"
+
+_F = TypeVar("_F", bound=Callable[..., object])
+
+
+def env_gated_skip(condition: bool, reason: str) -> Callable[[_F], _F]:
+    """``skipif``, tagged so ``outcome_row`` reports the skip as ``na`` (never
+    ``missing``) instead of a plain ``skip`` -- for a capability whose deployment
+    flag is structurally off in some environment, not one that merely hasn't run
+    yet. See ``ENV_GATED_MARKER``.
+    """
+    skip = pytest.mark.skipif(condition, reason=reason)
+    tag = getattr(pytest.mark, ENV_GATED_MARKER)
+
+    def decorator(fn: _F) -> _F:
+        return skip(tag(fn))
+
+    return decorator
 
 
 @dataclass(frozen=True)
@@ -128,10 +154,11 @@ def outcome_row(
     parametrized test carrying anything else (``test_send_event[thought]``) and the
     unparametrized tests (provisioning, user-ops, the registry guards) return ``None``.
     The verdict comes from the setup and call phases: a skip (lane scoping, E2E disabled,
-    or an in-body ``pytest.skip``) is ``skip``; a setup *error* (a failed fixture) or a
-    call failure is ``fail``; a passing call is ``pass``. Teardown reports and passing
-    setups carry no verdict and are ignored — so the accumulator's last-write-wins keeps
-    the call outcome, not a trailing teardown.
+    or an in-body ``pytest.skip``) is ``skip``, unless it carries ``ENV_GATED_MARKER``
+    (see ``env_gated_skip``), in which case it is ``na``; a setup *error* (a failed
+    fixture) or a call failure is ``fail``; a passing call is ``pass``. Teardown reports
+    and passing setups carry no verdict and are ignored — so the accumulator's
+    last-write-wins keeps the call outcome, not a trailing teardown.
     """
     if report.when not in ("setup", "call"):
         return None
@@ -140,8 +167,8 @@ def outcome_row(
         return None  # unparametrized, or a non-adapter parametrization
     test, adapter = key
     if report.skipped:
-        status: Status = "skip"
         reason = _skip_reason(report)
+        status: Status = "na" if ENV_GATED_MARKER in report.keywords else "skip"
     elif report.failed:
         status = "fail"
         reason = None

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -39,6 +39,7 @@ from tests.e2e.baseline.smoke.samples.sample_agents import (
     task_read_instruction,
     unique_marker,
 )
+from tests.e2e.baseline.scorecard import env_gated_skip
 from tests.e2e.baseline.settings import BaselineSettings
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
 from tests.e2e.baseline.toolkit.judge import Verdict, format_transcript
@@ -57,7 +58,10 @@ JudgeFn = Callable[..., Awaitable[Verdict]]
 # so they cannot pass. Skips rather than fails (the ``GITHUB_TOKEN`` hosted-auth
 # smoke's rationale): on SaaS the flag is off by design, not misconfiguration,
 # and no key can turn it on -- this is optional extra coverage over the matrix.
-requires_file_transfer = pytest.mark.skipif(
+# ``env_gated_skip`` (not a plain ``skipif``) so the scorecard gate reports these
+# cells ``na`` rather than "missing" -- on GitHub CI this condition is permanent,
+# never a crashed/incomplete lane, so it must never redden the release gate.
+requires_file_transfer = env_gated_skip(
     not BaselineSettings().deployment.file_transfer,
     reason="E2E_FILE_TRANSFER is not true (ff_file_transfer is on-prem-only)",
 )

--- a/tests/framework_conformance/test_scorecard.py
+++ b/tests/framework_conformance/test_scorecard.py
@@ -30,10 +30,12 @@ from tests.e2e.baseline.agents import (
     per_adapter,
 )
 from tests.e2e.baseline.scorecard import (
+    ENV_GATED_MARKER,
     MASS_FAILURE_THRESHOLD,
     ScorecardCollector,
     ScorecardRow,
     digest_body,
+    env_gated_skip,
     failed_fraction,
     gate,
     gate_summary,
@@ -141,7 +143,12 @@ def test_na_rows_ignores_items_without_per_adapter_marker() -> None:
 
 
 def _report(
-    nodeid: str, when: str, *, outcome: str, reason: str | None = None
+    nodeid: str,
+    when: str,
+    *,
+    outcome: str,
+    reason: str | None = None,
+    keywords: tuple[str, ...] = (),
 ) -> object:
     longrepr = ("m.py", 1, f"Skipped: {reason}") if reason is not None else None
     return SimpleNamespace(
@@ -151,6 +158,7 @@ def _report(
         failed=outcome == "failed",
         passed=outcome == "passed",
         longrepr=longrepr,
+        keywords=frozenset(keywords),
     )
 
 
@@ -166,6 +174,30 @@ def test_outcome_row_setup_skip_captures_reason() -> None:
         _report("m.py::t[agno]", "setup", outcome="skipped", reason="lane 'core'")
     )
     assert (row.status, row.reason) == ("skip", "lane 'core'")
+
+
+def test_env_gated_skip_applies_both_skipif_and_marker() -> None:
+    @env_gated_skip(True, reason="flag is off")
+    def fn() -> None: ...
+
+    marks = {mark.name for mark in fn.pytestmark}  # type: ignore[attr-defined]
+    assert marks == {"skipif", ENV_GATED_MARKER}
+
+
+def test_outcome_row_env_gated_skip_reports_na_not_missing() -> None:
+    # A deployment flag that is permanently off in this environment (e.g. the SaaS
+    # E2E lanes' ff_file_transfer) must never read as "missing coverage" -- see
+    # ENV_GATED_MARKER.
+    _, row = outcome_row(
+        _report(
+            "m.py::t[anthropic]",
+            "setup",
+            outcome="skipped",
+            reason="E2E_FILE_TRANSFER is not true",
+            keywords=(ENV_GATED_MARKER,),
+        )
+    )
+    assert (row.status, row.reason) == ("na", "E2E_FILE_TRANSFER is not true")
 
 
 def test_outcome_row_setup_error_is_a_fail() -> None:


### PR DESCRIPTION
## Summary

- \`test_file_round_trip_across_files_adapters\` and \`test_image_vision_passthrough_across_adapters\` are gated on \`E2E_FILE_TRANSFER\` (\`ff_file_transfer\` is on-prem-only, permanently off on GitHub CI), so they always `skip` there — correctly, that part already worked.
- But the scorecard gate (\`tests/e2e/baseline/scorecard.py\`) treats *any* skip in a cell's expected lane as "missing coverage" and reddens \`release-baseline-gate\` on it — so these two structurally-always-skip tests kept the gate permanently red regardless of real test health. Confirmed live: the [2026-09-06 nightly baseline run](https://github.com/band-ai/band-sdk-python/actions/runs/34009197145) had **0 test failures** (324 passed) yet the \`scorecard (merge + gate)\` job still failed, solely on these two tests' "Missing" cells.
- Adds \`scorecard.env_gated_skip\` — a \`skipif\` tagged with a dedicated \`ENV_GATED_MARKER\` — so \`outcome_row\` reports the skip as an \`na\` row (same treatment as an \`@per_adapter\` exclusion) instead of \`skip\`. \`na\` rows never gate, so a deployment-flag skip that can never flip true in this environment stops blocking the release gate forever, while a genuinely missing result (e.g. a crashed lane) still gates exactly as before.
- Swapped \`test_capability_matrix.py\`'s two file/image \`requires_file_transfer\` markers over to \`env_gated_skip\`; registered the new pytest marker in \`pyproject.toml\`.

## Test plan

- [x] \`uv run pytest tests/framework_conformance/test_scorecard.py -v\` — 34 passed, incl. 2 new tests covering \`env_gated_skip\`'s marker composition and \`outcome_row\`'s na promotion
- [x] \`uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/\` — 5585 passed, 146 skipped, 0 failed
- [x] \`uv run ruff check .\` / \`uv run ruff format --check .\` / \`uv run pyrefly check\` — clean
- [x] \`uv run pytest tests/e2e/baseline/smoke/matrix/test_capability_matrix.py --collect-only\` — collects cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WvEw1d2xBhkg7WBmjcQQu