### PR TITLE
test: Assert genuine memory retrieval in the rehydration smoke

### DIFF
--- a/src/band/adapters/opencode/adapter.py
+++ b/src/band/adapters/opencode/adapter.py
@@ -837,7 +837,9 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         match state.status:
             case OpencodeToolStatus.COMPLETED | OpencodeToolStatus.ERROR:
                 if room_state.mark_tool_result(call_id):
-                    await self._report_tool_result(room_state, state, call_id)
+                    await self._report_tool_result(
+                        room_state, tool_name, state, call_id
+                    )
 
     def _apply_part_delta(
         self, room_state: RoomState, event: MessagePartDeltaEvent
@@ -1182,6 +1184,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
     async def _report_tool_result(
         self,
         room_state: RoomState,
+        tool_name: str,
         state: OpencodeToolState,
         call_id: str,
     ) -> None:
@@ -1197,6 +1200,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
             await room_state.tools.send_event(
                 json.dumps(
                     {
+                        ToolEventKey.NAME: tool_name,
                         ToolEventKey.OUTPUT: output,
                         ToolEventKey.TOOL_CALL_ID: call_id,
                     }

--- a/src/band/adapters/opencode/adapter.py
+++ b/src/band/adapters/opencode/adapter.py
@@ -1191,7 +1191,8 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         if room_state.tools is None:
             return
         output: Any
-        if state.status == OpencodeToolStatus.ERROR:
+        is_error = state.status == OpencodeToolStatus.ERROR
+        if is_error:
             output = {"error": state.error or "OpenCode tool failed"}
         else:
             output = state.reported_output
@@ -1203,6 +1204,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
                         ToolEventKey.NAME: tool_name,
                         ToolEventKey.OUTPUT: output,
                         ToolEventKey.TOOL_CALL_ID: call_id,
+                        ToolEventKey.IS_ERROR: is_error,
                     }
                 ),
                 "tool_result",

--- a/tests/adapters/opencode/helpers.py
+++ b/tests/adapters/opencode/helpers.py
@@ -141,6 +141,7 @@ def event_tool_part(
     status: str,
     input_data: dict[str, Any],
     output: Any = None,
+    error: str | None = None,
 ) -> RawOpencodeEvent:
     state: dict[str, Any] = {"status": status, "input": input_data}
     if status == "running":
@@ -149,6 +150,9 @@ def event_tool_part(
         state["output"] = "" if output is None else output
         state["title"] = tool
         state["metadata"] = {}
+        state["time"] = {"start": 1, "end": 2}
+    if status == "error":
+        state["error"] = error or "OpenCode tool failed"
         state["time"] = {"start": 1, "end": 2}
 
     return {

--- a/tests/adapters/opencode/test_turns.py
+++ b/tests/adapters/opencode/test_turns.py
@@ -234,6 +234,45 @@ async def test_preserves_falsy_tool_result_outputs_when_reporting(
     assert json.loads(tool_results[0]["content"])["output"] == 0
 
 
+async def test_reports_is_error_on_a_failed_tool_result(make_adapter, tools) -> None:
+    """A tool part that ends in ``error`` must set ``is_error`` on the reported
+    tool_result -- consumers gate on that flag, not on inspecting ``output``."""
+    fake_client = FakeOpencodeClient(
+        prompt_event_sequences=[
+            [
+                event_tool_part(
+                    "sess-1",
+                    "msg-8",
+                    tool="bash",
+                    call_id="call-3",
+                    status="error",
+                    input_data={"command": "false"},
+                    error="command failed",
+                ),
+                event_session_idle("sess-1"),
+            ]
+        ]
+    )
+    adapter = make_adapter(fake_client, emit=Emit.TOOL_CALLS)
+
+    await adapter.on_started("OpenCode Agent", "A coding agent")
+    await adapter.on_message(
+        make_platform_message(),
+        tools_protocol(tools),
+        OpencodeSessionState(),
+        participants_msg=None,
+        contacts_msg=None,
+        is_session_bootstrap=True,
+        room_id="room-1",
+    )
+
+    tool_results = [e for e in tools.events_sent if e["message_type"] == "tool_result"]
+    assert len(tool_results) == 1
+    content = json.loads(tool_results[0]["content"])
+    assert content["is_error"] is True
+    assert content["output"] == {"error": "command failed"}
+
+
 async def test_does_not_echo_user_text_parts_as_assistant_output(
     make_adapter, tools
 ) -> None:
@@ -498,7 +537,13 @@ async def test_tool_reports_canonicalize_server_prefixed_names(
         for e in tools.events_sent
         if e["message_type"] == "tool_call"
     ]
+    tool_results = [
+        json.loads(e["content"])
+        for e in tools.events_sent
+        if e["message_type"] == "tool_result"
+    ]
     assert [c["name"] for c in tool_calls] == ["band_store_memory"]
+    assert [r["name"] for r in tool_results] == ["band_store_memory"]
 
 
 async def test_manual_relay_releases_turn_when_mentionless_send_rejected(

--- a/tests/adapters/opencode/test_turns.py
+++ b/tests/adapters/opencode/test_turns.py
@@ -131,6 +131,7 @@ async def test_reports_tool_events_when_enabled() -> None:
     assert len(tool_calls) == 1
     assert len(tool_results) == 1
     assert json.loads(tool_calls[0]["content"])["name"] == "bash"
+    assert json.loads(tool_results[0]["content"])["name"] == "bash"
     assert json.loads(tool_results[0]["content"])["output"] == "ok"
 
 

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -43,7 +43,7 @@ from tests.e2e.baseline.scorecard import env_gated_skip
 from tests.e2e.baseline.settings import BaselineSettings
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
 from tests.e2e.baseline.toolkit.judge import Verdict, format_transcript
-from tests.e2e.baseline.toolkit.observations import ContactTool, FileTool
+from tests.e2e.baseline.toolkit.observations import ContactTool, FileTool, MemoryTool
 from tests.e2e.baseline.toolkit.provisioning import (
     AdapterCell,
     ProvisionedAgent,
@@ -187,6 +187,9 @@ async def test_memory_survives_adapter_rehydration(
                 scope=MemoryListScope.AGENT,
                 content_query=marker,
             )
+            results = await capture.tool_results(
+                sender_id=identity.id, include_memory=True
+            )
 
     # Assert the *effect* of the rehydrated recall, not how an adapter narrated it:
     # the marker coming back in the reply is what proves the fresh run reached the
@@ -199,6 +202,10 @@ async def test_memory_survives_adapter_rehydration(
     mem.calls.assert_list_called()
     mem.calls.assert_get_called()
     mem.stored.assert_stored(content=marker)
+    # The checks above prove the tools fired and a matching record exists in the
+    # store independently -- neither proves band_get_memory's own tool_result
+    # actually carried it back during this turn. Assert that directly.
+    results.assert_succeeded(MemoryTool.GET.value, output_contains=marker)
 
 
 @per_adapter(supports={Capability.CONTACTS}, **CONTACTS_AGENT)


### PR DESCRIPTION
## Summary

- `test_memory_survives_adapter_rehydration` only checked that the reply echoed a marker string — a marker present in the test's own prompt, so it passes even if `get_memory` returns nothing or the wrong record. `mem.calls` proves only that tools fired; `mem.stored` queries the memory store directly, independent of the turn's tool_result. Neither proves what `band_get_memory`'s tool_result actually carried.
- Adds `results.assert_succeeded(MemoryTool.GET.value, output_contains=marker)` via `capture.tool_results()`, matching the existing `FileTool.READ` assertion pattern two tests below in the same file.
- `OpencodeAdapter._report_tool_result` never included `ToolEventKey.NAME` or `ToolEventKey.IS_ERROR` in its `tool_result` payload. `parse_tool_result` requires `name` and silently drops any event missing it; `is_error` defaults to `False` when absent. Net effect: every OpenCode tool_result was unparseable, and a failed tool call was indistinguishable from a successful one. Fixed by threading `tool_name` and `is_error` through `_report_tool_result`, mirroring `_report_tool_call`'s existing shape.

Closes INT-1226.

## Verification

- Fault-injection: `output_contains=marker + "-WRONG"` against `anthropic` fails with the real `ToolResults.assert_succeeded` error and the actual tool_result payload; reverted to the correct marker, passes.
- Live: `anthropic`, `opencode`, `gemini` all pass against the real platform.
- `tests/adapters/opencode/` — 76 passed.
- `tests/ --ignore=tests/integration/ --ignore=tests/e2e/` — 5590 passed, 146 skipped, 0 failed.
- `ruff check` / `ruff format --check` / `pyrefly check` — clean.

## Not fixed here

- `ToolResults.assert_succeeded` fails on any same-named tool_result with `is_error=True` in a turn, even if a different matching result succeeded and carried the expected content. Shared by every `assert_succeeded` caller — needs its own review, not a drive-by here.
- Same missing-mandatory-field pattern in two other adapters, untouched by this PR: `src/band/adapters/letta.py::_report_execution_event` and `src/band/integrations/crewai/reporting.py::EmitToolCallsReporter` both omit `ToolEventKey.TOOL_CALL_ID`.

## Test plan

- [x] Live E2E: `test_memory_survives_adapter_rehydration[anthropic]`, `[opencode]`, `[gemini]`
- [x] Fault-injection: assertion fails on wrong marker, passes on correct one
- [x] `tests/adapters/opencode/` — 76 passed
- [x] Full offline suite — 5590 passed, 0 failed
- [x] Lint/format/type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
