### PR TITLE
fix: document release baseline refresh

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -20,16 +20,8 @@ name: Release baseline gate
 # merge queue's temporary merge commit — without it the queue would wait forever once
 # this job's name is added as a required status check.
 #
-# Known limitation: this check only re-evaluates on the PR events above, so a
-# baseline that turns green overnight does not by itself clear an already-red gate
-# on the release-please PR — nothing re-triggers `pull_request` if no further
-# commits land on main in the meantime. Re-run this job by hand (Actions tab) once
-# the nightly is green, or push any commit that triggers release-please to
-# resynchronize its PR.
-#
-# Registered as a required status check on main-branch-protection under the context
-# "release-baseline-gate" (this job's name) — a live ruleset setting, not a file in
-# this repo.
+# A later nightly does not re-run a completed PR check. The next Release Please PR
+# update does: its `synchronize` event evaluates the newest eligible baseline status.
 
 on:
   pull_request:

--- a/tests/e2e/baseline/README.md
+++ b/tests/e2e/baseline/README.md
@@ -696,11 +696,10 @@ coarser matrix-leg granularity, not the per-cell one the grid markets.
 
 A subtlety worth calling out for on-call: once `release-gate.yml` has recorded a
 *failure*, GitHub does not automatically re-check it just because a later nightly run
-posts a fresh green `baseline-green` status — a required check's completed run is final
-until something re-triggers it (a new commit, or a manual "re-run failed jobs" on the
-release PR). This is ordinary GitHub required-check behavior, not a gap specific to
-this workflow; if the release PR is stuck red after main has actually gone green,
-re-run the check by hand.
+posts a fresh green `baseline-green` status — a completed check is final until another
+Release Please PR event creates a new gate. A Release Please update emits
+`pull_request:synchronize`, and that new gate reads the newest baseline status from
+`main`; a manual re-run remains available when no release update is needed.
 
 Two reporting jobs (`mark-baseline`, `report-scoped-run`) are gated on `!cancelled()`
 rather than `always()`. They write externally visible state — a commit status, and a
@@ -763,8 +762,8 @@ PR-triggered check: an instant no-op for every ordinary PR, and for the standing
 release-please PR it consults that status and fails the PR's check until the baseline
 is green. This is *not* the same thing as making the whole E2E suite a required PR
 check (explicitly out of scope; PR-level gating is covered by the existing Tier-1
-checks) — only this thin lookup is required on every PR, so the cost stays negligible
-for the 99% of PRs that aren't the release PR.
+checks) — this thin lookup remains optional, so the cost stays negligible for the 99%
+of PRs that aren't the release PR.
 
 It gates on the most recently **tested** commit of the base branch, not the live tip
 (`.github/scripts/check-release-baseline.sh`). A nightly marks exactly one commit —

--- a/tests/framework_conformance/test_e2e_lane_drift.py
+++ b/tests/framework_conformance/test_e2e_lane_drift.py
@@ -132,6 +132,28 @@ def test_release_gate_checks_out_before_running_repo_scripts() -> None:
     assert checkout < invokes_script
 
 
+def test_release_gate_refreshes_from_the_latest_nightly_when_release_please_updates() -> (
+    None
+):
+    """A Release Please update must re-read main's newest baseline verdict.
+
+    The nightly only publishes ``baseline-green``. Its result reaches the release
+    PR when Release Please's next synchronize event creates this gate again.
+    """
+    workflow = yaml.load(
+        _RELEASE_GATE_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader
+    )
+    pull_request = workflow["on"]["pull_request"]
+    job = _jobs(_RELEASE_GATE_WORKFLOW)["release-baseline-gate"]
+    gate_step = job["steps"][
+        _step_index(job, "Check the release-please PR's baseline-green status")
+    ]
+
+    assert "synchronize" in pull_request["types"]
+    assert "export BASE_REF=main" in gate_step["run"]
+    assert ".github/scripts/check-release-baseline.sh" in gate_step["run"]
+
+
 def test_mark_baseline_only_certifies_the_default_branch() -> None:
     """A full-matrix ``workflow_dispatch`` from a feature branch must not certify it.
 


### PR DESCRIPTION
## Summary

- clarify that a Release Please PR update re-evaluates the latest eligible nightly baseline
- remove stale required-check wording now that the gate is optional
- protect the workflow refresh contract with one focused test

## Validation

- `uv run pytest tests/framework_conformance/test_e2e_lane_drift.py -q`
- `uv run ruff check tests/framework_conformance/test_e2e_lane_drift.py`
- `actionlint .github/workflows/release-gate.yml`
- `git diff --check`

Closes INT-1437