### PR TITLE
fix: retry CrewAI's first-call empty completion before failing

### DIFF
--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -491,11 +491,18 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             )
             try:
                 return await agent.kickoff_async(prompt)
-            except Exception:
-                logger.warning(
-                    "Room %s: CrewAI's retry also came back empty; giving up",
-                    room_id,
-                )
+            except Exception as retry_exc:
+                if _is_empty_llm_response(retry_exc):
+                    logger.warning(
+                        "Room %s: CrewAI's retry also came back empty; giving up",
+                        room_id,
+                    )
+                else:
+                    logger.warning(
+                        "Room %s: CrewAI's retry failed with a different error: %s",
+                        room_id,
+                        retry_exc,
+                    )
                 raise
 
     async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -56,6 +56,11 @@ _reply_tracker_var: ContextVar[ReplyTracker | None] = ContextVar(
 # is the only discriminator. One definition, matched here and faked in tests.
 EMPTY_LLM_RESPONSE_MARKER = "Invalid response from LLM call"
 
+# Bound on the in-process retry for a turn's very first LLM call coming back
+# empty (see _kickoff_with_empty_response_retry) -- one immediate retry, no
+# backoff, since nothing has run yet this turn and so nothing is duplicated.
+_EMPTY_RESPONSE_FIRST_CALL_RETRIES = 1
+
 
 def _is_empty_llm_response(exc: Exception) -> bool:
     """Whether ``exc`` is CrewAI reporting that an LLM call came back empty.
@@ -405,7 +410,9 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             # "already handled" / "act on this now" markers, matches what
             # CrewAI actually does with the input either way.
             prompt = "\n\n".join(sections)
-            result = await self._crewai_agent.kickoff_async(prompt)
+            result = await self._kickoff_with_empty_response_retry(
+                self._crewai_agent, prompt, reply_tracker, room_id
+            )
 
         except Exception as e:
             # An empty response is benign only once some tool ran this turn --
@@ -460,6 +467,43 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         if room_id in self._message_history:
             del self._message_history[room_id]
             logger.debug("Room %s: Cleaned up CrewAI session", room_id)
+
+    async def _kickoff_with_empty_response_retry(
+        self,
+        agent: "CrewAIAgent",
+        prompt: str,
+        reply_tracker: ReplyTracker,
+        room_id: str,
+    ) -> Any:
+        """Retry a first-call empty completion once before giving up.
+
+        CrewAI raises the identical ValueError whether the model correctly has
+        nothing left to say (fine once a tool has run -- handled by the
+        caller) or the turn's very first call came back empty. The second case
+        has run no tool yet, so there is nothing to duplicate: one immediate
+        retry absorbs a single-call fluke instead of failing the whole
+        delivery and leaving CrewAI to improvise on a cold redelivery.
+        """
+        attempt = 0
+        while True:
+            try:
+                return await agent.kickoff_async(prompt)
+            except Exception as e:
+                attempt += 1
+                retryable = (
+                    attempt <= _EMPTY_RESPONSE_FIRST_CALL_RETRIES
+                    and _is_empty_llm_response(e)
+                    and not reply_tracker.any_tool_ran
+                )
+                if not retryable:
+                    raise
+                logger.info(
+                    "Room %s: CrewAI's first LLM call came back empty before "
+                    "any tool ran; retrying (%s/%s)",
+                    room_id,
+                    attempt,
+                    _EMPTY_RESPONSE_FIRST_CALL_RETRIES,
+                )
 
     async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
         """Send error event (best effort)."""

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -56,11 +56,6 @@ _reply_tracker_var: ContextVar[ReplyTracker | None] = ContextVar(
 # is the only discriminator. One definition, matched here and faked in tests.
 EMPTY_LLM_RESPONSE_MARKER = "Invalid response from LLM call"
 
-# Bound on the in-process retry for a turn's very first LLM call coming back
-# empty (see _kickoff_with_empty_response_retry) -- one immediate retry, no
-# backoff, since nothing has run yet this turn and so nothing is duplicated.
-_EMPTY_RESPONSE_FIRST_CALL_RETRIES = 1
-
 
 def _is_empty_llm_response(exc: Exception) -> bool:
     """Whether ``exc`` is CrewAI reporting that an LLM call came back empty.
@@ -484,26 +479,24 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         retry absorbs a single-call fluke instead of failing the whole
         delivery and leaving CrewAI to improvise on a cold redelivery.
         """
-        attempt = 0
-        while True:
+        try:
+            return await agent.kickoff_async(prompt)
+        except Exception as e:
+            if not (_is_empty_llm_response(e) and not reply_tracker.any_tool_ran):
+                raise
+            logger.info(
+                "Room %s: CrewAI's first LLM call came back empty before "
+                "any tool ran; retrying",
+                room_id,
+            )
             try:
                 return await agent.kickoff_async(prompt)
-            except Exception as e:
-                attempt += 1
-                retryable = (
-                    attempt <= _EMPTY_RESPONSE_FIRST_CALL_RETRIES
-                    and _is_empty_llm_response(e)
-                    and not reply_tracker.any_tool_ran
-                )
-                if not retryable:
-                    raise
-                logger.info(
-                    "Room %s: CrewAI's first LLM call came back empty before "
-                    "any tool ran; retrying (%s/%s)",
+            except Exception:
+                logger.warning(
+                    "Room %s: CrewAI's retry also came back empty; giving up",
                     room_id,
-                    attempt,
-                    _EMPTY_RESPONSE_FIRST_CALL_RETRIES,
                 )
+                raise
 
     async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
         """Send error event (best effort)."""

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -24,6 +24,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pydantic import BaseModel, Field
 
+import band.adapters.crewai as crewai_adapter
 from band.adapters.crewai import EMPTY_LLM_RESPONSE_MARKER
 from band.core.types import Capability, Emit, PlatformMessage
 from band.runtime.prompts import render_system_prompt
@@ -754,8 +755,6 @@ class TestErrorHandling:
         for the retry to duplicate; the retry either behaves exactly like the
         first attempt would have or, as here, recovers and replies.
         """
-        module = importlib.import_module("band.adapters.crewai")
-
         mock_result = MagicMock()
         mock_result.raw = "Hello! I'm here to help."
 
@@ -766,7 +765,7 @@ class TestErrorHandling:
             calls += 1
             if calls == 1:
                 raise ValueError(EMPTY_LLM_RESPONSE_ERROR)
-            tracker = module._reply_tracker_var.get()
+            tracker = crewai_adapter._reply_tracker_var.get()
             if tracker is not None:
                 tracker.replied = True
             return mock_result

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -760,12 +760,8 @@ class TestErrorHandling:
         mock_result = MagicMock()
         mock_result.raw = "Hello! I'm here to help."
 
-        calls = 0
-
         async def _kickoff(_prompt):
-            nonlocal calls
-            calls += 1
-            if calls == 1:
+            if mock_crewai_agent.kickoff_async.call_count == 1:
                 raise ValueError(EMPTY_LLM_RESPONSE_ERROR)
             tracker = crewai_adapter._reply_tracker_var.get()
             if tracker is not None:

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -742,6 +742,8 @@ class TestErrorHandling:
             )
 
         mock_tools.send_event.assert_awaited_once()
+        # First call plus the one retry -- proves the retry actually happens
+        # before the final raise, not a bare pass-through of the first failure.
         assert mock_crewai_agent.kickoff_async.call_count == 2
 
     @pytest.mark.asyncio
@@ -787,6 +789,7 @@ class TestErrorHandling:
         )
 
         assert error_events(mock_tools) == []
+        # First call plus the one retry that recovered it.
         assert mock_crewai_agent.kickoff_async.call_count == 2
 
     @pytest.mark.asyncio

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -741,6 +741,54 @@ class TestErrorHandling:
             )
 
         mock_tools.send_event.assert_awaited_once()
+        assert mock_crewai_agent.kickoff_async.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_first_call_recovers_on_retry(
+        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
+    ):
+        """A turn's first LLM call coming back empty is retried once before
+        giving up -- a successful retry must complete the turn normally.
+
+        Nothing ran before the empty completion, so there is no side effect
+        for the retry to duplicate; the retry either behaves exactly like the
+        first attempt would have or, as here, recovers and replies.
+        """
+        module = importlib.import_module("band.adapters.crewai")
+
+        mock_result = MagicMock()
+        mock_result.raw = "Hello! I'm here to help."
+
+        calls = 0
+
+        async def _kickoff(_prompt):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise ValueError(EMPTY_LLM_RESPONSE_ERROR)
+            tracker = module._reply_tracker_var.get()
+            if tracker is not None:
+                tracker.replied = True
+            return mock_result
+
+        mock_crewai_agent.kickoff_async = AsyncMock(side_effect=_kickoff)
+
+        adapter = CrewAIAdapter()
+        await adapter.on_started("TestBot", "Test bot")
+        adapter._crewai_agent = mock_crewai_agent
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        assert error_events(mock_tools) == []
+        assert mock_crewai_agent.kickoff_async.call_count == 2
 
     @pytest.mark.asyncio
     async def test_no_missing_reply_error_after_clean_tool_only_return(


### PR DESCRIPTION
## Summary
- CrewAI's native OpenAI tool-calling path can return an empty completion (`finish_reason='stop'`, no content, no tool_calls) on a turn's very first LLM call, before any tool has run — reproduced 8/8 times across local live runs, root-caused and filed upstream at [crewAIInc/crewAI#7349](https://github.com/crewAIInc/crewAI/issues/7349).
- That case is indistinguishable from a genuine provider outage from the caller's side, so `CrewAIAdapter` always failed the whole delivery — even though nothing ran yet this turn, so nothing is duplicated by retrying.
- Adds one bounded, in-process retry (`_EMPTY_RESPONSE_FIRST_CALL_RETRIES = 1`) via a new `_kickoff_with_empty_response_retry` helper, only for `_is_empty_llm_response(e) and not reply_tracker.any_tool_ran`. Any other failure, or exhausting the retry, still reports the error and raises exactly as before.
- No change to the existing `any_tool_ran` swallow logic (PR #621).

Traced from last night's failed nightly E2E run ([34307490909](https://github.com/band-ai/band-sdk-python/actions/runs/34307490909)) → root-caused → planned and independently fact-verified → implemented, per [INT-1427](https://linear.app/thenvoi/issue/INT-1427/crewai-adapter-still-fails-a-turn-when-its-very-first-llm-call-comes) (plan attached to the ticket).

## Test plan
- [x] `uv run --extra dev-crewai pytest tests/adapters/test_crewai_adapter.py -v` — 82 passed
  - Updated `test_empty_answer_with_no_tool_call_still_raises` to assert the retry happens (`kickoff_async.call_count == 2`) before the final raise
  - Added `test_empty_first_call_recovers_on_retry`: first call empty, second call replies — turn completes, no error event
- [x] `uv run ruff check .` / `uv run ruff format .` — clean
- [x] `uv run pyrefly check` — 0 errors
- [x] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/` — 5590 passed, 146 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw8AZwnoa3Fen6HBhHEQ7H