### PR TITLE
fix: patch build_adapter at its provisioning.py use site

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,6 +278,8 @@ dev-crewai = [
     # Anthropic client: the baseline E2E conftest imports it at module load and
     # the LLM judge needs it. A thin client (pydantic <3), so no crewai conflict.
     "anthropic>=0.75.0",
+    # A2A e2e smokes import band.integrations.a2a at module load, no crewai conflict
+    "a2a-sdk>=1.1.2,<2",
     # Pretty E2E test output
     "rich>=13.0.0",
     # Development tools
@@ -306,6 +308,8 @@ dev-parlant = [
     # Anthropic client: the baseline E2E conftest imports it at module load and
     # the LLM judge needs it. A thin client (pydantic <3), so no parlant conflict.
     "anthropic>=0.75.0",
+    # A2A e2e smokes import band.integrations.a2a at module load, no parlant conflict
+    "a2a-sdk>=1.1.2,<2",
     # Pretty E2E test output
     "rich>=13.0.0",
     # Development tools

--- a/tests/e2e/baseline/guards/test_adapter_cell.py
+++ b/tests/e2e/baseline/guards/test_adapter_cell.py
@@ -49,10 +49,10 @@ def captured(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
     ) -> Any:
         yield provisioned
 
-    # build() lazily does `from ...toolkit.adapters import build_adapter`, so patch there.
-    monkeypatch.setattr(
-        "tests.e2e.baseline.toolkit.adapters.build_adapter", fake_build_adapter
-    )
+    # provisioning.py imports build_adapter at top level, so it must be patched at that
+    # use site -- patching toolkit.adapters.build_adapter leaves provisioning's own
+    # already-bound name pointing at the real function.
+    monkeypatch.setattr(provisioning, "build_adapter", fake_build_adapter)
     monkeypatch.setattr(provisioning, "running_agent", fake_running_agent)
     return calls
 

--- a/uv.lock
+++ b/uv.lock
@@ -664,6 +664,7 @@ dev = [
     { name = "uvicorn" },
 ]
 dev-crewai = [
+    { name = "a2a-sdk" },
     { name = "anthropic" },
     { name = "band-testing-python" },
     { name = "crewai" },
@@ -684,6 +685,7 @@ dev-crewai = [
     { name = "tenacity" },
 ]
 dev-parlant = [
+    { name = "a2a-sdk" },
     { name = "anthropic" },
     { name = "band-testing-python" },
     { name = "httpx" },
@@ -758,6 +760,8 @@ strands = [
 requires-dist = [
     { name = "a2a-sdk", marker = "extra == 'a2a'", specifier = ">=1.1.2,<2" },
     { name = "a2a-sdk", marker = "extra == 'dev'", specifier = ">=1.1.2,<2" },
+    { name = "a2a-sdk", marker = "extra == 'dev-crewai'", specifier = ">=1.1.2,<2" },
+    { name = "a2a-sdk", marker = "extra == 'dev-parlant'", specifier = ">=1.1.2,<2" },
     { name = "a2a-sdk", extras = ["http-server"], marker = "extra == 'a2a-gateway'", specifier = ">=1.1.2,<2" },
     { name = "a2a-sdk", extras = ["http-server"], marker = "extra == 'a2a-gateway-demo'", specifier = ">=1.1.2,<2" },
     { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.11.0" },


### PR DESCRIPTION
## Summary
- After INT-1400 (a2a-sdk missing from crewai/parlant extras) fixed the collection error, re-verification runs against `main` still failed — this time in **every** lane (core, google, letta, backends, crewai, parlant), with `tests/e2e/baseline/guards/test_adapter_cell.py` failing 3 tests: `AttributeError: 'NoneType' object has no attribute 'llm_models'`.
- Root cause: #607's PLC0415 import cleanup moved `provisioning.py`'s `from tests.e2e.baseline.toolkit.adapters import build_adapter` from a lazy in-method import to a top-level one. `test_adapter_cell.py`'s `captured` fixture still patched `toolkit.adapters.build_adapter` (where it's *defined*) per a stale comment claiming the import was still lazy — but `provisioning.py` now binds its own top-level name, so the patch never took effect and the real `build_adapter` ran with `settings=None`, blowing up in `_build_anthropic`.
- #607's own PR description flags this exact bug class (monkeypatch target must be the use site, not the definition site) and says one instance (in `langgraph.py`) was "caught and reverted along the way" — this one in `provisioning.py`/`test_adapter_cell.py` was missed.
- Since these are `guards/` tests (no live platform, always collected), this has silently failed **every scheduled baseline E2E run since 2026-09-06**, independent of the crewai/parlant-specific a2a issue.
- Fix: `monkeypatch.setattr(provisioning, "build_adapter", fake_build_adapter)` — the file already imports `provisioning` as a module and uses this exact style for `running_agent` two lines below. Updated the stale comment to match.

Linear: INT-1401 (follow-on from INT-1400)

## Test plan
- [x] `tests/e2e/baseline/guards/test_adapter_cell.py` — all 3 tests pass (previously 3 failed)
- [x] `tests/e2e/baseline/guards/` full suite — 40 passed
- [x] `grep` confirms no other test uses this now-broken string-path monkeypatch pattern
- [x] `ruff check .` / `ruff format --check .` — pass
- [x] `pyrefly check` — 0 errors
- [x] `pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/` — 5585 passed, 146 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8z6z1muD8yg9Y3pre92ec