### PR TITLE
fix: add a2a-sdk to dev-crewai/dev-parlant extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,6 +278,8 @@ dev-crewai = [
     # Anthropic client: the baseline E2E conftest imports it at module load and
     # the LLM judge needs it. A thin client (pydantic <3), so no crewai conflict.
     "anthropic>=0.75.0",
+    # A2A e2e smokes import band.integrations.a2a at module load, no crewai conflict
+    "a2a-sdk>=1.1.2,<2",
     # Pretty E2E test output
     "rich>=13.0.0",
     # Development tools
@@ -306,6 +308,8 @@ dev-parlant = [
     # Anthropic client: the baseline E2E conftest imports it at module load and
     # the LLM judge needs it. A thin client (pydantic <3), so no parlant conflict.
     "anthropic>=0.75.0",
+    # A2A e2e smokes import band.integrations.a2a at module load, no parlant conflict
+    "a2a-sdk>=1.1.2,<2",
     # Pretty E2E test output
     "rich>=13.0.0",
     # Development tools

--- a/uv.lock
+++ b/uv.lock
@@ -664,6 +664,7 @@ dev = [
     { name = "uvicorn" },
 ]
 dev-crewai = [
+    { name = "a2a-sdk" },
     { name = "anthropic" },
     { name = "band-testing-python" },
     { name = "crewai" },
@@ -684,6 +685,7 @@ dev-crewai = [
     { name = "tenacity" },
 ]
 dev-parlant = [
+    { name = "a2a-sdk" },
     { name = "anthropic" },
     { name = "band-testing-python" },
     { name = "httpx" },
@@ -758,6 +760,8 @@ strands = [
 requires-dist = [
     { name = "a2a-sdk", marker = "extra == 'a2a'", specifier = ">=1.1.2,<2" },
     { name = "a2a-sdk", marker = "extra == 'dev'", specifier = ">=1.1.2,<2" },
+    { name = "a2a-sdk", marker = "extra == 'dev-crewai'", specifier = ">=1.1.2,<2" },
+    { name = "a2a-sdk", marker = "extra == 'dev-parlant'", specifier = ">=1.1.2,<2" },
     { name = "a2a-sdk", extras = ["http-server"], marker = "extra == 'a2a-gateway'", specifier = ">=1.1.2,<2" },
     { name = "a2a-sdk", extras = ["http-server"], marker = "extra == 'a2a-gateway-demo'", specifier = ">=1.1.2,<2" },
     { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.11.0" },


### PR DESCRIPTION
## Summary
- Scheduled `main E2E (baseline)` [run 34080081207](https://github.com/band-ai/band-sdk-python/actions/runs/34080081207) failed the `crewai` and `parlant` lanes (ubuntu + windows) with a pytest collection error: `ModuleNotFoundError: No module named 'a2a'`.
- Yesterday's new A2A baseline smokes (`test_a2a.py`, `test_a2a_gateway.py`, `test_a2a_roundtrip.py`, #605) import `band.integrations.a2a` at module load. `pytest tests/e2e/baseline/` collects the whole directory regardless of `BAND_E2E_LANE`, so every lane's venv must be able to import every module even though these smokes only ever *run* in the `core` lane.
- `a2a-sdk` was already in the `dev` extra ("Include a2a-sdk for testing") but was never added to the isolated `dev-crewai`/`dev-parlant` extras when those were split out — a plain gap, not a real dependency conflict (verified: `uv sync --extra dev-crewai` / `--extra dev-parlant` both resolve and install `a2a-sdk` cleanly alongside crewai/parlant).
- Fix: add `a2a-sdk>=1.1.2,<2` to both extras and regenerate `uv.lock`.

Considered and rejected an alternative fix — guarding the three test files with `pytest.importorskip("a2a")` like `test_parlant.py` does for the real parlant/crewai conflict. That would permanently and silently skip these tests under crewai/parlant, hiding a genuine future regression, which conflicts with this repo's fail-loud testing policy (skips are reserved for structural, unresolvable conflicts).

Linear: INT-1400

## Test plan
- [x] `uv lock` — resolves cleanly, no conflicts
- [x] `uv sync --extra dev-crewai` / `--extra dev-parlant` — a2a-sdk installs alongside crewai/parlant with no errors
- [x] `pytest tests/e2e/baseline/ --collect-only` under both venvs — 455/456 items, 0 errors (previously 3 collection errors)
- [x] `ruff check .` / `ruff format --check .` — pass
- [x] `pyrefly check` — 0 errors
- [x] `pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/` — 5585 passed, 146 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8z6z1muD8yg9Y3pre92ec