### PR TITLE
fix: build crewai turn prompt as one string, not a list CrewAI flattens

### DIFF
--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -321,6 +321,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         reply_tracker: ReplyTracker | None = None,
     ) -> None:
         """Internal message processing logic."""
+        assert self._crewai_agent is not None, "on_message already checked this"
         if is_session_bootstrap:
             if history:
                 self._message_history[room_id] = [
@@ -337,39 +338,27 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         elif room_id not in self._message_history:
             self._message_history[room_id] = []
 
-        messages = []
+        sections: list[str] = []
 
         if self._message_history.get(room_id):
             history_text = "\n".join(
                 f"{m['role']}: {m['content']}" for m in self._message_history[room_id]
             )
-            messages.append(
-                {
-                    "role": "user",
-                    "content": f"[Previous conversation:]\n{history_text}",
-                }
+            sections.append(
+                "[Earlier conversation in this room -- already handled, for "
+                f"context only. Do not repeat any action described in it:]\n{history_text}"
             )
 
         if participants_msg:
-            messages.append(
-                {
-                    "role": "user",
-                    "content": f"[System]: {participants_msg}",
-                }
-            )
+            sections.append(f"[System]: {participants_msg}")
             logger.info("Room %s: Participants updated", room_id)
 
         if contacts_msg:
-            messages.append(
-                {
-                    "role": "user",
-                    "content": f"[System]: {contacts_msg}",
-                }
-            )
+            sections.append(f"[System]: {contacts_msg}")
             logger.info("Room %s: Contacts broadcast received", room_id)
 
         user_message = msg.format_for_llm()
-        messages.append({"role": "user", "content": user_message})
+        sections.append(f"[New message -- act on this now:]\n{user_message}")
 
         self._message_history[room_id].append(
             {
@@ -390,12 +379,19 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         # SUPPORTED_EMIT): result.usage_metrics is cumulative-lifetime, not
         # per-turn. Proper per-turn capture is deferred — don't add emit_usage here.
         try:
-            # Type ignore explanation: CrewAI's kickoff_async is typed to accept
-            # only a string prompt, but the implementation also accepts a list of
-            # message dicts (similar to OpenAI's messages format) for multi-turn
-            # context. This is documented behavior but the type stubs haven't been
-            # updated. See: https://docs.crewai.com/concepts/agents
-            result = await self._crewai_agent.kickoff_async(messages)  # type: ignore[arg-type]
+            # CrewAI's kickoff_async accepts str | list[dict], but a list is
+            # flattened internally into one role-blind "\n".join(...) of every
+            # message's content (crewai.agent.core.Agent._prepare_kickoff) --
+            # it does NOT preserve per-message turn/role structure the way a
+            # chat-completions API would. Passing a list here previously left
+            # an earlier turn's imperative ("do X, do not call any other
+            # tool") sitting unmarked next to the new turn's instruction, and
+            # models would sometimes replay the old instruction instead of the
+            # new one. Building the final prompt ourselves, with explicit
+            # "already handled" / "act on this now" markers, matches what
+            # CrewAI actually does with the input either way.
+            prompt = "\n\n".join(sections)
+            result = await self._crewai_agent.kickoff_async(prompt)
 
             if result and result.raw:
                 self._message_history[room_id].append(

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -417,10 +417,9 @@ class TestOnMessage:
 
         # The second kickoff must carry the prior turn as replayed context, not
         # just the current message.
-        second_call_messages = mock_crewai_agent.kickoff_async.call_args_list[1][0][0]
-        blob = "\n".join(m["content"] for m in second_call_messages)
-        assert "[Previous conversation:]" in blob
-        assert "Hello, agent!" in blob  # turn-1 content replayed to the model
+        prompt = mock_crewai_agent.kickoff_async.call_args_list[1][0][0]
+        assert "already handled" in prompt
+        assert "Hello, agent!" in prompt  # turn-1 content replayed to the model
 
 
 class TestOnCleanup:
@@ -799,10 +798,9 @@ class TestParticipantsUpdate:
         )
 
         call_args = mock_crewai_agent.kickoff_async.call_args
-        messages = call_args[0][0]
+        prompt = call_args[0][0]
 
-        found = any("Alice joined" in str(m.get("content", "")) for m in messages)
-        assert found
+        assert "Alice joined" in prompt
 
 
 class TestContactsUpdate:
@@ -825,12 +823,9 @@ class TestContactsUpdate:
         )
 
         call_args = mock_crewai_agent.kickoff_async.call_args
-        messages = call_args[0][0]
+        prompt = call_args[0][0]
 
-        found = any(
-            "@alice is now a contact" in str(m.get("content", "")) for m in messages
-        )
-        assert found
+        assert "@alice is now a contact" in prompt
 
 
 class TestContactAndMemoryToolRegistration:


### PR DESCRIPTION
## Summary
- E2E baseline test `test_task_lifecycle_across_task_adapters[crewai]` intermittently (4 of 5 known attempts) failed: the crewai adapter replayed turn 1's create/update/update plan again on turn 2 instead of doing turn 2's list/get/get-history/get-board ask -- confirmed it even created a genuinely *new* second task record with the same marker, ruling out a test/toolkit read bug.
- Root cause: `crewai==1.15.5`'s `Agent._prepare_kickoff` flattens a `list[dict]` messages argument into one **role-blind, turn-blind** string via `"\n".join(msg["content"] for msg in messages)` -- it does not preserve per-message roles/turns the way a chat-completions API would. This adapter's own code comment claimed otherwise ("similar to OpenAI's messages format... documented behavior"), which is false for the installed version. `_process_message` built a per-turn `list[dict]` embedding turn 1's full imperative text right next to turn 2's new instruction (both `role="user"`), so the flattened blob left turn 1's "do X, do not call any other tool" sitting unmarked next to turn 2's ask -- the model would sometimes latch onto the first imperative instead of the last.
- Investigated via 4 parallel, independently-validated hypotheses (adapter bug / test-assumption bug / toolkit bug / LLM flakiness). Adapter-bug hypothesis confirmed via live instrumentation capturing CrewAI's actual flattened string in a failing run; the other three investigations each ruled out their own hypothesis with evidence (toolkit event correlation/timing is correct; test design/prompts are sound; the failure signature was byte-identical across repeats, arguing against ordinary LLM non-determinism as the primary driver). Also ruled out: agent-level memory recall (never enabled) and CrewAI's `_is_resuming_agent_executor` reuse path (confirmed `False` on every turn).
- Fix: build the final prompt as a single string ourselves, with explicit `"[Earlier conversation... already handled...]"` / `"[New message -- act on this now:]"` markers, instead of relying on a list-of-messages illusion the library collapses anyway. Corrected the adapter's own comment. Updated 3 unit tests that asserted on the old `list[dict]` shape.

Linear: INT-1402

## Test plan
- [x] `tests/adapters/test_crewai_adapter.py` -- 79 passed
- [x] CI's exact `test-crewai` command -- 91 passed
- [x] `ruff check .` / `ruff format --check .` -- pass
- [x] `pyrefly check` -- 0 errors
- [x] `pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/` -- 5585 passed, 146 skipped
- [x] Live E2E `test_task_lifecycle_across_task_adapters[crewai]` against the real platform + `gpt-5.4-mini`: correct 7-tool sequence (create→update→update→list→get→get_history→get_board) on 3/3 attempts, where it previously replayed turn 1's plan on turn 2 in 4/5 attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8z6z1muD8yg9Y3pre92ec