### PR TITLE
fix: report OpenCode tool_call args from a non-PENDING frame (INT-1403)

### DIFF
--- a/src/band/adapters/opencode/adapter.py
+++ b/src/band/adapters/opencode/adapter.py
@@ -823,7 +823,15 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         assert part.id is not None
         call_id = part.call_id or part.id
 
-        if room_state.mark_tool_call(call_id):
+        # OpenCode's first frame for a tool part is always PENDING with
+        # input={} -- arguments land on the next frame (RUNNING or later).
+        # Waiting past PENDING here is what makes the single report
+        # (mark_tool_call fires once) land on a frame that actually carries
+        # the arguments, instead of permanently losing them to an empty
+        # first snapshot.
+        if state.status != OpencodeToolStatus.PENDING and room_state.mark_tool_call(
+            call_id
+        ):
             await self._report_tool_call(room_state, tool_name, state, call_id)
 
         match state.status:

--- a/tests/adapters/opencode/test_turns.py
+++ b/tests/adapters/opencode/test_turns.py
@@ -134,6 +134,64 @@ async def test_reports_tool_events_when_enabled() -> None:
     assert json.loads(tool_results[0]["content"])["output"] == "ok"
 
 
+async def test_reports_tool_call_args_from_first_non_pending_frame(
+    make_adapter, tools
+) -> None:
+    """OpenCode's first frame for a tool part is always PENDING with an empty
+    ``input`` -- arguments only appear once the part moves past PENDING. The
+    single tool_call report (fired once per call_id) must land on that later
+    frame, not the empty first one.
+    """
+    fake_client = FakeOpencodeClient(
+        prompt_event_sequences=[
+            [
+                event_tool_part(
+                    "sess-1",
+                    "msg-4",
+                    tool="band_create_task",
+                    call_id="call-1",
+                    status="pending",
+                    input_data={},
+                ),
+                event_tool_part(
+                    "sess-1",
+                    "msg-4",
+                    tool="band_create_task",
+                    call_id="call-1",
+                    status="running",
+                    input_data={"subject": "write tests"},
+                ),
+                event_tool_part(
+                    "sess-1",
+                    "msg-4",
+                    tool="band_create_task",
+                    call_id="call-1",
+                    status="completed",
+                    input_data={"subject": "write tests"},
+                    output="task-1",
+                ),
+                event_session_idle("sess-1"),
+            ]
+        ]
+    )
+    adapter = make_adapter(fake_client, emit=Emit.TOOL_CALLS)
+
+    await adapter.on_started("OpenCode Agent", "A coding agent")
+    await adapter.on_message(
+        make_platform_message(),
+        tools_protocol(tools),
+        OpencodeSessionState(),
+        participants_msg=None,
+        contacts_msg=None,
+        is_session_bootstrap=True,
+        room_id="room-1",
+    )
+
+    tool_calls = [e for e in tools.events_sent if e["message_type"] == "tool_call"]
+    assert len(tool_calls) == 1
+    assert json.loads(tool_calls[0]["content"])["args"] == {"subject": "write tests"}
+
+
 async def test_preserves_falsy_tool_result_outputs_when_reporting(
     make_adapter, tools
 ) -> None:


### PR DESCRIPTION
## Summary

- Fixes `test_task_lifecycle_across_task_adapters[opencode]` failing in CI with `observed args: [{}]` on `band_create_task`.
- Root cause: `OpencodeAdapter._report_tool_part` narrates a `tool_call` event exactly once per `call_id`, on the *first* `message.part.updated` frame it sees — but OpenCode's wire protocol always sends that first frame as `status: pending` with an empty `input: {}`. The real arguments only land on the next (`running`) frame, by which point the one-time report has already fired and is suppressed for good.
- This mechanism was already discovered once, in `b3684686`, while fixing a different smoke test — that fix loosened the *other* test's assertions rather than touching the adapter. `test_task_lifecycle_across_task_adapters` asserts on argument content directly and has no equivalent workaround available, so this PR fixes the adapter itself: skip `PENDING` when deciding whether to fire the one-time `tool_call` report.

## Root-cause validation

Reproduced live against a real local `opencode serve` (pinned CI version 1.18.4). Added temporary logging of every tool-part frame's `status`/`input`; every call in the run showed the identical sequence:

```
status=pending   input={}
status=running   input={'subject': 'E2E baseline test xtask-...', 'chat_id': '...'}
status=completed input={'subject': 'E2E baseline test xtask-...', 'chat_id': '...'}
```

...confirming the narrated `tool_call` always carried the empty first snapshot, not the real one. Instrumentation was removed before committing.

## Test plan

- [x] New unit test `test_reports_tool_call_args_from_first_non_pending_frame` (`tests/adapters/opencode/test_turns.py`) reproduces the `pending({}) -> running(args)` sequence; confirmed it fails without the fix (`{} == {'subject': ...}`) and passes with it.
- [x] `uv run pytest tests/adapters/opencode/ tests/converters/test_opencode.py` — 81 passed.
- [x] `uv run ruff check` / `ruff format --check` / `pyrefly check` — clean.
- [x] Live re-run of `test_task_lifecycle_across_task_adapters[opencode]` against a real local `opencode serve` — PASSED (previously reproduced the exact CI failure before the fix).

Linear: INT-1403

🤖 Generated with [Claude Code](https://claude.com/claude-code)