### PR TITLE
fix(deps): pin mcp<2 ceiling on claude_sdk extra, cap anthropic<1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,6 @@ pydantic-ai = [
     "openai>=2.0.0",
 ]
 anthropic = [
-    # Ceiling: anthropic 1.0.0 (2026-08-20) migrated the SDK's HTTP layer from
-    # httpx to httpx2 (an API-compatible fork) -- a documented breaking change
-    # per its MIGRATION.md. Capped until that migration is verified here.
     "anthropic>=0.75.0,<1",
 ]
 langgraph = [
@@ -89,10 +86,6 @@ langgraph = [
 ]
 claude_sdk = [
     "claude-agent-sdk>=0.1.81",  # Floor: ResultMessage.errors/api_error_status (used by the failure path). Requires Node.js 20+ and @anthropic-ai/claude-code CLI
-    # Capped like every other mcp consumer here: 2.x drops the lowlevel Server
-    # decorator registration that band.integrations.mcp.engine's FastMCP usage
-    # depends on. Floor pinned to crewai's own transitive pin -- see `desktop`
-    # extra above for the full rationale.
     "mcp>=1.28.1,<2",
 ]
 copilot_sdk = [
@@ -201,8 +194,7 @@ dev = [
     "pytest-httpx>=0.35.0",  # httpx_mock fixture: REST header-emission proof
     # Include pydantic-ai for testing
     "pydantic-ai-slim>=2.18.0",
-    # Include anthropic for testing; capped like the anthropic extra above --
-    # see its comment for the httpx2 breaking-change rationale.
+    # Include anthropic for testing
     "anthropic>=0.75.0,<1",
     # Include claude_sdk for testing
     "claude-agent-sdk>=0.1.81",
@@ -286,8 +278,6 @@ dev-crewai = [
     "pillow>=12.1.1",
     # Anthropic client: the baseline E2E conftest imports it at module load and
     # the LLM judge needs it. A thin client (pydantic <3), so no crewai conflict.
-    # Capped like the anthropic extra above -- see its comment for the httpx2
-    # breaking-change rationale.
     "anthropic>=0.75.0,<1",
     # A2A e2e smokes import band.integrations.a2a at module load, no crewai conflict
     "a2a-sdk>=1.1.2,<2",
@@ -318,8 +308,6 @@ dev-parlant = [
     "werkzeug>=3.1.6",
     # Anthropic client: the baseline E2E conftest imports it at module load and
     # the LLM judge needs it. A thin client (pydantic <3), so no parlant conflict.
-    # Capped like the anthropic extra above -- see its comment for the httpx2
-    # breaking-change rationale.
     "anthropic>=0.75.0,<1",
     # A2A e2e smokes import band.integrations.a2a at module load, no parlant conflict
     "a2a-sdk>=1.1.2,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,10 @@ pydantic-ai = [
     "openai>=2.0.0",
 ]
 anthropic = [
-    "anthropic>=0.75.0",
+    # Ceiling: anthropic 1.0.0 (2026-08-20) migrated the SDK's HTTP layer from
+    # httpx to httpx2 (an API-compatible fork) -- a documented breaking change
+    # per its MIGRATION.md. Capped until that migration is verified here.
+    "anthropic>=0.75.0,<1",
 ]
 langgraph = [
     "langchain>=1.0.0",
@@ -86,6 +89,11 @@ langgraph = [
 ]
 claude_sdk = [
     "claude-agent-sdk>=0.1.81",  # Floor: ResultMessage.errors/api_error_status (used by the failure path). Requires Node.js 20+ and @anthropic-ai/claude-code CLI
+    # Capped like every other mcp consumer here: 2.x drops the lowlevel Server
+    # decorator registration that band.integrations.mcp.engine's FastMCP usage
+    # depends on. Floor pinned to crewai's own transitive pin -- see `desktop`
+    # extra above for the full rationale.
+    "mcp>=1.28.1,<2",
 ]
 copilot_sdk = [
     "github-copilot-sdk>=1.0.5",  # Bundles/downloads the Copilot CLI runtime; needs GitHub Copilot auth
@@ -193,8 +201,9 @@ dev = [
     "pytest-httpx>=0.35.0",  # httpx_mock fixture: REST header-emission proof
     # Include pydantic-ai for testing
     "pydantic-ai-slim>=2.18.0",
-    # Include anthropic for testing
-    "anthropic>=0.75.0",
+    # Include anthropic for testing; capped like the anthropic extra above --
+    # see its comment for the httpx2 breaking-change rationale.
+    "anthropic>=0.75.0,<1",
     # Include claude_sdk for testing
     "claude-agent-sdk>=0.1.81",
     # Include copilot_sdk for testing
@@ -277,7 +286,9 @@ dev-crewai = [
     "pillow>=12.1.1",
     # Anthropic client: the baseline E2E conftest imports it at module load and
     # the LLM judge needs it. A thin client (pydantic <3), so no crewai conflict.
-    "anthropic>=0.75.0",
+    # Capped like the anthropic extra above -- see its comment for the httpx2
+    # breaking-change rationale.
+    "anthropic>=0.75.0,<1",
     # A2A e2e smokes import band.integrations.a2a at module load, no crewai conflict
     "a2a-sdk>=1.1.2,<2",
     # Pretty E2E test output
@@ -307,7 +318,9 @@ dev-parlant = [
     "werkzeug>=3.1.6",
     # Anthropic client: the baseline E2E conftest imports it at module load and
     # the LLM judge needs it. A thin client (pydantic <3), so no parlant conflict.
-    "anthropic>=0.75.0",
+    # Capped like the anthropic extra above -- see its comment for the httpx2
+    # breaking-change rationale.
+    "anthropic>=0.75.0,<1",
     # A2A e2e smokes import band.integrations.a2a at module load, no parlant conflict
     "a2a-sdk>=1.1.2,<2",
     # Pretty E2E test output

--- a/uv.lock
+++ b/uv.lock
@@ -595,6 +595,8 @@ bridge-agentcore = [
 ]
 claude-sdk = [
     { name = "claude-agent-sdk" },
+    { name = "mcp", version = "1.28.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-crewai' or extra == 'extra-8-band-sdk-dev-crewai' or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-parlant') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-parlant' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "mcp", version = "1.29.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-dev-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai')" },
 ]
 codex = [
     { name = "websockets" },
@@ -772,10 +774,10 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'bridge-agentcore'", specifier = ">=3.9,<4" },
     { name = "aiohttp", marker = "extra == 'dev'", specifier = ">=3.9,<4" },
     { name = "aiohttp", marker = "extra == 'slack'", specifier = ">=3.9,<4" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.75.0" },
-    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.75.0" },
-    { name = "anthropic", marker = "extra == 'dev-crewai'", specifier = ">=0.75.0" },
-    { name = "anthropic", marker = "extra == 'dev-parlant'", specifier = ">=0.75.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.75.0,<1" },
+    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.75.0,<1" },
+    { name = "anthropic", marker = "extra == 'dev-crewai'", specifier = ">=0.75.0,<1" },
+    { name = "anthropic", marker = "extra == 'dev-parlant'", specifier = ">=0.75.0,<1" },
     { name = "async-lru", specifier = ">=2.3.0" },
     { name = "band-client-rest", specifier = "==0.0.27" },
     { name = "band-sdk-core", specifier = "==2.2.0" },
@@ -827,6 +829,7 @@ requires-dist = [
     { name = "letta-client", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "letta-client", marker = "extra == 'letta'", specifier = ">=0.1.0" },
     { name = "mcp", marker = "extra == 'acp'", specifier = ">=1.28.1,<2" },
+    { name = "mcp", marker = "extra == 'claude-sdk'", specifier = ">=1.28.1,<2" },
     { name = "mcp", marker = "extra == 'desktop'", specifier = ">=1.28.1,<2" },
     { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.28.1,<2" },
     { name = "mcp", marker = "extra == 'letta'", specifier = ">=1.28.1,<2" },


### PR DESCRIPTION
## Summary

- **`claude_sdk` extra**: added the missing `mcp>=1.28.1,<2` ceiling. This extra transitively imports `band.integrations.mcp.engine`'s unconditional `from mcp.server.fastmcp import FastMCP` (via `band.adapters.claude_sdk` → `band.integrations.claude_sdk.tools` → `band.integrations.mcp.engine`), but never capped `mcp` like its siblings (`desktop`, `opencode`, `letta`, `acp`, `dev`) already do. A standalone `pip install band-sdk[claude_sdk]` / `uv sync --extra claude_sdk` could resolve `mcp` 2.x, which removed `mcp.server.fastmcp`, and crash on import. Reported via an external user's fresh WSL setup (two Claude Agent SDK-based agents crashed on startup with the identical traceback). Same root cause already fixed once for the sibling `packages/band-mcp` CLI package ([INT-1194](https://linear.app/thenvoi/issue/INT-1194) / `band-ai/band-mcp#128`) — that fix never touched this extra.
- **`anthropic` (+ `dev`, `dev-crewai`, `dev-parlant`)**: added an `<1` ceiling. `anthropic` 1.0.0 migrated the SDK's HTTP layer from `httpx` to `httpx2` (an API-compatible fork) — a documented breaking change per its `MIGRATION.md`. The floor-only pin had no ceiling at all. Direct usage in `adapters/anthropic.py` looks unaffected (no custom httpx client/timeout passed), but this hasn't been verified end-to-end against 1.x, so capping until it is.

Audited every extra for the same FastMCP-import gap: `opencode`/`acp`/`letta`/`desktop` are already covered; `crewai`/`parlant` (and their `dev-*` variants) don't need one since those adapters never import `band.integrations.mcp.*`.

## Verification

- `uv lock` — resolves cleanly, 367 packages, `mcp` stays at 1.28.1/1.29.0, `anthropic` stays at 0.120.0 (no locked-version churn, just tighter constraints).
- Isolated repro: `UV_PROJECT_ENVIRONMENT=/tmp/... uv sync --extra claude_sdk` (no `dev`/other mcp-pinning extra) now resolves `mcp==1.29.0` and `import band.adapters.claude_sdk` succeeds. This is the exact failure mode from the incident.
- `uv run pytest tests/ -k claude_sdk --ignore=tests/integration/` — 239 passed, 39 skipped, 0 failed.

Fixes [INT-1433](https://linear.app/thenvoi/issue/INT-1433/claude-sdk-extra-missing-mcp2-pin-resolves-to-mcp-2x-breaks-fastmcp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY57bnUvBN8u2joqe1WQrN