### PR TITLE
fix: treat CrewAI's empty final answer as a finished turn, not a failure

### DIFF
--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -52,12 +52,25 @@ _reply_tracker_var: ContextVar[ReplyTracker | None] = ContextVar(
 )
 
 
+def _is_empty_final_answer(exc: Exception) -> bool:
+    """Whether ``exc`` is CrewAI signalling that the model returned no final text.
+
+    ``crewai.utilities.agent_utils`` raises a bare ``ValueError`` whenever an LLM
+    call comes back empty, final-answer step included. This agent answers only
+    through band_send_message and its system prompt says so, so the model has
+    nothing left to say once its tools have run: CrewAI raises on every turn
+    here. It marks a finished turn, not a failure. The message is the only
+    discriminator CrewAI offers — there is no error type or code to match on.
+    """
+    return isinstance(exc, ValueError) and "Invalid response from LLM call" in str(exc)
+
+
 def _silence_lite_agent_error_panel() -> None:
     """Deregister CrewAI's benign red "LiteAgent Failed" console panel.
 
     The agent replies via the band_send_message tool, so CrewAI's post-tool step
     returns an empty final answer and raises the "Invalid response from LLM call"
-    ValueError that on_message already swallows — yet its global console listener
+    ValueError that on_message treats as a finished turn — yet its global console listener
     prints an alarming panel anyway (regardless of verbose). Remove only that
     handler; tracing and genuine errors are untouched. Idempotent (a later call
     finds nothing) and best-effort (leave the panel if CrewAI internals move).
@@ -393,59 +406,45 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             prompt = "\n\n".join(sections)
             result = await self._crewai_agent.kickoff_async(prompt)
 
-            if result and result.raw:
-                self._message_history[room_id].append(
-                    {
-                        "role": "assistant",
-                        "content": result.raw,
-                    }
-                )
+        except Exception as e:
+            if not _is_empty_final_answer(e):
+                logger.error("Error processing message: %s", e, exc_info=True)
+                await self._report_error(tools, str(e))
+                raise
+            logger.debug("Room %s: CrewAI ended the turn with no final text", room_id)
+            result = None
 
-            if not (reply_tracker is not None and reply_tracker.replied):
-                await self._report_error(
-                    tools,
-                    missing_reply_error(
-                        "CrewAI",
-                        detail=(
-                            "Repeated tool failures may also have exhausted "
-                            f"max_iter={self.max_iter}."
-                        ),
-                    ),
-                )
-
-            logger.info(
-                "Room %s: CrewAI agent completed (output_length=%s)",
-                room_id,
-                len(result.raw) if result and result.raw else 0,
+        if result and result.raw:
+            self._message_history[room_id].append(
+                {
+                    "role": "assistant",
+                    "content": result.raw,
+                }
             )
 
-        except Exception as e:
-            # CrewAI raises ValueError("Invalid response from LLM call - None or
-            # empty.") when its ReAct loop yields an empty final answer. In this
-            # adapter the agent acts via tools (band_send_message to reply,
-            # band_store_memory, etc.), so an empty final answer AFTER the agent
-            # already did productive work is benign noise — a reply went out, or a
-            # tool-only turn (e.g. a memory store the user told it not to follow
-            # with a message) completed and there is simply nothing left to say.
-            # Match that specific ValueError narrowly so genuine no-response
-            # failures (the LLM returned empty without doing anything) still
-            # surface as error events and propagate.
-            if (
-                reply_tracker is not None
-                and (reply_tracker.replied or reply_tracker.tool_executed)
-                and isinstance(e, ValueError)
-                and "Invalid response from LLM call" in str(e)
-            ):
-                logger.warning(
-                    "Room %s: CrewAI returned an empty final answer after the agent "
-                    "already did productive work this turn; treating as non-fatal: %s",
-                    room_id,
-                    e,
-                )
-                return
-            logger.error("Error processing message: %s", e, exc_info=True)
-            await self._report_error(tools, str(e))
-            raise
+        # A reply that went out, or terminal work that landed, is the turn
+        # answering for itself. Only a turn that did neither leaves the room
+        # with nothing to show for it.
+        if not (
+            reply_tracker is not None
+            and (reply_tracker.replied or reply_tracker.tool_executed)
+        ):
+            await self._report_error(
+                tools,
+                missing_reply_error(
+                    "CrewAI",
+                    detail=(
+                        "Repeated tool failures may also have exhausted "
+                        f"max_iter={self.max_iter}."
+                    ),
+                ),
+            )
+
+        logger.info(
+            "Room %s: CrewAI agent completed (output_length=%s)",
+            room_id,
+            len(result.raw) if result and result.raw else 0,
+        )
 
         logger.debug(
             "Message %s processed successfully (history now has %s messages)",

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -52,28 +52,29 @@ _reply_tracker_var: ContextVar[ReplyTracker | None] = ContextVar(
 )
 
 
-def _is_empty_final_answer(exc: Exception) -> bool:
-    """Whether ``exc`` is CrewAI signalling that the model returned no final text.
+# CrewAI offers no error type or code for an empty completion, so its message
+# is the only discriminator. One definition, matched here and faked in tests.
+EMPTY_LLM_RESPONSE_MARKER = "Invalid response from LLM call"
 
-    ``crewai.utilities.agent_utils`` raises a bare ``ValueError`` whenever an LLM
-    call comes back empty, final-answer step included. This agent answers only
-    through band_send_message and its system prompt says so, so the model has
-    nothing left to say once its tools have run: CrewAI raises on every turn
-    here. It marks a finished turn, not a failure. The message is the only
-    discriminator CrewAI offers — there is no error type or code to match on.
+
+def _is_empty_llm_response(exc: Exception) -> bool:
+    """Whether ``exc`` is CrewAI reporting that an LLM call came back empty.
+
+    ``crewai.utilities.agent_utils`` raises this bare ``ValueError`` for every
+    empty completion in its loop, not only the forced final-answer step — so a
+    match means "no text came back", never "the turn is healthy".
     """
-    return isinstance(exc, ValueError) and "Invalid response from LLM call" in str(exc)
+    return isinstance(exc, ValueError) and EMPTY_LLM_RESPONSE_MARKER in str(exc)
 
 
 def _silence_lite_agent_error_panel() -> None:
     """Deregister CrewAI's benign red "LiteAgent Failed" console panel.
 
-    The agent replies via the band_send_message tool, so CrewAI's post-tool step
-    returns an empty final answer and raises the "Invalid response from LLM call"
-    ValueError that on_message treats as a finished turn — yet its global console listener
-    prints an alarming panel anyway (regardless of verbose). Remove only that
-    handler; tracing and genuine errors are untouched. Idempotent (a later call
-    finds nothing) and best-effort (leave the panel if CrewAI internals move).
+    This agent answers only through band_send_message, so most turns end on an
+    empty completion and CrewAI's global console listener prints an alarming
+    panel anyway (regardless of verbose). Remove only that handler; tracing and
+    genuine errors are untouched. Idempotent (a later call finds nothing) and
+    best-effort (leave the panel if CrewAI internals move).
     """
     try:
         # event_listener is imported for its side effect: registering the handlers.
@@ -331,7 +332,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         *,
         is_session_bootstrap: bool,
         room_id: str,
-        reply_tracker: ReplyTracker | None = None,
+        reply_tracker: ReplyTracker,
     ) -> None:
         """Internal message processing logic."""
         assert self._crewai_agent is not None, "on_message already checked this"
@@ -407,28 +408,34 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             result = await self._crewai_agent.kickoff_async(prompt)
 
         except Exception as e:
-            if not _is_empty_final_answer(e):
+            # An empty response is benign only once some tool ran this turn --
+            # otherwise the model's very first call came back empty, which is
+            # indistinguishable from a genuine provider failure and must keep
+            # failing the delivery so the platform retries it.
+            if not (_is_empty_llm_response(e) and reply_tracker.any_tool_ran):
                 logger.error("Error processing message: %s", e, exc_info=True)
                 await self._report_error(tools, str(e))
                 raise
-            logger.debug("Room %s: CrewAI ended the turn with no final text", room_id)
+            # Keep the exception text: it is the only record that CrewAI raised,
+            # and this turn is no longer marked failed for the runtime to log.
+            logger.debug("Room %s: CrewAI returned no text: %s", room_id, e)
             result = None
 
-        if result and result.raw:
+        final_text = (result.raw or "") if result else ""
+        if final_text:
             self._message_history[room_id].append(
                 {
                     "role": "assistant",
-                    "content": result.raw,
+                    "content": final_text,
                 }
             )
 
-        # A reply that went out, or terminal work that landed, is the turn
-        # answering for itself. Only a turn that did neither leaves the room
-        # with nothing to show for it.
-        if not (
-            reply_tracker is not None
-            and (reply_tracker.replied or reply_tracker.tool_executed)
-        ):
+        if not reply_tracker.did_productive_work:
+            # Warn, not debug: nothing reached the room, and the delivery is
+            # still acked as processed, so this log is the only operator signal.
+            logger.warning(
+                "Room %s: CrewAI turn produced nothing for the room", room_id
+            )
             await self._report_error(
                 tools,
                 missing_reply_error(
@@ -441,14 +448,10 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             )
 
         logger.info(
-            "Room %s: CrewAI agent completed (output_length=%s)",
+            "Room %s: CrewAI turn over for %s (output=%s chars, history=%s)",
             room_id,
-            len(result.raw) if result and result.raw else 0,
-        )
-
-        logger.debug(
-            "Message %s processed successfully (history now has %s messages)",
             msg.id,
+            len(final_text),
             len(self._message_history[room_id]),
         )
 

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -1032,9 +1032,10 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             # other response the run cannot turn into output can still spend the
             # refused output budget. Once a terminal tool has run (a
             # band_send_message reply, a band_store_memory, ...) the work already went
-            # out, so that exhaustion is benign — mirror the crewai adapter and
-            # swallow it. Genuine no-response failures (no terminal tool ran — only
-            # read-only lookups or failed tools) still propagate.
+            # out, so that exhaustion is benign — swallow it. Genuine no-response
+            # failures (no terminal tool ran — only read-only lookups or failed
+            # tools) still propagate here, unlike the crewai adapter, which cannot
+            # tell them apart from the empty completion that ends its every turn.
             if tool_executed and _is_output_retries_exhausted(e):
                 logger.warning(
                     "Room %s: Pydantic AI exhausted its output retries after "

--- a/src/band/integrations/crewai/reporting.py
+++ b/src/band/integrations/crewai/reporting.py
@@ -26,11 +26,18 @@ class ReplyTracker:
     """Mutable per-turn markers shared (by reference) with the tool wrappers.
 
     ``replied`` flips once ``band_send_message`` succeeds; ``tool_executed`` flips
-    once any terminal tool succeeds.
+    once any terminal tool succeeds; ``any_tool_ran`` flips on any tool call at
+    all, success or failure, terminal or not.
     """
 
     replied: bool = False
     tool_executed: bool = False
+    any_tool_ran: bool = False
+
+    @property
+    def did_productive_work(self) -> bool:
+        """Whether the turn left something behind for the room to show for it."""
+        return self.replied or self.tool_executed
 
 
 @dataclass(frozen=True)

--- a/src/band/integrations/crewai/tools.py
+++ b/src/band/integrations/crewai/tools.py
@@ -132,8 +132,12 @@ def _mark_productive_work(
     CrewAI raises on an empty final answer; that is a genuine no-response
     failure only when nothing terminal ran. ``is_terminal_success`` is the
     shared rule for what counts (read-only Band tools and undeclared custom
-    tools do not).
+    tools do not) toward the missing-reply decision. ``any_tool_ran`` is
+    separate and coarser: it flips on this call alone, whether the tool
+    succeeded or not, so a turn that tried *something* is never mistaken for
+    one where the model's very first response came back empty.
     """
+    tracker.any_tool_ran = True
     try:
         if json.loads(result).get("status") != "success":
             return

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -571,20 +571,23 @@ class TestErrorHandling:
         """CrewAI raising an empty final answer AFTER the agent already replied
         via band_send_message is non-fatal: no error event, no re-raise.
 
-        Regression: CrewAI 1.14.3 raises ValueError("Invalid response from LLM
-        call - None or empty.") on its forced final-answer step. Because this
-        adapter replies through the tool, that fired on essentially every turn,
-        posting a spurious error event alongside each (successful) reply.
+        Regression: this adapter replies only through band_send_message, so
+        CrewAI's empty-final-answer ValueError fires on essentially every turn
+        -- including this successful one. Routes through the real
+        ``_mark_productive_work`` (not hand-set flags) so the test fails if a
+        future change stops SEND_MESSAGE from marking a turn productive.
         """
 
         module = importlib.import_module("band.adapters.crewai")
+        tools_module = importlib.import_module("band.integrations.crewai.tools")
 
-        async def _kickoff(_messages):
-            # Simulate band_send_message having succeeded earlier this turn.
-            tracker = module._reply_tracker_var.get()
-            if tracker is not None:
-                tracker.replied = True
-                tracker.any_tool_ran = True
+        async def _kickoff(_prompt):
+            tools_module._mark_productive_work(
+                module._reply_tracker_var.get(),
+                BandTool.SEND_MESSAGE,
+                json.dumps({"status": "success"}),
+                custom_terminal=False,
+            )
             raise ValueError(EMPTY_LLM_RESPONSE_ERROR)
 
         mock_crewai_agent.kickoff_async = AsyncMock(side_effect=_kickoff)
@@ -618,18 +621,21 @@ class TestErrorHandling:
         nothing left to say — CrewAI then raises ValueError("Invalid response
         from LLM call - None or empty.") on its forced final-answer step. Because
         a tool already executed successfully this turn, that empty answer is
-        benign: no error event, no re-raise.
+        benign: no error event, no re-raise. Routes through the real
+        ``_mark_productive_work`` (not hand-set flags) so the test fails if a
+        future change stops a terminal tool from marking a turn productive.
         """
 
         module = importlib.import_module("band.adapters.crewai")
+        tools_module = importlib.import_module("band.integrations.crewai.tools")
 
-        async def _kickoff(_messages):
-            # Simulate a non-reply tool (e.g. band_store_memory) having succeeded
-            # earlier this turn — tool_executed flips, replied does not.
-            tracker = module._reply_tracker_var.get()
-            if tracker is not None:
-                tracker.tool_executed = True
-                tracker.any_tool_ran = True
+        async def _kickoff(_prompt):
+            tools_module._mark_productive_work(
+                module._reply_tracker_var.get(),
+                BandTool.STORE_MEMORY,
+                json.dumps({"status": "success"}),
+                custom_terminal=False,
+            )
             raise ValueError(EMPTY_LLM_RESPONSE_ERROR)
 
         mock_crewai_agent.kickoff_async = AsyncMock(side_effect=_kickoff)

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -571,9 +571,9 @@ class TestErrorHandling:
         """CrewAI raising an empty final answer AFTER the agent already replied
         via band_send_message is non-fatal: no error event, no re-raise.
 
-        Regression: this adapter replies only through band_send_message, so
-        CrewAI's empty-final-answer ValueError fires on essentially every turn
-        -- including this successful one. Routes through the real
+        This adapter replies only through band_send_message, so CrewAI's
+        empty-final-answer ValueError fires on essentially every turn --
+        including this successful one. Routes through the real
         ``_mark_productive_work`` (not hand-set flags) so the test fails if a
         future change stops SEND_MESSAGE from marking a turn productive.
         """

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -637,6 +637,45 @@ class TestErrorHandling:
         mock_tools.send_event.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_read_only_turn_with_empty_final_answer_completes(
+        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
+    ):
+        """A turn whose only work was read-only must finish, not fail the delivery.
+
+        Told to run read tools and nothing else ("call band_list_tasks ... do not
+        call any other tool"), the agent does exactly that and stays silent, so
+        neither ``replied`` nor ``tool_executed`` flips — fetching state is not
+        terminal work. CrewAI then raises its empty-final-answer ValueError, as it
+        does on every turn here. That ends the turn normally: the room gets the
+        missing-reply error and the message stays processed. Re-raising would mark
+        the delivery failed for a turn that did precisely what it was asked.
+        """
+        mock_crewai_agent.kickoff_async = AsyncMock(
+            side_effect=ValueError("Invalid response from LLM call - None or empty.")
+        )
+
+        adapter = CrewAIAdapter()
+        await adapter.on_started("TestBot", "Test bot")
+        adapter._crewai_agent = mock_crewai_agent
+
+        # Must NOT raise — the delivery completes.
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        event_kwargs = mock_tools.send_event.await_args.kwargs
+        assert event_kwargs["message_type"] == "error"
+        assert "band_send_message" in event_kwargs["content"]
+        # The room hears about the missing reply, not CrewAI's internal error.
+        assert "Invalid response from LLM call" not in event_kwargs["content"]
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "error",
         [

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -24,8 +24,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pydantic import BaseModel, Field
 
+from band.adapters.crewai import EMPTY_LLM_RESPONSE_MARKER
 from band.core.types import Capability, Emit, PlatformMessage
 from band.runtime.prompts import render_system_prompt
+from band.runtime.tools import BandTool, missing_reply_error
+
+# The exact text CrewAI raises; the marker is the part the adapter matches on.
+EMPTY_LLM_RESPONSE_ERROR = f"{EMPTY_LLM_RESPONSE_MARKER} - None or empty."
 
 if TYPE_CHECKING:
     from band.adapters.crewai import CrewAIAdapter as CrewAIAdapterType
@@ -37,6 +42,15 @@ class MockBaseTool:
 
     def __init__(self):
         pass
+
+
+def error_events(mock_tools: Any) -> list[str]:
+    """The content of every error event the adapter posted to the room."""
+    return [
+        call.kwargs["content"]
+        for call in mock_tools.send_event.await_args_list
+        if call.kwargs.get("message_type") == "error"
+    ]
 
 
 @pytest.fixture
@@ -570,7 +584,8 @@ class TestErrorHandling:
             tracker = module._reply_tracker_var.get()
             if tracker is not None:
                 tracker.replied = True
-            raise ValueError("Invalid response from LLM call - None or empty.")
+                tracker.any_tool_ran = True
+            raise ValueError(EMPTY_LLM_RESPONSE_ERROR)
 
         mock_crewai_agent.kickoff_async = AsyncMock(side_effect=_kickoff)
 
@@ -614,7 +629,8 @@ class TestErrorHandling:
             tracker = module._reply_tracker_var.get()
             if tracker is not None:
                 tracker.tool_executed = True
-            raise ValueError("Invalid response from LLM call - None or empty.")
+                tracker.any_tool_ran = True
+            raise ValueError(EMPTY_LLM_RESPONSE_ERROR)
 
         mock_crewai_agent.kickoff_async = AsyncMock(side_effect=_kickoff)
 
@@ -643,16 +659,26 @@ class TestErrorHandling:
         """A turn whose only work was read-only must finish, not fail the delivery.
 
         Told to run read tools and nothing else ("call band_list_tasks ... do not
-        call any other tool"), the agent does exactly that and stays silent, so
-        neither ``replied`` nor ``tool_executed`` flips — fetching state is not
-        terminal work. CrewAI then raises its empty-final-answer ValueError, as it
-        does on every turn here. That ends the turn normally: the room gets the
-        missing-reply error and the message stays processed. Re-raising would mark
-        the delivery failed for a turn that did precisely what it was asked.
+        call any other tool"), the agent does exactly that and stays silent:
+        fetching state is not terminal work, so the real marker leaves both
+        tracker flags down. Re-raising CrewAI's empty-response ValueError would
+        mark the delivery failed for a turn that did precisely what it was asked.
         """
-        mock_crewai_agent.kickoff_async = AsyncMock(
-            side_effect=ValueError("Invalid response from LLM call - None or empty.")
-        )
+        module = importlib.import_module("band.adapters.crewai")
+        tools_module = importlib.import_module("band.integrations.crewai.tools")
+
+        async def _kickoff(_prompt):
+            # Route through the real marker so the read-only classification --
+            # not a hand-set flag -- is what keeps this turn "unproductive".
+            tools_module._mark_productive_work(
+                module._reply_tracker_var.get(),
+                BandTool.LIST_TASKS,
+                json.dumps({"status": "success", "data": []}),
+                custom_terminal=False,
+            )
+            raise ValueError(EMPTY_LLM_RESPONSE_ERROR)
+
+        mock_crewai_agent.kickoff_async = AsyncMock(side_effect=_kickoff)
 
         adapter = CrewAIAdapter()
         await adapter.on_started("TestBot", "Test bot")
@@ -669,11 +695,82 @@ class TestErrorHandling:
             room_id="room-123",
         )
 
-        event_kwargs = mock_tools.send_event.await_args.kwargs
-        assert event_kwargs["message_type"] == "error"
-        assert "band_send_message" in event_kwargs["content"]
-        # The room hears about the missing reply, not CrewAI's internal error.
-        assert "Invalid response from LLM call" not in event_kwargs["content"]
+        # Exactly one event, carrying the shared missing-reply wording -- the
+        # room hears about the missing reply, not CrewAI's internal error.
+        [error] = error_events(mock_tools)
+        assert missing_reply_error("CrewAI") in error
+        mock_tools.send_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_answer_with_no_tool_call_still_raises(
+        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
+    ):
+        """An empty answer with zero tool activity is a genuine failure, not a
+        finished turn -- it must still fail the delivery so the platform retries.
+
+        Nothing distinguishes "the model correctly stopped after read-only
+        work" from "the very first LLM call came back empty" by the exception
+        alone -- both raise CrewAI's identical ValueError. ``any_tool_ran`` is
+        that distinction: it is the only turn where this adapter can rule out
+        a genuine no-response failure, so it is the only one that must not be
+        silently marked processed.
+        """
+        mock_crewai_agent.kickoff_async = AsyncMock(
+            side_effect=ValueError(EMPTY_LLM_RESPONSE_ERROR)
+        )
+
+        adapter = CrewAIAdapter()
+        await adapter.on_started("TestBot", "Test bot")
+        adapter._crewai_agent = mock_crewai_agent
+
+        with pytest.raises(ValueError, match=EMPTY_LLM_RESPONSE_ERROR):
+            await adapter.on_message(
+                msg=sample_message,
+                tools=mock_tools,
+                history=[],
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-123",
+            )
+
+        mock_tools.send_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_missing_reply_error_after_clean_tool_only_return(
+        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
+    ):
+        """Terminal tool work answers for a turn even when kickoff returns cleanly.
+
+        The empty-response path is not the only ending without a reply: CrewAI
+        can also return normally after a tool-only turn. One rule judges both, so
+        neither posts a missing-reply error once terminal work has landed.
+        """
+        module = importlib.import_module("band.adapters.crewai")
+        mock_result = MagicMock()
+        mock_result.raw = "Stored it."
+
+        async def _kickoff(_prompt):
+            module._reply_tracker_var.get().tool_executed = True
+            return mock_result
+
+        mock_crewai_agent.kickoff_async = AsyncMock(side_effect=_kickoff)
+
+        adapter = CrewAIAdapter()
+        await adapter.on_started("TestBot", "Test bot")
+        adapter._crewai_agent = mock_crewai_agent
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        assert error_events(mock_tools) == []
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -137,9 +137,9 @@ async def test_recall_memory_across_memory_adapters(
     exclude=[
         ExcludedAdapter(
             Adapter.CREWAI,
-            "the second, post-reboot retrieval turn returns an empty completion "
-            "('Invalid response from LLM call - None or empty'), so the turn never "
-            "finishes; reproduced on every attempt, not a transient",
+            "the second, post-reboot retrieval turn reads the memory but ends on "
+            "an empty completion before band_send_message runs, so no reply ever "
+            "reaches the room; reproduced on every attempt, not a transient",
         )
     ],
     **MEMORY_AGENT,


### PR DESCRIPTION
## Problem

CrewAI raises `ValueError("Invalid response from LLM call - None or empty.")` on every turn (this agent replies only via `band_send_message`, so the model has nothing left to say once its tools ran — measured 61/61 turns in one lane run). The `except` handler guessed from tool bookkeeping whether that was benign, and re-raised when no *terminal* (write) tool had run — failing the whole delivery for a turn instructed to do read-only work only (`test_task_lifecycle_across_task_adapters`'s second turn: "call band_list_tasks ... do not call any other tool").

Looked like flakiness / a platform difference, but wasn't: both `crewai/ubuntu` and `crewai/windows` ran the same 3 attempts; ubuntu's model obeyed every time and failed every time, windows only passed the attempt where the model disobeyed and sent a message anyway.

## Fix

Catch the empty final answer, normalize it to "no final text", and let the existing missing-reply policy (previously unreachable) decide the outcome instead of the `except` handler guessing. No change to `is_terminal_success` or read-only classification. Genuine errors still report and raise.

## Verification

- New unit test reproduces the failure: fails on old code, passes with the fix.
- Full unit suite: 5587 passed. Ruff + pyrefly clean.
- Real CI: scoped `crewai` E2E green on **both ubuntu and windows**, first attempt, no retry needed for the target test (runs 34147284182, 34148069857).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8z6z1muD8yg9Y3pre92ec